### PR TITLE
Add Time of Flight between readout pulse `play` and `acquire`

### DIFF
--- a/src/qililab/instruments/awg_analog_digital_converter.py
+++ b/src/qililab/instruments/awg_analog_digital_converter.py
@@ -38,7 +38,7 @@ class AWGAnalogDigitalConverter(AWG):
 
         acquisition_delay_time: int  # ns
         awg_sequencers: Sequence[AWGADCSequencer]
-        time_of_flight: int = 146
+        time_of_flight: int
 
     settings: AWGAnalogDigitalConverterSettings
 

--- a/src/qililab/instruments/awg_analog_digital_converter.py
+++ b/src/qililab/instruments/awg_analog_digital_converter.py
@@ -37,6 +37,7 @@ class AWGAnalogDigitalConverter(AWG):
         """
 
         acquisition_delay_time: int  # ns
+        time_of_flight: int = 146
         awg_sequencers: Sequence[AWGADCSequencer]
 
     settings: AWGAnalogDigitalConverterSettings

--- a/src/qililab/instruments/awg_analog_digital_converter.py
+++ b/src/qililab/instruments/awg_analog_digital_converter.py
@@ -37,8 +37,8 @@ class AWGAnalogDigitalConverter(AWG):
         """
 
         acquisition_delay_time: int  # ns
-        time_of_flight: int = 146
         awg_sequencers: Sequence[AWGADCSequencer]
+        time_of_flight: int = 146
 
     settings: AWGAnalogDigitalConverterSettings
 

--- a/src/qililab/instruments/qblox/qblox_qrm.py
+++ b/src/qililab/instruments/qblox/qblox_qrm.py
@@ -303,7 +303,7 @@ class QbloxQRM(QbloxModule, AWGAnalogDigitalConverter):
     ):
         """Append an acquire instruction to the loop."""
 
-        tof = self.settings.acquisition_delay_time
+        tof = self.settings.time_of_flight
         wait_tof = Wait(tof)
         loop.append_component(wait_tof)
 

--- a/src/qililab/instruments/qblox/qblox_qrm.py
+++ b/src/qililab/instruments/qblox/qblox_qrm.py
@@ -20,7 +20,7 @@ from qpysequence import Program
 from qpysequence import Sequence as QpySequence
 from qpysequence import Weights
 from qpysequence.program import Loop, Register
-from qpysequence.program.instructions import Acquire, AcquireWeighed, Move
+from qpysequence.program.instructions import Acquire, AcquireWeighed, Move, Wait
 
 from qililab.config import logger
 from qililab.instruments.awg_analog_digital_converter import AWGAnalogDigitalConverter
@@ -302,8 +302,12 @@ class QbloxQRM(QbloxModule, AWGAnalogDigitalConverter):
         self, loop: Loop, bin_index: Register | int, sequencer_id: int, weight_regs: tuple[Register, Register]
     ):
         """Append an acquire instruction to the loop."""
-        weighed_acq = self._get_sequencer_by_id(id=sequencer_id).weighed_acq_enabled
 
+        tof = self.settings.acquisition_delay_time
+        wait_tof = Wait(tof)
+        loop.append_component(wait_tof)
+
+        weighed_acq = self._get_sequencer_by_id(id=sequencer_id).weighed_acq_enabled
         acq_instruction = (
             AcquireWeighed(
                 acq_index=0,

--- a/src/qililab/instruments/qblox/qblox_qrm.py
+++ b/src/qililab/instruments/qblox/qblox_qrm.py
@@ -304,8 +304,9 @@ class QbloxQRM(QbloxModule, AWGAnalogDigitalConverter):
         """Append an acquire instruction to the loop."""
 
         tof = self.settings.time_of_flight
-        wait_tof = Wait(tof)
-        loop.append_component(wait_tof)
+        if tof != 0:
+            wait_tof = Wait(tof)
+            loop.append_component(wait_tof)
 
         weighed_acq = self._get_sequencer_by_id(id=sequencer_id).weighed_acq_enabled
         acq_instruction = (


### PR DESCRIPTION
This adds a `wait` operation between the readout pulse and the acquisition time. This is the time the pulse takes to go to the fridge and come back