### PR TITLE
Remove Qblox compiler Settings class.

### DIFF
--- a/src/qililab/qprogram/__init__.py
+++ b/src/qililab/qprogram/__init__.py
@@ -1,3 +1,3 @@
 """This module contains the QProgram class and all the needed information to build a QProgram."""
-from .qblox_compiler import QBloxCompiler
+from .qblox_compiler import QbloxCompiler
 from .qprogram import QProgram

--- a/src/qililab/qprogram/qblox_compiler.py
+++ b/src/qililab/qprogram/qblox_compiler.py
@@ -55,7 +55,7 @@ class BusInfo:  # pylint: disable=too-many-instance-attributes, too-few-public-m
         self.average_counter = 0
 
 
-class QBloxCompiler:  # pylint: disable=too-few-public-methods
+class QbloxCompiler:  # pylint: disable=too-few-public-methods
     """A class for compiling QProgram to QBlox hardware."""
 
     minimum_wait_duration: int = 4
@@ -153,7 +153,7 @@ class QBloxCompiler:  # pylint: disable=too-few-public-methods
         """
 
         def handle_waveform(waveform: Waveform | None, default_length: int = 0):
-            _hash = QBloxCompiler._hash(waveform) if waveform else f"zeros {default_length}"
+            _hash = QbloxCompiler._hash(waveform) if waveform else f"zeros {default_length}"
 
             if _hash in self._buses[bus].waveform_to_index:
                 index = self._buses[bus].waveform_to_index[_hash]
@@ -177,7 +177,7 @@ class QBloxCompiler:  # pylint: disable=too-few-public-methods
 
     def _append_to_weights_of_bus(self, bus: str, weights: IQPair):
         def handle_waveform(waveform: Waveform):
-            _hash = QBloxCompiler._hash(waveform)
+            _hash = QbloxCompiler._hash(waveform)
 
             if _hash in self._buses[bus].weight_to_index:
                 index = self._buses[bus].weight_to_index[_hash]
@@ -209,10 +209,10 @@ class QBloxCompiler:  # pylint: disable=too-few-public-methods
             iterations = int((element.loops[0].stop - element.loops[0].start) / element.loops[0].step)
             qpy_loop = QPyProgram.Loop(name=f"loop_{self._buses[bus].loop_counter}", begin=iterations)
             for loop in element.loops:
-                operation = QBloxCompiler._get_reference_operation_of_loop(loop=loop, starting_block=element)
+                operation = QbloxCompiler._get_reference_operation_of_loop(loop=loop, starting_block=element)
                 if not operation:
                     raise NotImplementedError("Variables referenced in loops should be used in at least one operation.")
-                begin, _, step = QBloxCompiler._convert_for_loop_values(loop, operation)
+                begin, _, step = QbloxCompiler._convert_for_loop_values(loop, operation)
                 loop_register = QPyProgram.Register()
                 self._buses[bus].qpy_block_stack[-1].append_component(
                     component=QPyInstructions.Move(var=begin, register=loop_register)
@@ -234,7 +234,7 @@ class QBloxCompiler:  # pylint: disable=too-few-public-methods
         for bus in self._buses:
             qpy_loop = QPyProgram.Loop(name=f"avg_{self._buses[bus].average_counter}", begin=element.shots)
             qpy_loop.append_component(
-                component=QPyInstructions.WaitSync(wait_time=QBloxCompiler.minimum_wait_duration),
+                component=QPyInstructions.WaitSync(wait_time=QbloxCompiler.minimum_wait_duration),
                 bot_position=len(qpy_loop.components),
             )
             self._buses[bus].qpy_block_stack[-1].append_component(qpy_loop)
@@ -243,14 +243,14 @@ class QBloxCompiler:  # pylint: disable=too-few-public-methods
         return True
 
     def _handle_for_loop(self, element: ForLoop):
-        operation = QBloxCompiler._get_reference_operation_of_loop(element)
+        operation = QbloxCompiler._get_reference_operation_of_loop(element)
         if not operation:
             raise NotImplementedError("Variables referenced in loops should be used in at least one operation.")
-        begin, end, step = QBloxCompiler._convert_for_loop_values(element, operation)
+        begin, end, step = QbloxCompiler._convert_for_loop_values(element, operation)
         for bus in self._buses:
             qpy_loop = QPyProgram.Loop(name=f"loop_{self._buses[bus].loop_counter}", begin=begin, end=end, step=step)
             qpy_loop.append_component(
-                component=QPyInstructions.WaitSync(wait_time=QBloxCompiler.minimum_wait_duration),
+                component=QPyInstructions.WaitSync(wait_time=QbloxCompiler.minimum_wait_duration),
                 bot_position=len(qpy_loop.components),
             )
             self._buses[bus].qpy_block_stack[-1].append_component(qpy_loop)
@@ -263,7 +263,7 @@ class QBloxCompiler:  # pylint: disable=too-few-public-methods
         raise NotImplementedError("Loops with arbitrary numpy arrays are not currently supported for QBlox.")
 
     def _handle_set_frequency(self, element: SetFrequency):
-        convert = QBloxCompiler._convert_value(element)
+        convert = QbloxCompiler._convert_value(element)
         frequency = (
             self._buses[element.bus].variable_to_register[element.frequency]
             if isinstance(element.frequency, Variable)
@@ -274,7 +274,7 @@ class QBloxCompiler:  # pylint: disable=too-few-public-methods
         )
 
     def _handle_set_phase(self, element: SetPhase):
-        convert = QBloxCompiler._convert_value(element)
+        convert = QbloxCompiler._convert_value(element)
         phase = (
             self._buses[element.bus].variable_to_register[element.phase]
             if isinstance(element.phase, Variable)
@@ -286,7 +286,7 @@ class QBloxCompiler:  # pylint: disable=too-few-public-methods
         self._buses[element.bus].qpy_block_stack[-1].append_component(component=QPyInstructions.ResetPh())
 
     def _handle_set_gain(self, element: SetGain):
-        convert = QBloxCompiler._convert_value(element)
+        convert = QbloxCompiler._convert_value(element)
         gain_0 = (
             self._buses[element.bus].variable_to_register[element.gain_path0]
             if isinstance(element.gain_path0, Variable)
@@ -302,7 +302,7 @@ class QBloxCompiler:  # pylint: disable=too-few-public-methods
         )
 
     def _handle_set_offset(self, element: SetOffset):
-        convert = QBloxCompiler._convert_value(element)
+        convert = QbloxCompiler._convert_value(element)
         offset_0 = (
             self._buses[element.bus].variable_to_register[element.offset_path0]
             if isinstance(element.offset_path0, Variable)
@@ -318,7 +318,7 @@ class QBloxCompiler:  # pylint: disable=too-few-public-methods
         )
 
     def _handle_wait(self, element: Wait):
-        convert = QBloxCompiler._convert_value(element)
+        convert = QbloxCompiler._convert_value(element)
         time = (
             self._buses[element.bus].variable_to_register[element.time]
             if isinstance(element.time, Variable)
@@ -331,7 +331,7 @@ class QBloxCompiler:  # pylint: disable=too-few-public-methods
         # buses = element.buses if element.buses is not None else self._buses.keys()
         for bus in self._buses:
             self._buses[bus].qpy_block_stack[-1].append_component(
-                component=QPyInstructions.WaitSync(wait_time=QBloxCompiler.minimum_wait_duration)
+                component=QPyInstructions.WaitSync(wait_time=QbloxCompiler.minimum_wait_duration)
             )
 
     def _handle_acquire(self, element: Acquire):
@@ -447,7 +447,7 @@ class QBloxCompiler:  # pylint: disable=too-few-public-methods
 
     @staticmethod
     def _convert_for_loop_values(for_loop: ForLoop, operation: Operation):
-        convert = QBloxCompiler._convert_value(operation)
+        convert = QbloxCompiler._convert_value(operation)
         return tuple(convert(value) for value in (for_loop.start, for_loop.stop, for_loop.step))
 
     @staticmethod
@@ -457,7 +457,7 @@ class QBloxCompiler:  # pylint: disable=too-few-public-methods
             SetPhase: lambda x: int(x * 1e9 / 360),
             SetGain: lambda x: int(x * 32_767),
             SetOffset: lambda x: int(x * 32_767),
-            Wait: lambda x: max(x, QBloxCompiler.minimum_wait_duration),
+            Wait: lambda x: max(x, QbloxCompiler.minimum_wait_duration),
         }
         return conversion_map.get(type(operation), lambda x: x)
 

--- a/tests/qprogram/test_qblox_compiler.py
+++ b/tests/qprogram/test_qblox_compiler.py
@@ -2,7 +2,7 @@
 import pytest
 import qpysequence as QPy
 
-from qililab.qprogram import QBloxCompiler, QProgram
+from qililab.qprogram import QbloxCompiler, QProgram
 from qililab.qprogram.blocks import ForLoop
 from qililab.waveforms import DragPulse, Gaussian, IQPair, Square
 
@@ -224,7 +224,7 @@ def fixture_multiple_play_operations_with_no_Q_waveform() -> QProgram:
 
 class TestQBloxCompiler:
     def test_no_loops_all_operations(self, no_loops_all_operations: QProgram):
-        compiler = QBloxCompiler()
+        compiler = QbloxCompiler()
         output = compiler.compile(qprogram=no_loops_all_operations)
 
         assert len(output) == 2
@@ -254,7 +254,7 @@ class TestQBloxCompiler:
         )
 
     def test_average(self, average: QProgram):
-        compiler = QBloxCompiler()
+        compiler = QbloxCompiler()
         output = compiler.compile(qprogram=average)
 
         assert len(output) == 2
@@ -284,7 +284,7 @@ class TestQBloxCompiler:
         )
 
     def test_average_with_weights(self, average_with_weights: QProgram):
-        compiler = QBloxCompiler()
+        compiler = QbloxCompiler()
         output = compiler.compile(qprogram=average_with_weights)
 
         assert len(output) == 2
@@ -317,11 +317,11 @@ class TestQBloxCompiler:
         self, average_with_weights_of_different_length: QProgram
     ):
         with pytest.raises(NotImplementedError, match="Weights should have equal lengths."):
-            compiler = QBloxCompiler()
+            compiler = QbloxCompiler()
             _ = compiler.compile(qprogram=average_with_weights_of_different_length)
 
     def test_average_with_for_loop(self, average_with_for_loop: QProgram):
-        compiler = QBloxCompiler()
+        compiler = QbloxCompiler()
         output = compiler.compile(qprogram=average_with_for_loop)
 
         assert len(output) == 2
@@ -351,7 +351,7 @@ class TestQBloxCompiler:
         )
 
     def test_acquire_loop_with_for_loop_with_weights(self, acquire_loop_with_for_loop_with_weights: QProgram):
-        compiler = QBloxCompiler()
+        compiler = QbloxCompiler()
         output = compiler.compile(qprogram=acquire_loop_with_for_loop_with_weights)
 
         assert len(output) == 2
@@ -381,7 +381,7 @@ class TestQBloxCompiler:
         )
 
     def test_average_with_multiple_for_loops_and_acquires(self, average_with_multiple_for_loops_and_acquires: QProgram):
-        compiler = QBloxCompiler()
+        compiler = QbloxCompiler()
         output = compiler.compile(qprogram=average_with_multiple_for_loops_and_acquires)
 
         assert len(output) == 1
@@ -403,7 +403,7 @@ class TestQBloxCompiler:
         )
 
     def test_average_with_nested_for_loops(self, average_with_nested_for_loops: QProgram):
-        compiler = QBloxCompiler()
+        compiler = QbloxCompiler()
         output = compiler.compile(qprogram=average_with_nested_for_loops)
 
         assert len(output) == 2
@@ -433,7 +433,7 @@ class TestQBloxCompiler:
         )
 
     def test_average_with_parallel_for_loops(self, average_with_parallel_for_loops: QProgram):
-        compiler = QBloxCompiler()
+        compiler = QbloxCompiler()
         output = compiler.compile(qprogram=average_with_parallel_for_loops)
 
         assert len(output) == 2
@@ -466,7 +466,7 @@ class TestQBloxCompiler:
         with pytest.raises(
             NotImplementedError, match="Variables referenced in loops should be used in at least one operation."
         ):
-            compiler = QBloxCompiler()
+            compiler = QbloxCompiler()
             _ = compiler.compile(qprogram=for_loop_variable_with_no_target)
 
     def test_for_loop_variable_with_different_targets_throws_exception(
@@ -475,18 +475,18 @@ class TestQBloxCompiler:
         with pytest.raises(
             NotImplementedError, match="Variables referenced in a loop cannot be used in different types of operations."
         ):
-            compiler = QBloxCompiler()
+            compiler = QbloxCompiler()
             _ = compiler.compile(qprogram=for_loop_variable_with_different_targets)
 
     def test_play_operation_with_waveforms_of_different_length_throws_exception(
         self, play_operation_with_waveforms_of_different_length: QProgram
     ):
         with pytest.raises(NotImplementedError, match="Waveforms should have equal lengths."):
-            compiler = QBloxCompiler()
+            compiler = QbloxCompiler()
             _ = compiler.compile(qprogram=play_operation_with_waveforms_of_different_length)
 
     def test_multiple_play_operations_with_same_waveform(self, multiple_play_operations_with_same_waveform: QProgram):
-        compiler = QBloxCompiler()
+        compiler = QbloxCompiler()
         output = compiler.compile(qprogram=multiple_play_operations_with_same_waveform)
 
         assert len(output) == 1
@@ -505,7 +505,7 @@ class TestQBloxCompiler:
         )
 
     def test_multiple_play_operations_with_no_Q_waveform(self, multiple_play_operations_with_no_Q_waveform: QProgram):
-        compiler = QBloxCompiler()
+        compiler = QbloxCompiler()
         output = compiler.compile(qprogram=multiple_play_operations_with_no_Q_waveform)
 
         assert len(output) == 1


### PR DESCRIPTION
Removed `Settings` class of Qblox compiler to make the UI simpler.

We go from:
```python
from qililab.qprogram import QbloxCompiler, Settings

settings = Settings(integration_length=1500)
compiler = QbloxCompiler(settings=settings)
```

To:
```python
from qililab.qprogram import QbloxCompiler

compiler = QbloxCompiler(integration_length=integration_length)
```