### PR TITLE
Hotfix for setitem in stream_results

### DIFF
--- a/src/qililab/result/stream_results.py
+++ b/src/qililab/result/stream_results.py
@@ -89,7 +89,8 @@ def stream_results(shape: tuple, path: str, loops: dict[str, np.ndarray]):
 
 
 class StreamArray:
-    """Allows for real time saving of results from an experiment.
+    """
+    Allows for real time saving of results from an experiment.
 
     This class wraps a numpy array and adds a context manager to save results on real time while they are acquired by
     the instruments.
@@ -107,7 +108,7 @@ class StreamArray:
         self._file: h5py.File | None = None
         self._dataset = None
 
-    def __setitem__(self, key: str, value: float):
+    def __setitem__(self, key: tuple, value: float):
         """Sets and item by key and value in the dataset.
 
         Args:

--- a/src/qililab/result/stream_results.py
+++ b/src/qililab/result/stream_results.py
@@ -112,7 +112,7 @@ class StreamArray:
         """Sets and item by key and value in the dataset.
 
         Args:
-            key (str): key for the item to save.
+            key (tuple): key for the item to save.
             value (float): value to save.
         """
         if self._file is not None and self._dataset is not None:


### PR DESCRIPTION
Quick hotfix to make the __setitem__ requirements match the data of stream_results