### PR TITLE
release 0.23.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## 0.23.3 (2024-02-19)
+
+### Bug fixes
+
+- Fixed an issue when serializing / deserializing a QProgram so results are returned in a standard results class.
+  [#688](https://github.com/qilimanjaro-tech/qililab/pull/688)
+
 ## 0.23.2 (2024-02-13)
 
 ### Bug fixes

--- a/src/qililab/config/version.py
+++ b/src/qililab/config/version.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 """Version number (major.minor.patch[-label])"""
-__version__ = "0.23.2"
+__version__ = "0.23.3"


### PR DESCRIPTION
This PR brings a release for the hotfix for QProgram being serializable and returning a proper results class rather than a dictionary with results.