### PR TITLE
fix: [QILI-177]:bug: make sure amplitude and duration are float or int

### DIFF
--- a/src/qililab/pulse/circuit_to_pulses.py
+++ b/src/qililab/pulse/circuit_to_pulses.py
@@ -96,11 +96,11 @@ class CircuitToPulses:
         )
         if not isinstance(gate_settings.amplitude, float) and not isinstance(gate_settings.amplitude, int):
             raise ValueError(
-                f"Gate settings converstion to master failed. Value {gate_settings.amplitude} is still a string."
+                f"Gate settings conversion to master failed. Value {gate_settings.amplitude} is still a string."
             )
-        if not isinstance(gate_settings.duration, int):
+        if not isinstance(gate_settings.duration, float) and not isinstance(gate_settings.duration, int):
             raise ValueError(
-                f"Gate settings converstion to master failed. Value {gate_settings.duration} is still a string."
+                f"Gate settings conversion to master failed. Value {gate_settings.duration} is still a string."
             )
         return gate_settings
 

--- a/src/qililab/pulse/hardware_gates/hardware_gate.py
+++ b/src/qililab/pulse/hardware_gates/hardware_gate.py
@@ -13,7 +13,7 @@ from qililab.utils import SingletonABC
 
 def _use_master_value_when_variable_is_referencing_master_name(
     gate_current_value: int | float | MasterGateSettingsName, master_amplitude_gate: float, master_duration_gate: int
-):
+):  # sourcery skip: remove-unnecessary-cast
     """use master value when variable is referencing master name"""
     if not isinstance(gate_current_value, MasterGateSettingsName):
         return gate_current_value
@@ -26,8 +26,8 @@ def _use_master_value_when_variable_is_referencing_master_name(
             + f"[{MasterGateSettingsName.MASTER_AMPLITUDE_GATE}, {MasterGateSettingsName.MASTER_DURATION_GATE}]"
         )
     if gate_current_value == MasterGateSettingsName.MASTER_AMPLITUDE_GATE:
-        return master_amplitude_gate
-    return master_duration_gate
+        return float(master_amplitude_gate)
+    return int(master_duration_gate)
 
 
 class HardwareGate(ABC, metaclass=SingletonABC):


### PR DESCRIPTION
Duration is set to float when changed from the code.

Now, it is specifically casted both amplitude and duration to the correspondent typings: float, int.