### PR TITLE
Split 1q and 2q tables into different dataframes

### DIFF
--- a/src/qililab/calibration/calibration_controller.py
+++ b/src/qililab/calibration/calibration_controller.py
@@ -743,9 +743,8 @@ class CalibrationController:
         Returns:
             tuple(pd.DataFrame): Split 1q and 2q tables.
         """
-        bool_compare = len(df.index) == 1
-        df_1q = df[bool_compare]
-        df_2q = df[~bool_compare]
+        df_1q = df.filter(like="-", axis=0)
+        df_2q = df.subtract(df_1q, fill_value=0)
 
         return df_1q, df_2q
 

--- a/src/qililab/calibration/calibration_controller.py
+++ b/src/qililab/calibration/calibration_controller.py
@@ -743,7 +743,7 @@ class CalibrationController:
         Returns:
             tuple(pd.DataFrame): Split 1q and 2q tables.
         """
-        bool_compare = len(df["qubit"]) == 1
+        bool_compare = len(df.index) == 1
         df_1q = df[bool_compare]
         df_2q = df[~bool_compare]
 

--- a/src/qililab/calibration/calibration_controller.py
+++ b/src/qililab/calibration/calibration_controller.py
@@ -260,9 +260,20 @@ class CalibrationController:
             "Automatic calibration completed successfully!\n"
             "#############################################\n"
         )
+        return self.get_qubit_fidelities_and_parameters_df_tables()
+
+    def get_qubit_fidelities_and_parameters_df_tables(self) -> dict[str, pd.DataFrame]:
+        """Generates the 1q, 2q, fidelities and parameters dataframes, with the last calibrations.
+
+        Returns:
+            dict[str, pd.DataFrame]: Last calibrations dataframes.
+        """
+        df = self.get_qubits_table()
+        df_1q, df_2q = self._split_1q_2q_tables(df)
 
         return {
-            "qubits_table": self.get_qubits_table(),
+            "1q_table": df_1q,
+            "2q_table": df_2q,
             "set_parameters": self.get_last_set_parameters(),
             "fidelities": self.get_last_fidelities(),
         }
@@ -722,6 +733,21 @@ class CalibrationController:
                 df.insert(0, column, first_column)
 
         return df
+
+    def _split_1q_2q_tables(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Splits the qubit table into 2 tables, for the 1q and the 2q information.
+
+        Args:
+            df (pd.DataFrame): Qubits table dataframe.
+
+        Returns:
+            tuple(pd.DataFrame): Split 1q and 2q tables.
+        """
+        bool_compare = len(df["qubit"]) == 1
+        df_1q = df[bool_compare]
+        df_2q = df[~bool_compare]
+
+        return df_1q, df_2q
 
     def _dependencies(self, node: CalibrationNode) -> list:
         """Finds the dependencies of a node.

--- a/src/qililab/calibration/calibration_controller.py
+++ b/src/qililab/calibration/calibration_controller.py
@@ -744,7 +744,7 @@ class CalibrationController:
             tuple(pd.DataFrame): Split 1q and 2q tables.
         """
         df_1q = df.filter(like="-", axis=0)
-        df_2q = df.subtract(df_1q, fill_value=0)
+        df_2q = pd.concat([df, df_1q, df_1q]).drop_duplicates(keep=False)
 
         return df_1q, df_2q
 

--- a/src/qililab/calibration/calibration_controller.py
+++ b/src/qililab/calibration/calibration_controller.py
@@ -659,6 +659,7 @@ class CalibrationController:
             pd.DataFrame: Empty df, where columns are each fidelity or parameter, and rows each qubit.
         """
         q1_idx, q1_col, q2_idx, q2_col = [], [], [], []
+
         for node in self.node_sequence.values():
             qubit_list = node.node_id.split("_")
             qubit = "_".join(

--- a/src/qililab/calibration/calibration_controller.py
+++ b/src/qililab/calibration/calibration_controller.py
@@ -684,7 +684,7 @@ class CalibrationController:
         Returns:
             pd.DataFrame: Empty df, where columns are each fidelity or parameter, and rows each qubit.
         """
-        q1_idx, q1_col, q2_idx, q2_col = [], [], [], []
+        q1_idx, q1_col, q2_idx, q2_col = [], [], [], []  # type: ignore[var-annotated]
 
         for node in self.node_sequence.values():
             qubit_list = node.node_id.split("_")

--- a/tests/calibration/test_calibration_controller.py
+++ b/tests/calibration/test_calibration_controller.py
@@ -922,46 +922,61 @@ class TestCalibrationController:
                     "fidelities": [("0-1", f"fidelity_{ind}", 0.967)],
                 }
 
-            if node.node_id == "fourth":
+            elif node.node_id == "fourth":
+                node.node_id = "fourth_q1"
                 node.output_parameters = {
                     "check_parameters": {"x": [0, 1, 2, 3, 4, 5], "y": [0, 1, 2, 3, 4, 5]},
-                    "platform_parameters": [("test_bus", "", f"param_{ind}", 1)],
-                    "fidelities": [("", f"fidelity_{ind}", 0.967)],
+                    "platform_parameters": [("test_bus", 1, f"param_{ind}", 1)],
+                    "fidelities": [(1, f"fidelity_{ind}", 0.967)],
                 }
 
-            node.output_parameters = {
-                "check_parameters": {"x": [0, 1, 2, 3, 4, 5], "y": [0, 1, 2, 3, 4, 5]},
-                "platform_parameters": [("test_bus", 0, f"param_{ind}", 1)],
-                "fidelities": [(0, f"fidelity_{ind}", 0.967)],
-            }
+            else:
+                node.output_parameters = {
+                    "check_parameters": {"x": [0, 1, 2, 3, 4, 5], "y": [0, 1, 2, 3, 4, 5]},
+                    "platform_parameters": [("test_bus", 0, f"param_{ind}", 1)],
+                    "fidelities": [(0, f"fidelity_{ind}", 0.967)],
+                }
             node.previous_timestamp = 1999
 
-        df = controller.get_qubits_table()
+        q1_df, q2_df = controller.get_qubits_tables()
 
         # Create the pandas DataFrame to test
-        idx = ["0-1", "0", ""]
+        idx = ["0-1", "0", "1"]
         data = [
-            [1, "-", "-", "-", "-", 0.967, "-", "-", "-", "-"],
-            ["-", 1, 1, 1, "-", "-", 0.967, 0.967, 0.967, "-"],
-            ["-", "-", "-", "-", 1, "-", "-", "-", "-", 0.967],
+            [1, 0.967],
+            [1, 1, 1, "-", 0.967, 0.967, 0.967, "-"],
+            ["-", "-", "-", 1, "-", "-", "-", 0.967],
         ]
-        col = [
-            "param_0_test_bus",
+        col_q1 = [
             "param_1_test_bus",
             "param_2_test_bus",
             "param_3_test_bus",
             "param_4_test_bus",
-            "fidelity_0",
             "fidelity_1",
             "fidelity_2",
             "fidelity_3",
             "fidelity_4",
         ]
-        test_df = pd.DataFrame(data, idx, col)
-        test_df.index.name = "qubit"
+        col_q2 = [
+            "param_0_test_bus",
+            "fidelity_0",
+        ]
+        test_q1_df = pd.DataFrame(data[1:], idx[1:], col_q1)
+        test_q2_df = pd.DataFrame(data[:1], idx[:1], col_q2)
+
+        test_q1_df.index.name = "qubit"
+        test_q2_df.index.name = "qubit"
 
         assert (
-            pd.testing.assert_frame_equal(df, test_df, check_dtype=False, check_like=True, check_index_type=False)
+            pd.testing.assert_frame_equal(
+                q1_df, test_q1_df, check_dtype=False, check_like=True, check_index_type=False, check_column_type=False
+            )
+            is None
+        )
+        assert (
+            pd.testing.assert_frame_equal(
+                q2_df, test_q2_df, check_dtype=False, check_like=True, check_index_type=False, check_column_type=False
+            )
             is None
         )
 

--- a/tests/calibration/test_calibration_controller.py
+++ b/tests/calibration/test_calibration_controller.py
@@ -219,6 +219,7 @@ class RunAutomaticCalibrationMockedController(CalibrationController):
     def __init__(self, node_sequence, calibration_graph, runcard):
         super().__init__(node_sequence=node_sequence, calibration_graph=calibration_graph, runcard=runcard)
         self.maintain = MagicMock(return_value=None)
+        self.get_qubits_tables = MagicMock(return_value=(10, 10))
         self.get_last_set_parameters = MagicMock(
             return_value={("test", "test"): (0.0, "test", datetime.fromtimestamp(1999))}
         )
@@ -327,20 +328,24 @@ class TestInitializationCalibrationController:
 class TestRunAutomaticCalibrationFromCalibrationController:
     """Test that ``run_autoamtic_calibration()`` of ``CalibrationController`` behaves well."""
 
-    # TODO: Add functionality for new flags, and new changes!
-    # def test_run_automatic_calibration(self, controller):
-    #     """Test that `run_automatic_calibration()` gets the proper nodes to maintain."""
-    #     # Act:
-    #     output_dict = controller.run_automatic_calibration()
+    def test_run_automatic_calibration(self, controller):
+        """Test that `run_automatic_calibration()` gets the proper nodes to maintain."""
+        # Act:
+        output_dict = controller.run_automatic_calibration()
 
-    #     # Asserts:
-    #     controller.get_last_set_parameters.assert_called_once_with()
-    #     controller.get_last_fidelities.assert_called_once_with()
-    #     assert output_dict == {
-    #         "set_parameters": {("test", "test"): (0.0, "test", datetime.fromtimestamp(1999))},
-    #         "fidelities": {"test": (0.0, "test", datetime.fromtimestamp(1999))},
-    #     }
+        # Asserts:
+        controller.get_last_set_parameters.assert_called_once_with()
+        controller.get_last_fidelities.assert_called_once_with()
+        controller.get_qubits_tables.assert_called_once_with()
 
+        assert output_dict == {
+            "1q_table": 10,
+            "2q_table": 10,
+            "set_parameters": {("test", "test"): (0.0, "test", datetime.fromtimestamp(1999))},
+            "fidelities": {"test": (0.0, "test", datetime.fromtimestamp(1999))},
+        }
+
+    # TODO: Add functionality for new flags, and new changes to test above!
     #     # sourcery skip: extract-duplicate-method
     #     if controller.calibration_graph in [G0, G3]:
     #         controller.maintain.assert_any_call(fourth)

--- a/tests/calibration/test_calibration_controller.py
+++ b/tests/calibration/test_calibration_controller.py
@@ -1018,6 +1018,11 @@ class TestCalibrationController:
             is None
         )
 
+        # Undo the previous change to the node_id, for the nexts tests:
+        for node in controller.node_sequence.values():
+            if node.node_id == "fourth_q1":
+                node.node_id = "fourth"
+
     def test_reorder_fidelities(self, controller):
         """Test that the reorder method, puts the fidelities in the front."""
         idx = ["0", "1"]
@@ -1055,9 +1060,9 @@ class TestCalibrationController:
 
         assert pd.testing.assert_frame_equal(df, ordered_df, check_dtype=False, check_index_type=False) is None
 
-    #######################
-    ### TEST DEPENDENTS ###
-    #######################
+    #########################
+    ### TEST DEPENDENCIES ###
+    #########################
     def test_dependencies(self, controller):
         """Test that dependencies return the correct dependencies."""
         result = controller._dependencies(nodes["zeroth_q0q1"])


### PR DESCRIPTION
This PR splits the 1q and 2q tables, and since lot of code was going to be duplicated, I have refactored lot of code in methods, to be called twice, making also the code more readable 🥇 

The final result tables look like this:
![Screenshot 2024-01-16 at 18 33 43](https://github.com/qilimanjaro-tech/qililab/assets/109400222/fb4410a5-b71f-42fd-961c-167fc2ed78c5)
