### PR TITLE
Add project card only for bugs and feature requests.

### DIFF
--- a/.github/workflows/create_project_card.yml
+++ b/.github/workflows/create_project_card.yml
@@ -14,3 +14,5 @@ jobs:
         with:
           project-url: https://github.com/orgs/qilimanjaro-tech/projects/1
           github-token: ${{ secrets.PROJECT_TOKEN }}
+          labeled: bug, enhancement
+          label-operator: OR


### PR DESCRIPTION
Avoid creating a card in the GitHub project for issues that doesn't have the `bug` or `enhancement` labels