### PR TITLE
[QHC-217] Ensure QProgram supports variables in waveforms

### DIFF
--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -5,11 +5,11 @@
 - Allow execution of `QProgram` through `platform.execute_qprogram` method for Quantum Machines hardware.
   [#648](https://github.com/qilimanjaro-tech/qililab/pull/648)
 
-- Allow multiple measurements of the same qubit in a single circuit. Also allow measurements in the middle of a circuit
+- Allow multiple measurements of the same qubit in a single circuit. Also allow measurements in the middle of a circuit.
   [#674](https://github.com/qilimanjaro-tech/qililab/pull/674)
 
 - Wait times longer than 2\*\*16-4 (QBLOX maximum wait time in a Q1ASM wait instruction) are now allowed in the middle of
-  a circuit
+  a circuit.
   [#674](https://github.com/qilimanjaro-tech/qililab/pull/674)
 
 ### Improvements
@@ -26,8 +26,11 @@
 - Added `DictSerializable` protocol and `from_dict` utility function to enable (de)serialization (from)to dictionary for any class.
   [#659](https://github.com/qilimanjaro-tech/qililab/pull/659)
 
-- Added method to get the QRM `channel_id` for a given qubit
+- Added method to get the QRM `channel_id` for a given qubit.
   [#664](https://github.com/qilimanjaro-tech/qililab/pull/664)
+
+- Added Domain restrictions to `Drag` pulse, `DragCorrection` waveform and `Gaussian` waveform.
+  [#679](https://github.com/qilimanjaro-tech/qililab/pull/679)
 
 ### Improvements
 
@@ -36,10 +39,10 @@
   not possible otherwise. It also decouples, to a great extent, the instruments and instrument controllers (hardware) from higher level processes more typical of quantum control, which are involved in the pulse compilation to assembly program steps.
   [#651](https://github.com/qilimanjaro-tech/qililab/pull/651)
 
-- Changed save and load methods using `PyYAML` to `ruamel.YAML`
+- Changed save and load methods using `PyYAML` to `ruamel.YAML`.
   [#661](https://github.com/qilimanjaro-tech/qililab/pull/661)
 
-- Qprogram's qblox compiler now allows iterations over variables even if these variables do nothing (eg. iterate over nshots)
+- Qprogram's qblox compiler now allows iterations over variables even if these variables do nothing. (eg. iterate over nshots)
   [#666](https://github.com/qilimanjaro-tech/qililab/pull/666)
 
 ### Breaking changes

--- a/src/qililab/waveforms/__init__.py
+++ b/src/qililab/waveforms/__init__.py
@@ -25,6 +25,7 @@ Waveforms
     ~Waveform
     ~Arbitrary
     ~Gaussian
+    ~DragCorrection
     ~Square
     ~IQPair
     ~DragPair
@@ -32,6 +33,7 @@ Waveforms
 
 from .arbitrary import Arbitrary
 from .drag import Drag as DragPair
+from .drag_correction import DragCorrection
 from .gaussian import Gaussian
 from .iq_pair import IQPair
 from .square import Square

--- a/src/qililab/waveforms/drag.py
+++ b/src/qililab/waveforms/drag.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 """Drag IQPair."""
+from qililab.qprogram.decorators import requires_domain
+from qililab.qprogram.variable import Domain
 from qililab.waveforms.drag_correction import DragCorrection
 from qililab.waveforms.gaussian import Gaussian
 
@@ -30,6 +32,10 @@ class Drag(IQPair):  # pylint: disable=too-few-public-methods
         drag_coefficient (float): Drag coefficient that gives the DRAG its imaginary components.
     """
 
+    @requires_domain("amplitude", Domain.Voltage)
+    @requires_domain("duration", Domain.Time)
+    @requires_domain("num_sigmas", Domain.Scalar)
+    @requires_domain("drag_coefficient", Domain.Scalar)
     def __init__(self, amplitude: float, duration: int, num_sigmas: float, drag_coefficient: float):
         waveform_i = Gaussian(amplitude=amplitude, duration=duration, num_sigmas=num_sigmas)
         waveform_q = DragCorrection(drag_coefficient=drag_coefficient, waveform=waveform_i)

--- a/src/qililab/waveforms/drag_correction.py
+++ b/src/qililab/waveforms/drag_correction.py
@@ -15,6 +15,9 @@
 """DragCorrection waveform."""
 import numpy as np
 
+from qililab.qprogram.decorators import requires_domain
+from qililab.qprogram.variable import Domain
+
 from .gaussian import Gaussian
 from .waveform import Waveform
 
@@ -29,6 +32,7 @@ class DragCorrection(Waveform):  # pylint: disable=too-few-public-methods
         waveform (Waveform): waveform on which the drag transformation is calculated
     """
 
+    @requires_domain("drag_coefficient", Domain.Scalar)
     def __init__(self, drag_coefficient: float, waveform: Waveform):
         super().__init__()
         self.drag_coefficient = drag_coefficient

--- a/src/qililab/waveforms/gaussian.py
+++ b/src/qililab/waveforms/gaussian.py
@@ -15,6 +15,9 @@
 """Gaussian waveform."""
 import numpy as np
 
+from qililab.qprogram.decorators import requires_domain
+from qililab.qprogram.variable import Domain
+
 from .waveform import Waveform
 
 
@@ -64,6 +67,9 @@ class Gaussian(Waveform):  # pylint: disable=too-few-public-methods
         num_sigmas (float): Sigma number of the gaussian pulse shape. Defines the width of the gaussian pulse.
     """
 
+    @requires_domain("amplitude", Domain.Voltage)
+    @requires_domain("duration", Domain.Time)
+    @requires_domain("num_sigmas", Domain.Scalar)
     def __init__(self, amplitude: float, duration: int, num_sigmas: float):
         super().__init__()
         self.amplitude = amplitude


### PR DESCRIPTION
Added Domain restrictions to `Drag` pulse, `DragCorrection` waveform and `Gaussian` waveform.