### PR TITLE
Fail codecov CI when coverage is decreased.

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -9,8 +9,7 @@ coverage:
       src:
         paths:
           - "src"
-        target: 80% # the required coverage value
-        threshold: 10% # the leniency in hitting the target
+        target: auto # make sure coverage is not decreased (in comparison with the main branch)
         flags:
           - "unittests"
   notify:


### PR DESCRIPTION
Right now, the codecov CI might pass even if the added lines are not fully covered (because it is only expecting 80% of the lines to be covered).

This is now changed to only pass the CI check when 100% of the added lines are covered.

If there is a specific case where we can't test all the lines, I can manually surpass the PR requirements and merge the PR.