### PR TITLE
[DIRTY-FIX] Add `wait_time` to play operation for Qblox

### DIFF
--- a/src/qililab/qprogram/operations/play.py
+++ b/src/qililab/qprogram/operations/play.py
@@ -23,6 +23,7 @@ from qililab.waveforms import IQPair, Waveform
 class Play(Operation):  # pylint: disable=missing-class-docstring
     bus: str
     waveform: Waveform | IQPair
+    wait_time: int | None = None  # TODO: remove this in clean fix
 
     def get_waveforms(self) -> tuple[Waveform, Waveform | None]:
         """Get the waveforms.

--- a/src/qililab/qprogram/qblox_compiler.py
+++ b/src/qililab/qprogram/qblox_compiler.py
@@ -454,7 +454,8 @@ class QbloxCompiler:  # pylint: disable=too-few-public-methods
             index_I, index_Q, duration = self._append_to_waveforms_of_bus(
                 bus=element.bus, waveform_I=waveform_I, waveform_Q=waveform_Q
             )
-            duration = element.wait_time or duration  # TODO: Change this in clean fix
+            if element.wait_time is not None:  # TODO: Change this in clean fix
+                duration = element.wait_time
             convert = QbloxCompiler._convert_value(element)
             duration = convert(duration)
             self._buses[element.bus].static_duration += duration

--- a/src/qililab/qprogram/qblox_compiler.py
+++ b/src/qililab/qprogram/qblox_compiler.py
@@ -454,6 +454,7 @@ class QbloxCompiler:  # pylint: disable=too-few-public-methods
             index_I, index_Q, duration = self._append_to_waveforms_of_bus(
                 bus=element.bus, waveform_I=waveform_I, waveform_Q=waveform_Q
             )
+            duration = element.wait_time or duration  # TODO: Change this in clean fix
             convert = QbloxCompiler._convert_value(element)
             duration = convert(duration)
             self._buses[element.bus].static_duration += duration

--- a/src/qililab/qprogram/qprogram.py
+++ b/src/qililab/qprogram/qprogram.py
@@ -211,14 +211,14 @@ class QProgram(DictSerializable):
 
         return QProgram._ForLoopContext(qprogram=self, variable=variable, start=start, stop=stop, step=step)
 
-    def play(self, bus: str, waveform: Waveform | IQPair):
+    def play(self, bus: str, waveform: Waveform | IQPair, wait_time: int | None = None):
         """Play a single waveform or an I/Q pair of waveforms on the bus.
 
         Args:
             bus (str): Unique identifier of the bus.
             waveform (Waveform | IQPair): A single waveform or an I/Q pair of waveforms
         """
-        operation = Play(bus=bus, waveform=waveform)
+        operation = Play(bus=bus, waveform=waveform, wait_time=wait_time)
         self._active_block.append(operation)
 
     @requires_domain("duration", Domain.Time)

--- a/tests/qprogram/test_qblox_compiler.py
+++ b/tests/qprogram/test_qblox_compiler.py
@@ -22,6 +22,7 @@ def fixture_no_loops_all_operations() -> QProgram:
     qp.sync()
     qp.wait(bus="readout", duration=100)
     qp.play(bus="readout", waveform=readout_pair)
+    qp.play(bus="readout", waveform=readout_pair, wait_time=4)
     qp.acquire(bus="readout", weights=weights_pair)
     return qp
 
@@ -281,6 +282,7 @@ class TestQBloxCompiler:
                             wait             40
                             wait             100
                             play             0, 1, 1000
+                            play             0, 1, 4
                             acquire_weighed  0, 0, 0, 1, 2000
                             stop
         """


### PR DESCRIPTION
Since `time_of_flight` is not yet added to runcard settings for Qblox, and measurement is not unified under one operation `measure`, users need a way to define a `time_of_flight` wait time between readout pulse and acquisition. This PR adds this functionality:

```
qp.play(bus="readout_bus", waveform=readout_pair, wait_time=4)
```