### PR TITLE
fix: :bug: Raise error if the alias of an instrument (in SystemControl) is not found in platform.

### DIFF
--- a/src/qililab/system_control/system_control.py
+++ b/src/qililab/system_control/system_control.py
@@ -45,7 +45,17 @@ class SystemControl(FactoryElement, ABC):
 
         def __post_init__(self, platform_instruments: Instruments):  # type: ignore # pylint: disable=arguments-differ
             # ``self.instruments`` contains a list of instrument aliases
-            self.instruments = [platform_instruments.get_instrument(alias=i) for i in self.instruments]  # type: ignore
+            instruments = []
+            for inst_alias in self.instruments:
+                inst_class = platform_instruments.get_instrument(alias=inst_alias)  # type: ignore
+                if inst_class is None:
+                    raise NameError(
+                        f"The instrument with alias {inst_alias} could not be found within the instruments of the "
+                        "platform. The available instrument aliases are: "
+                        f"{[inst.alias for inst in platform_instruments.elements]}."
+                    )
+                instruments.append(inst_class)
+            self.instruments = instruments
             super().__post_init__()
 
     settings: SystemControlSettings

--- a/tests/pulse/test_circuit_to_pulses.py
+++ b/tests/pulse/test_circuit_to_pulses.py
@@ -472,7 +472,7 @@ class TestTranslation:
             "alias": "flux_q1_bus",
             "system_control": {
                 "name": "system_control",
-                "instruments": ["rs"],
+                "instruments": ["rs_1"],
             },
             "port": "flux_q1",
             "distortions": [],

--- a/tests/pulse/test_circuit_to_pulses.py
+++ b/tests/pulse/test_circuit_to_pulses.py
@@ -272,7 +272,7 @@ def fixture_platform(chip: Chip) -> Platform:
             "alias": "feedline_bus",
             "system_control": {
                 "name": "readout_system_control",
-                "instruments": ["QRM1", "rs_1"],
+                "instruments": ["QRM", "rs_1"],
             },
             "port": "feedline_input",
             "distortions": [],
@@ -282,7 +282,7 @@ def fixture_platform(chip: Chip) -> Platform:
             "alias": "drive_q0_bus",
             "system_control": {
                 "name": "system_control",
-                "instruments": ["QCM-RF1"],
+                "instruments": ["QCM"],
             },
             "port": "drive_q0",
             "distortions": [],
@@ -292,7 +292,7 @@ def fixture_platform(chip: Chip) -> Platform:
             "alias": "flux_q0_bus",
             "system_control": {
                 "name": "system_control",
-                "instruments": ["QCM1"],
+                "instruments": ["QCM"],
             },
             "port": "flux_q0",
             "distortions": [],
@@ -302,7 +302,7 @@ def fixture_platform(chip: Chip) -> Platform:
             "alias": "drive_q1_bus",
             "system_control": {
                 "name": "system_control",
-                "instruments": ["QCM-RF1"],
+                "instruments": ["QCM"],
             },
             "port": "drive_q1",
             "distortions": [],
@@ -312,7 +312,7 @@ def fixture_platform(chip: Chip) -> Platform:
             "alias": "flux_q1_bus",
             "system_control": {
                 "name": "system_control",
-                "instruments": ["QCM1"],
+                "instruments": ["QCM"],
             },
             "port": "flux_q1",
             "distortions": [],
@@ -322,7 +322,7 @@ def fixture_platform(chip: Chip) -> Platform:
             "alias": "drive_q2_bus",
             "system_control": {
                 "name": "system_control",
-                "instruments": ["QCM-RF2"],
+                "instruments": ["QCM"],
             },
             "port": "drive_q2",
             "distortions": [],
@@ -332,7 +332,7 @@ def fixture_platform(chip: Chip) -> Platform:
             "alias": "flux_q2_bus",
             "system_control": {
                 "name": "system_control",
-                "instruments": ["QCM2"],
+                "instruments": ["QCM"],
             },
             "port": "flux_q2",
             "distortions": [],
@@ -342,7 +342,7 @@ def fixture_platform(chip: Chip) -> Platform:
             "alias": "flux_c2_bus",  # c2 coupler
             "system_control": {
                 "name": "system_control",
-                "instruments": ["QCM1"],
+                "instruments": ["QCM"],
             },
             "port": "flux_c2",
             "distortions": [],
@@ -352,7 +352,7 @@ def fixture_platform(chip: Chip) -> Platform:
             "alias": "drive_q3_bus",
             "system_control": {
                 "name": "system_control",
-                "instruments": ["QCM-RF3"],
+                "instruments": ["QCM"],
             },
             "port": "drive_q3",
             "distortions": [],
@@ -362,7 +362,7 @@ def fixture_platform(chip: Chip) -> Platform:
             "alias": "flux_q3_bus",
             "system_control": {
                 "name": "system_control",
-                "instruments": ["QCM1"],
+                "instruments": ["QCM"],
             },
             "port": "flux_q3",
             "distortions": [],
@@ -372,7 +372,7 @@ def fixture_platform(chip: Chip) -> Platform:
             "alias": "drive_q4_bus",
             "system_control": {
                 "name": "system_control",
-                "instruments": ["QCM-RF3"],
+                "instruments": ["QCM"],
             },
             "port": "drive_q4",
             "distortions": [],
@@ -382,7 +382,7 @@ def fixture_platform(chip: Chip) -> Platform:
             "alias": "flux_q4_bus",
             "system_control": {
                 "name": "system_control",
-                "instruments": ["QCM1"],
+                "instruments": ["QCM"],
             },
             "port": "flux_q4",
             "distortions": [],

--- a/tests/system_controls/test_system_control.py
+++ b/tests/system_controls/test_system_control.py
@@ -54,6 +54,18 @@ class TestInitialization:
             assert isinstance(instrument, Instrument)
         assert not hasattr(system_control.settings, "platform_instruments")
 
+    def test_init_with_a_wrong_instrument_alias_raises_an_error(self, platform: Platform):
+        """Test that an error is raised when initializing a SystemControl with an instrument alias that is not
+        present in the platform.
+        """
+        alias = "UnknownInstrument"
+        wrong_system_control_settings = {"instruments": [alias]}
+        with pytest.raises(
+            NameError,
+            match=f"The instrument with alias {alias} could not be found within the instruments of the platform",
+        ):
+            SystemControl(settings=wrong_system_control_settings, platform_instruments=platform.instruments)
+
 
 @pytest.fixture(name="base_system_control")
 def fixture_base_system_control(platform: Platform) -> SystemControl:


### PR DESCRIPTION
This PR fixes a bug where, if the user added an instrument alias inside a system control that was not present in the platform, no error was raised and no instrument was added in the bus.

```yaml
- alias: drive_line_q4_bus
  system_control:
    name: system_control
    instruments: [Unknown-alias]
  port: drive_line_q4
  distortions: []
```
Now an error is raised to make sure the user knows that the alias of the instrument doesn't exist.