### PR TITLE
Add low_priority jobs to slurm magic method

### DIFF
--- a/src/qililab/slurm.py
+++ b/src/qililab/slurm.py
@@ -56,6 +56,11 @@ def is_variable_used(code, variable):
     default=None,
     help="Select execution environment. Targets slurm by default but if '-e local' the job is run locally.",
 )
+@argument(
+    "-lp" "--low_priority",
+    default=None,
+    help="By default lab jobs have higher priority than QaaS jobs. However, if '--lp True' they will have the same priority than QaaS jobs and other Lab jobs will be processed first.",
+)
 @needs_local_scope
 @register_cell_magic
 def submit_job(line: str, cell: str, local_ns: dict) -> None:
@@ -73,6 +78,11 @@ def submit_job(line: str, cell: str, local_ns: dict) -> None:
     folder_path = args.logs
     execution_env = args.execution_environment
     begin_time = args.begin
+    low_priority = args.low_priority
+
+    nice_factor = 0
+    if low_priority is True:
+        nice_factor = 1000000  # this ensure Lab jobs have 0 priority, same as QaaS jobs
 
     # Take all the import lines and add them right before the code of the cell (to make sure all the needed libraries
     # are imported inside the SLURM job)
@@ -86,7 +96,7 @@ def submit_job(line: str, cell: str, local_ns: dict) -> None:
         slurm_partition=partition,
         name=job_name,
         timeout_min=time_limit,
-        slurm_additional_parameters={"begin": begin_time},
+        slurm_additional_parameters={"begin": begin_time, "nice": nice_factor},
     )
 
     # Compile the code defined above

--- a/src/qililab/slurm.py
+++ b/src/qililab/slurm.py
@@ -59,7 +59,7 @@ def is_variable_used(code, variable):
     "-lp",
     "--low_priority",
     default=None,
-    help="By default lab jobs have higher priority than QaaS jobs. However, if '--lp True' they will have the same priority than QaaS jobs and other Lab jobs will be executed first.",
+    help="By default lab jobs have higher priority than QaaS jobs. However, if '--lp True' or '--lp true' they will be queued with same priority as QaaS jobs, hence other Lab jobs will be executed first.",
 )
 @needs_local_scope
 @register_cell_magic
@@ -78,10 +78,10 @@ def submit_job(line: str, cell: str, local_ns: dict) -> None:
     folder_path = args.logs
     execution_env = args.execution_environment
     begin_time = args.begin
-    is_low_priority = args.low_priority
+    low_priority = args.low_priority
 
     nice_factor = 0
-    if is_low_priority:
+    if low_priority in ['True','true']:
         nice_factor = 1000000  # this ensures Lab jobs have 0 priority, same as QaaS jobs
 
     # Take all the import lines and add them right before the code of the cell (to make sure all the needed libraries

--- a/src/qililab/slurm.py
+++ b/src/qililab/slurm.py
@@ -57,7 +57,8 @@ def is_variable_used(code, variable):
     help="Select execution environment. Targets slurm by default but if '-e local' the job is run locally.",
 )
 @argument(
-    "-lp" "--low_priority",
+    "-lp",
+    "--low_priority",
     default=None,
     help="By default lab jobs have higher priority than QaaS jobs. However, if '--lp True' they will have the same priority than QaaS jobs and other Lab jobs will be processed first.",
 )
@@ -78,10 +79,10 @@ def submit_job(line: str, cell: str, local_ns: dict) -> None:
     folder_path = args.logs
     execution_env = args.execution_environment
     begin_time = args.begin
-    low_priority = args.low_priority
+    is_low_priority = args.low_priority
 
     nice_factor = 0
-    if low_priority is True:
+    if is_low_priority:
         nice_factor = 1000000  # this ensure Lab jobs have 0 priority, same as QaaS jobs
 
     # Take all the import lines and add them right before the code of the cell (to make sure all the needed libraries

--- a/src/qililab/slurm.py
+++ b/src/qililab/slurm.py
@@ -4,8 +4,9 @@ from types import ModuleType
 
 from IPython.core.magic import needs_local_scope, register_cell_magic
 from IPython.core.magic_arguments import argument, magic_arguments, parse_argstring
-from qililab.config import logger
 from submitit import AutoExecutor
+
+from qililab.config import logger
 
 num_files_to_keep = 60  # needs to be a multiple of 4 and 5: 20,40,60,80..
 
@@ -81,7 +82,7 @@ def submit_job(line: str, cell: str, local_ns: dict) -> None:
     low_priority = args.low_priority
 
     nice_factor = 0
-    if low_priority in ['True','true']:
+    if low_priority in ["True", "true"]:
         nice_factor = 1000000  # this ensures Lab jobs have 0 priority, same as QaaS jobs
 
     # Take all the import lines and add them right before the code of the cell (to make sure all the needed libraries

--- a/src/qililab/slurm.py
+++ b/src/qililab/slurm.py
@@ -4,9 +4,8 @@ from types import ModuleType
 
 from IPython.core.magic import needs_local_scope, register_cell_magic
 from IPython.core.magic_arguments import argument, magic_arguments, parse_argstring
-from submitit import AutoExecutor
-
 from qililab.config import logger
+from submitit import AutoExecutor
 
 num_files_to_keep = 60  # needs to be a multiple of 4 and 5: 20,40,60,80..
 
@@ -60,7 +59,7 @@ def is_variable_used(code, variable):
     "-lp",
     "--low_priority",
     default=None,
-    help="By default lab jobs have higher priority than QaaS jobs. However, if '--lp True' they will have the same priority than QaaS jobs and other Lab jobs will be processed first.",
+    help="By default lab jobs have higher priority than QaaS jobs. However, if '--lp True' they will have the same priority than QaaS jobs and other Lab jobs will be executed first.",
 )
 @needs_local_scope
 @register_cell_magic
@@ -83,7 +82,7 @@ def submit_job(line: str, cell: str, local_ns: dict) -> None:
 
     nice_factor = 0
     if is_low_priority:
-        nice_factor = 1000000  # this ensure Lab jobs have 0 priority, same as QaaS jobs
+        nice_factor = 1000000  # this ensures Lab jobs have 0 priority, same as QaaS jobs
 
     # Take all the import lines and add them right before the code of the cell (to make sure all the needed libraries
     # are imported inside the SLURM job)

--- a/tests/test_slurm.py
+++ b/tests/test_slurm.py
@@ -76,7 +76,7 @@ class TestSubmitJob:
                 line=f"-o results -p debug -l {slurm_job_data_test} -n unit_test -e local",
                 cell="results=a+b",
             )
-            time.sleep(1)  # give time submitit to create the files
+            time.sleep(2)  # give time submitit to create the files
 
         assert (
             len([f for f in os.listdir(slurm_job_data_test) if os.path.isfile(os.path.join(slurm_job_data_test, f))])
@@ -87,7 +87,7 @@ class TestSubmitJob:
             line=f"-o results -p debug -l {slurm_job_data_test} -n unit_test -e local",
             cell="results=a+b",
         )
-        time.sleep(1)
+        time.sleep(2)
         assert (
             len([f for f in os.listdir(slurm_job_data_test) if os.path.isfile(os.path.join(slurm_job_data_test, f))])
             == ql.slurm.num_files_to_keep
@@ -103,10 +103,13 @@ class TestSubmitJob:
             with patch("qililab.slurm.os"):
                 ip.run_cell_magic(
                     magic_name="submit_job",
-                    line=f"-o results -p debug -l {slurm_job_data_test} -n unit_test -e local -t 5 --begin now+1hour",
+                    line=f"-o results -p debug -l {slurm_job_data_test} -n unit_test -e local -t 5 --begin now+1hour -lp true",
                     cell="results=a+b",
                 )
         executor.assert_called_once_with(folder=slurm_job_data_test, cluster="local")
         executor_instance.update_parameters.assert_called_once_with(
-            slurm_partition="debug", name="unit_test", timeout_min=5, slurm_additional_parameters={"begin": "now+1hour"}
+            slurm_partition="debug",
+            name="unit_test",
+            timeout_min=5,
+            slurm_additional_parameters={"begin": "now+1hour", "nice": 1000000},
         )


### PR DESCRIPTION
See below that jobs 969 to 973 have been queued with low priority with -`lp true` and 974 has priority != 0. Hence, 974 is executed first  despite it was the last to be submitted

```
(qililab) adria@adria-Summit-E16Flip-A12UCT:~/Projects/qililab$ sprio -n
          JOBID PARTITION PRIORITY   PARTITION 
            969 local     0.00000000 1.0000000 
            970 local     0.00000000 1.0000000 
            971 local     0.00000000 1.0000000 
            972 local     0.00000000 1.0000000 
            973 local     0.00000000 1.0000000 
            974 local     0.00000023 1.0000000 
(qililab) adria@adria-Summit-E16Flip-A12UCT:~/Projects/qililab$ squeue
             JOBID PARTITION     NAME     USER ST       TIME  NODES NODELIST(REASON)
               973     local submitit    adria PD       0:00      1 (Priority)
               972     local submitit    adria PD       0:00      1 (Priority)
               971     local submitit    adria PD       0:00      1 (Priority)
               970     local submitit    adria PD       0:00      1 (Priority)
               969     local submitit    adria PD       0:00      1 (Resources)
               974     local submitit    adria  R       0:00      1 adria-Summit-E16Flip-A12UCT
```