### PR TITLE
Fix gates with negative amplitudes

### DIFF
--- a/src/qililab/pulse/circuit_to_pulses.py
+++ b/src/qililab/pulse/circuit_to_pulses.py
@@ -159,6 +159,9 @@ class CircuitToPulses:  # pylint: disable=too-few-public-methods
         theta = self.normalize_angle(angle=gate.parameters[0])
         amplitude = drag_schedule.pulse.amplitude * theta / np.pi
         phase = self.normalize_angle(angle=gate.parameters[1])
+        if amplitude < 0:
+            amplitude = -amplitude
+            phase = self.normalize_angle(angle=gate.parameters[1] + np.pi)
         drag_schedule.pulse.amplitude = amplitude
         drag_schedule.pulse.phase = phase
         return [drag_schedule]

--- a/tests/pulse/test_circuit_to_pulses.py
+++ b/tests/pulse/test_circuit_to_pulses.py
@@ -662,7 +662,16 @@ class TestTranslation:
         c.add(Drag(0, np.pi + 0.1, 0))
         translator = CircuitToPulses(platform=platform)
         pulse_schedules = translator.translate(circuits=[c])
-        assert np.allclose(pulse_schedules[0].elements[0].timeline[0].pulse.amplitude, -0.7745352091052967)
+        assert np.allclose(pulse_schedules[0].elements[0].timeline[0].pulse.amplitude, abs(-0.7745352091052967))
+
+    def test_negative_amplitudes_add_extra_phase(self, platform):
+        """Test that transpiling negative amplitudes results in an added PI phase."""
+        c = Circuit(1)
+        c.add(Drag(0, -np.pi / 2, 0))
+        translator = CircuitToPulses(platform=platform)
+        pulse_schedule = translator.translate(circuits=[c])[0]
+        assert np.allclose(pulse_schedule.elements[0].timeline[0].pulse.amplitude, (np.pi / 2) * 0.8 / np.pi)
+        assert np.allclose(pulse_schedule.elements[0].timeline[0].pulse.phase, 0 + np.pi)
 
     def test_drag_schedule_error(self, platform: Platform):
         """Test error is raised if len(drag schedule) > 1"""


### PR DESCRIPTION
For some unknown reason gates with negative amplitudes are not working properly with Qblox.

A workaround we can take is, when transpiling gates into pulses, add `np.pi` to the phase if the amplitude is negative.