### PR TITLE
fix: remove master drag coefficient

### DIFF
--- a/examples/runcards/template_base_runcard.yml
+++ b/examples/runcards/template_base_runcard.yml
@@ -1,0 +1,200 @@
+settings:
+  id_: 0
+  category: platform
+  name: galadriel_master
+  delay_between_pulses: 0
+  delay_before_readout: 40
+  master_amplitude_gate: 1
+  master_duration_gate: 100
+  gates:
+    - name: M
+      amplitude: 1
+      phase: 0
+      duration: 2000
+      shape:
+        name: rectangular
+
+    - name: I
+      amplitude: 0
+      phase: 0
+      duration: master_duration_gate
+      shape:
+        name: rectangular
+
+    - name: X
+      amplitude: master_amplitude_gate
+      phase: 0
+      duration: master_duration_gate
+      shape:
+        name: drag
+        num_sigmas: 4
+        drag_coefficient: 0
+
+    - name: Y
+      amplitude: master_amplitude_gate
+      phase: 1.5707963267948966 # pi / 2
+      duration: master_duration_gate
+      shape:
+        name: drag
+        num_sigmas: 4
+        drag_coefficient: 0
+schema:
+  chip:
+    id_: 0
+    category: chip
+    nodes:
+      - name: port
+        id_: 0
+        nodes: [3]
+      - name: port
+        id_: 1
+        nodes: [2]
+      - name: resonator
+        alias: resonator
+        id_: 2
+        frequency: 7.3264369805783645e+09
+        nodes: [1, 3]
+      - name: qubit
+        alias: qubit
+        id_: 3
+        qubit_idx: 0
+        frequency: 3.351e+09
+        nodes: [0, 2]
+  instruments:
+    - name: QCM
+      alias: QCM
+      id_: 0
+      category: awg
+      firmware: 0.7.0
+      frequency: 1.e+08
+      num_bins: 1
+      num_sequencers: 1
+      gain: [1]
+      epsilon: [0]
+      delta: [0]
+      offset_i: [0]
+      offset_q: [0]
+      sync_enabled: true
+    - name: QRM
+      alias: QRM
+      id_: 1
+      category: awg
+      firmware: 0.7.0
+      frequency: 2.e+07
+      num_sequencers: 1
+      gain: [1]
+      epsilon: [0]
+      delta: [0]
+      offset_i: [0]
+      offset_q: [0]
+      acquisition_delay_time: 100
+      sync_enabled: true
+      scope_acquire_trigger_mode: sequencer
+      scope_hardware_averaging: false
+      sampling_rate: 1.e+09
+      num_bins: 1
+      integration: true
+      integration_length: 2000
+      integration_mode: ssb
+      sequence_timeout: 1
+      acquisition_timeout: 1
+    - name: rohde_schwarz
+      alias: rs_0
+      id_: 0
+      category: signal_generator
+      firmware: 4.30.046.295
+      power: 15
+
+    - name: rohde_schwarz
+      alias: rs_1
+      id_: 1
+      category: signal_generator
+      firmware: 4.30.046.295
+      power: 15
+
+    - name: mini_circuits
+      alias: attenuator
+      id_: 1
+      category: attenuator
+      firmware: None
+      attenuation: 32
+  buses:
+    - id_: 0
+      category: bus
+      subcategory: control
+      system_control:
+        id_: 0
+        category: system_control
+        subcategory: mixer_based_system_control
+        awg: QCM
+        signal_generator: rs_0
+      port: 0
+    - id_: 0
+      category: bus
+      subcategory: readout
+      system_control:
+        id_: 1
+        category: system_control
+        subcategory: mixer_based_system_control
+        awg: QRM
+        signal_generator: rs_1
+      attenuator: attenuator
+      port: 1
+  instrument_controllers:
+    - name: qblox_pulsar
+      id_: 0
+      alias: pulsar_controller_qcm_0
+      category: instrument_controller
+      subcategory: single_instrument
+      reference_clock: internal
+      connection:
+        name: tcp_ip
+        address: 192.168.0.3
+      modules:
+        - awg: QCM
+          slot_id: 0
+    - name: qblox_pulsar
+      id_: 1
+      alias: pulsar_controller_qrm_0
+      category: instrument_controller
+      subcategory: single_instrument
+      reference_clock: external
+      connection:
+        name: tcp_ip
+        address: 192.168.0.4
+      modules:
+        - awg: QRM
+          slot_id: 0
+    - name: rohde_schwarz
+      id_: 2
+      alias: rohde_schwarz_controller_0
+      category: instrument_controller
+      subcategory: single_instrument
+      connection:
+        name: tcp_ip
+        address: 192.168.0.10
+      modules:
+        - signal_generator: rs_0
+          slot_id: 0
+    - name: rohde_schwarz
+      id_: 3
+      alias: rohde_schwarz_controller_1
+      category: instrument_controller
+      subcategory: single_instrument
+      connection:
+        name: tcp_ip
+        address: 192.168.0.7
+      modules:
+        - signal_generator: rs_1
+          slot_id: 0
+    - name: mini_circuits
+      id_: 4
+      alias: attenuator_controller_0
+      category: instrument_controller
+      subcategory: single_instrument
+      connection:
+        name: tcp_ip
+        address: 192.168.0.222
+      modules:
+        - attenuator: attenuator
+          slot_id: 0

--- a/src/qililab/constants.py
+++ b/src/qililab/constants.py
@@ -45,7 +45,6 @@ class PLATFORM:
     DELAY_BEFORE_READOUT = "delay_before_readout"
     MASTER_AMPLITUDE_GATE = "master_amplitude_gate"
     MASTER_DURATION_GATE = "master_duration_gate"
-    MASTER_DRAG_COEFFICIENT = "master_drag_coefficient"
 
 
 class SIGNALGENERATOR:

--- a/src/qililab/pulse/circuit_to_pulses.py
+++ b/src/qililab/pulse/circuit_to_pulses.py
@@ -65,13 +65,6 @@ class CircuitToPulses:
     def _build_pulse_shape_from_gate_settings(self, gate_settings: HardwareGate.HardwareGateSettings):
         """Build Pulse Shape from Gate seetings"""
         shape_settings = gate_settings.shape.copy()
-        if RUNCARD.NAME in shape_settings and shape_settings[RUNCARD.NAME] in [
-            PulseShapeName.DRAG,
-            PulseShapeName.DRAG.value,
-        ]:
-            return Factory.get(shape_settings.pop(RUNCARD.NAME))(
-                **shape_settings, master_drag_coefficient=self.settings.master_drag_coefficient
-            )
         return Factory.get(shape_settings.pop(RUNCARD.NAME))(**shape_settings)
 
     def _control_gate_to_pulse_event(

--- a/src/qililab/pulse/pulse_shape/drag.py
+++ b/src/qililab/pulse/pulse_shape/drag.py
@@ -1,13 +1,12 @@
 """Drag pulse shape."""
 from dataclasses import dataclass
-from typing import Literal
 
 import numpy as np
 
 from qililab.constants import RUNCARD
 from qililab.pulse.pulse_shape.pulse_shape import PulseShape
 from qililab.typings import PulseShapeName
-from qililab.typings.enums import MasterPulseShapeSettingsName, PulseShapeSettingsName
+from qililab.typings.enums import PulseShapeSettingsName
 from qililab.utils import Factory
 
 
@@ -18,50 +17,7 @@ class Drag(PulseShape):
 
     name = PulseShapeName.DRAG
     num_sigmas: float
-    drag_coefficient: float | Literal[MasterPulseShapeSettingsName.DRAG_COEFFICIENT]
-    master_drag_coefficient: float | None = None
-
-    def __post_init__(self):
-        """Update drag coefficient value"""
-        if (
-            isinstance(self.drag_coefficient, str)
-            and self.drag_coefficient != MasterPulseShapeSettingsName.DRAG_COEFFICIENT.value
-        ):
-            raise ValueError(
-                f"master drag coefficient {self.drag_coefficient} does not have a valid value: {MasterPulseShapeSettingsName.DRAG_COEFFICIENT.value}."
-            )
-        if (
-            isinstance(self.drag_coefficient, MasterPulseShapeSettingsName)
-            and self.drag_coefficient != MasterPulseShapeSettingsName.DRAG_COEFFICIENT
-        ):
-            raise ValueError(
-                f"master drag coefficient {self.drag_coefficient} does not have a valid value: {MasterPulseShapeSettingsName.DRAG_COEFFICIENT.value}."
-            )
-        if isinstance(self.drag_coefficient, str):
-            self.drag_coefficient = MasterPulseShapeSettingsName.DRAG_COEFFICIENT
-        if (
-            self.drag_coefficient == MasterPulseShapeSettingsName.DRAG_COEFFICIENT
-            and self.master_drag_coefficient is None
-        ):
-            raise ValueError(
-                f"master drag coefficient pulse shape is not defined when drag coefficient value is {self.drag_coefficient}."
-            )
-
-    def _get_drag_coefficient(self) -> float:
-        """Returns the associated drag coefficient value checking whether it has to retrieve
-        it from the `master_drag coefficient_pulse_shape`"""
-        if (
-            self.drag_coefficient == MasterPulseShapeSettingsName.DRAG_COEFFICIENT
-            and self.master_drag_coefficient is None
-        ):
-            raise ValueError(
-                f"master drag coefficient pulse shape is not defined when drag coefficient value is {self.drag_coefficient}."
-            )
-        if self.drag_coefficient == MasterPulseShapeSettingsName.DRAG_COEFFICIENT:
-            return self.master_drag_coefficient  # type: ignore
-        if not isinstance(self.drag_coefficient, float):
-            raise ValueError(f"Beta value type should be float. Got {type(self.drag_coefficient)} instead")
-        return self.drag_coefficient
+    drag_coefficient: float
 
     def envelope(self, duration: int, amplitude: float, resolution: float = 1.0):
         """DRAG envelope centered with respect to the pulse.
@@ -74,13 +30,12 @@ class Drag(PulseShape):
             ndarray: Amplitude of the envelope for each time step.
         """
 
-        drag_coefficient = self._get_drag_coefficient()
         sigma = duration / self.num_sigmas
         time = np.arange(duration / resolution) * resolution
         mu_ = duration / 2
         gaussian = amplitude * np.exp(-0.5 * (time - mu_) ** 2 / sigma**2)
         gaussian = (gaussian - gaussian[0]) / (1 - gaussian[0])  # Shift to avoid introducing noise at time 0
-        return gaussian + 1j * drag_coefficient * (-(time - mu_) / sigma**2) * gaussian
+        return gaussian + 1j * self.drag_coefficient * (-(time - mu_) / sigma**2) * gaussian
 
     def to_dict(self):
         """Return dictionary representation of the pulse shape.
@@ -91,10 +46,5 @@ class Drag(PulseShape):
         return {
             RUNCARD.NAME: self.name.value,
             PulseShapeSettingsName.NUM_SIGMAS.value: self.num_sigmas,
-            PulseShapeSettingsName.DRAG_COEFFICIENT.value: self.drag_coefficient
-            if isinstance(self.drag_coefficient, float)
-            else self.drag_coefficient.value,
-            MasterPulseShapeSettingsName.DRAG_COEFFICIENT.value: self.master_drag_coefficient
-            if self.master_drag_coefficient is not None
-            else None,
+            PulseShapeSettingsName.DRAG_COEFFICIENT.value: self.drag_coefficient,
         }

--- a/src/qililab/settings/runcard_schema.py
+++ b/src/qililab/settings/runcard_schema.py
@@ -1,5 +1,5 @@
 """PlatformSchema class."""
-from dataclasses import InitVar, dataclass
+from dataclasses import dataclass
 from typing import List, Literal
 
 from qililab.constants import PLATFORM
@@ -101,7 +101,6 @@ class RuncardSchema:
         delay_before_readout: int
         master_amplitude_gate: float
         master_duration_gate: int
-        master_drag_coefficient: float
         gates: List[GateSettings]
 
         def __post_init__(self):

--- a/src/qililab/typings/enums.py
+++ b/src/qililab/typings/enums.py
@@ -203,16 +203,6 @@ class PulseShapeSettingsName(Enum):
     DRAG_COEFFICIENT = "drag_coefficient"
 
 
-class MasterPulseShapeSettingsName(Enum):
-    """Master Pulse Shape Settings names.
-    Args:
-        enum (str): Available types of master pulse shape settings names:
-        * master_drag_coefficient
-    """
-
-    DRAG_COEFFICIENT = "master_drag_coefficient"
-
-
 class BusSubcategory(Enum):
     """Bus types.
 
@@ -332,7 +322,6 @@ class Parameter(Enum):
     SEQUENCE_TIMEOUT = "sequence_timeout"
     MASTER_AMPLITUDE_GATE = "master_amplitude_gate"
     MASTER_DURATION_GATE = "master_duration_gate"
-    MASTER_DRAG_COEFFICIENT = "master_drag_coefficient"
     EXTERNAL = "external"
     RESET = "reset"
 

--- a/tests/data.py
+++ b/tests/data.py
@@ -13,7 +13,6 @@ from qililab.constants import (
     RUNCARD,
     SCHEMA,
 )
-from qililab.pulse.pulse_shape import Drag, Rectangular
 from qililab.typings.enums import (
     Category,
     ConnectionName,
@@ -38,7 +37,6 @@ class Galadriel:
         PLATFORM.DELAY_BEFORE_READOUT: 40,
         PLATFORM.MASTER_AMPLITUDE_GATE: 1,
         PLATFORM.MASTER_DURATION_GATE: 100,
-        PLATFORM.MASTER_DRAG_COEFFICIENT: 0,
         "gates": [
             {
                 "name": "M",
@@ -62,7 +60,7 @@ class Galadriel:
                 "shape": {
                     "name": "drag",
                     "num_sigmas": 4,
-                    "drag_coefficient": PLATFORM.MASTER_DRAG_COEFFICIENT,
+                    "drag_coefficient": 0,
                 },
             },
             {
@@ -73,7 +71,7 @@ class Galadriel:
                 "shape": {
                     "name": "drag",
                     "num_sigmas": 4,
-                    "drag_coefficient": PLATFORM.MASTER_DRAG_COEFFICIENT,
+                    "drag_coefficient": 0,
                 },
             },
         ],
@@ -376,7 +374,6 @@ class FluxQubitSimulator:
         PLATFORM.DELAY_BEFORE_READOUT: 40,
         PLATFORM.MASTER_AMPLITUDE_GATE: 1,
         PLATFORM.MASTER_DURATION_GATE: 10,
-        PLATFORM.MASTER_DRAG_COEFFICIENT: 0,
         "gates": [
             {
                 "name": "M",
@@ -404,7 +401,7 @@ class FluxQubitSimulator:
                 "shape": {
                     "name": "drag",
                     "num_sigmas": 4,
-                    "drag_coefficient": PLATFORM.MASTER_DRAG_COEFFICIENT,
+                    "drag_coefficient": 0,
                 },
             },
             {
@@ -415,7 +412,7 @@ class FluxQubitSimulator:
                 "shape": {
                     "name": "drag",
                     "num_sigmas": 4,
-                    "drag_coefficient": PLATFORM.MASTER_DRAG_COEFFICIENT,
+                    "drag_coefficient": 0,
                 },
             },
         ],


### PR DESCRIPTION
On runcard, we are going to remove the `master_drag_coefficient` , so every time a user wants to define a drag pulse, it is required to specify a `drag_coefficient` value instead of using a master one (as it was confusing).

Closes #90 