### PR TITLE
Fix slurm magic method

### DIFF
--- a/src/qililab/slurm.py
+++ b/src/qililab/slurm.py
@@ -8,7 +8,7 @@ from submitit import AutoExecutor
 
 from qililab.config import logger
 
-num_files_to_keep = 500  # needs to be a multiple of 5 since each submitit execution created 5 files
+num_files_to_keep = 500  # needs to be a multiple of 4 and 5
 
 
 # pylint: disable=too-many-locals
@@ -121,9 +121,12 @@ def submit_job(line: str, cell: str, local_ns: dict) -> None:
     for file_path in file_paths:
         try:
             job_ids.append(int(file_path.split("/")[1].split("_")[0]))
-            if len(file_paths) >= num_files_to_keep and (str(min(job_ids)) in file_path):
-                os.remove(file_path)
+
         # remove non-submitit files, not starting with an id
         except ValueError:
             logger.warning("%s shouldn't be in %s. It has been removed!", file_path.split("/")[1], folder_path)
+            os.remove(file_path)
+
+    for file_path in file_paths:
+        if len(file_paths) >= num_files_to_keep and str(min(job_ids)) in file_path:
             os.remove(file_path)

--- a/src/qililab/slurm.py
+++ b/src/qililab/slurm.py
@@ -8,7 +8,7 @@ from submitit import AutoExecutor
 
 from qililab.config import logger
 
-num_files_to_keep = 60  # needs to be a multiple of 4 and 5: 20,40,60,80..
+num_files_to_keep = 500  # needs to be a multiple of 5 since each submitit execution created 5 files
 
 
 # pylint: disable=too-many-locals
@@ -121,7 +121,7 @@ def submit_job(line: str, cell: str, local_ns: dict) -> None:
     for file_path in file_paths:
         try:
             job_ids.append(int(file_path.split("/")[1].split("_")[0]))
-            if len(file_paths) >= num_files_to_keep and (str(job_ids[0]) in file_path):
+            if len(file_paths) >= num_files_to_keep and (str(min(job_ids)) in file_path):
                 os.remove(file_path)
         # remove non-submitit files, not starting with an id
         except ValueError:

--- a/tests/test_slurm.py
+++ b/tests/test_slurm.py
@@ -4,8 +4,9 @@ import time
 from unittest.mock import MagicMock, patch
 
 import pytest
-import qililab as ql
 from IPython.testing.globalipapp import start_ipython
+
+import qililab as ql
 
 # pylint: disable=redefined-outer-name
 slurm_job_data_test = "slurm_job_data_test"
@@ -66,7 +67,7 @@ class TestSubmitJob:
         assert os.path.isfile(os.path.join(slurm_job_data_test, "abc.py")) is False
 
     def test_submit_job_delete_info_from_past_jobs(self, ip):
-        """Check only 60 files are kept in the logs folder"""
+        """Check only a certain amount files are kept in the logs folder"""
         ql.slurm.num_files_to_keep = 8
         ip.run_cell(raw_cell="a=1\nb=1")
         for _ in range(int(ql.slurm.num_files_to_keep / 4)):

--- a/tests/test_slurm.py
+++ b/tests/test_slurm.py
@@ -4,9 +4,8 @@ import time
 from unittest.mock import MagicMock, patch
 
 import pytest
-from IPython.testing.globalipapp import start_ipython
-
 import qililab as ql
+from IPython.testing.globalipapp import start_ipython
 
 # pylint: disable=redefined-outer-name
 slurm_job_data_test = "slurm_job_data_test"
@@ -76,7 +75,7 @@ class TestSubmitJob:
                 line=f"-o results -p debug -l {slurm_job_data_test} -n unit_test -e local",
                 cell="results=a+b",
             )
-            time.sleep(1)  # give time submitit to create the files
+            time.sleep(2)  # give time submitit to create the files
 
         assert (
             len([f for f in os.listdir(slurm_job_data_test) if os.path.isfile(os.path.join(slurm_job_data_test, f))])


### PR DESCRIPTION
- when logs folder size limit is reached, ensure that the oldest job files are deleted (age defined by job id). There might have been some cases where log files from recent jobs were deleted and hence the error appeared
- raise the size limit of the logs folder to 100 jobs (=500 files). This should avoid deleting logs from most recent jobs and hence prevent the error from appearing although several jobs are submitted in a short time-frame (that's the case of autocalibration, if i'm not mistaken)