### PR TITLE
Fix 🔧 Software modulation consistency

### DIFF
--- a/src/qililab/pulse/pulse.py
+++ b/src/qililab/pulse/pulse.py
@@ -40,7 +40,7 @@ class Pulse:
         """
         envelope = self.envelope(resolution=resolution)
         envelopes = [np.real(envelope), np.imag(envelope)]
-        time = np.arange(self.duration / resolution) * 1e-9 * resolution + self.start_time
+        time = np.arange(self.duration / resolution) * 1e-9 * resolution + self.start_time * 1e-9
         cosalpha = np.cos(2 * np.pi * frequency * time + self.phase)
         sinalpha = np.sin(2 * np.pi * frequency * time + self.phase)
         mod_matrix = (1.0 / np.sqrt(2)) * np.array([[cosalpha, -sinalpha], [sinalpha, cosalpha]])


### PR DESCRIPTION
# Modulation matrix

The `modulated_waveforms` method from the class `Pulse` is now modulating in the same way the Qblox sequencer does when modulating by hardware.

A Pulsar QRM outputs are directly connected to its inputs, resulting in the following scope acquisitions for different cases

1. Hardware modulation
![hw_mod](https://user-images.githubusercontent.com/78150444/196379943-8e4fdc7f-5bdb-4a0d-97cb-609148a0451e.png)
2. Old software modulation
![sw_mod](https://user-images.githubusercontent.com/78150444/196379865-ecdf93fd-558f-479e-9348-44085ec8ca4f.png)
3. New software modulation after inverting the matrix and adding a $(1/\sqrt{2})$ factor
![sw_mod_2](https://user-images.githubusercontent.com/78150444/196379954-dcdfada4-f24a-438e-87d1-0e65c076eafe.png)

# Phase

The `start_time` attribute of the `Pulse` is now being taken into account in the `Pulse.modulated_waveforms` method.

The behavior is tested creating a 10 MHz pulse with `start_time` of 40 ns (0.4 times its period) and running the following Q1ASM program both with hardware and software modulation
```asm
setup:
    wait_sync        4
main:
    reset_ph
    upd_param        40
    play             0, 1, 4
    acquire          0, 0, 16380
    stop


```
```py
program = Program()
main = Block("main")
main.append_components([ResetPh(),
                        UpdParam(pulse_start),
                        Play(idx_i, idx_q, wait_after_play),
                        Acquire(acq_idx, 0, wait_after_acq),
                        Stop()])
program.append_block(main)
```

And the scope acquisition for
1. Hardware modulation
![hw_mod_start40](https://user-images.githubusercontent.com/78150444/196384669-8057854d-6d82-43c6-bc26-eeccb5fbbdda.png)
2. Software modulation
![sw_mod_start40](https://user-images.githubusercontent.com/78150444/196384745-4c5b3532-ffee-4ab5-9c70-c0b2c4b92a5f.png)
