### PR TITLE
feat: Update qblox version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ qutip==4.7.0
 tqdm==4.64.1
 urllib3==1.26.12
 qiboconnection==0.6.0
-qpysequence@ git+https://github.com/qilimanjaro-tech/qpysequence.git@0.3.2
+qpysequence@ git+https://github.com/qilimanjaro-tech/qpysequence.git@0.5.0
 qilimanjaro-qilisimulator-library@ git+https://github.com/qilimanjaro-tech/qilisimulator.git@0.1.2
 dummy-qblox@ git+https://github.com/qilimanjaro-tech/qililab-tools.git@0.3.2#subdirectory=services/dummy_qblox
 lmfit==1.0.3


### PR DESCRIPTION
- `qblox-instruments` version updated to the latest 0.8.1, which is compatible with the current installed firmware.
- `qpysequence` updated to 0.5.0, compatible with the current installed firmware