### PR TITLE
Extracted sync from upload_qpysequence into an independent line

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -20,4 +20,4 @@ disable=
     too-many-ancestors,
     missing-module-docstring,
     too-many-arguments,
-    R0912
+    too-many-branches

--- a/.pylintrc
+++ b/.pylintrc
@@ -19,5 +19,5 @@ disable=
     duplicate-code,
     too-many-ancestors,
     missing-module-docstring,
-    too-many-arguments
+    too-many-arguments,
     R0912

--- a/.pylintrc
+++ b/.pylintrc
@@ -20,3 +20,4 @@ disable=
     too-many-ancestors,
     missing-module-docstring,
     too-many-arguments
+    R0912

--- a/src/qililab/instruments/qblox/qblox_module.py
+++ b/src/qililab/instruments/qblox/qblox_module.py
@@ -116,7 +116,6 @@ class QbloxModule(AWG):
         sequencers = self.get_sequencers_from_chip_port_id(chip_port_id=port)
         for sequencer in sequencers:
             self.device.sequencers[sequencer.identifier].sync_en(True)
-        return None
 
     # TODO: merge both desyncs or decide if desync_sequencers is enough
     def desync_by_port(self, port: str) -> None:
@@ -124,7 +123,6 @@ class QbloxModule(AWG):
         sequencers = self.get_sequencers_from_chip_port_id(chip_port_id=port)
         for sequencer in sequencers:
             self.device.sequencers[sequencer.identifier].sync_en(False)
-        return None
 
     def desync_sequencers(self) -> None:
         """Desyncs all sequencers."""

--- a/src/qililab/instruments/qblox/qblox_module.py
+++ b/src/qililab/instruments/qblox/qblox_module.py
@@ -70,9 +70,9 @@ class QbloxModule(AWG):
                 )
 
             self.awg_sequencers = [
-                AWGQbloxSequencer(**sequencer)
-                if isinstance(sequencer, dict)
-                else sequencer  # pylint: disable=not-a-mapping
+                (
+                    AWGQbloxSequencer(**sequencer) if isinstance(sequencer, dict) else sequencer
+                )  # pylint: disable=not-a-mapping
                 for sequencer in self.awg_sequencers
             ]
             super().__post_init__()
@@ -115,6 +115,11 @@ class QbloxModule(AWG):
         """Desyncs all sequencers."""
         for sequencer in self.awg_sequencers:
             self.device.sequencers[sequencer.identifier].sync_en(False)
+
+    def sync_sequencers(self) -> None:
+        """Syncs all sequencers."""
+        for sequencer in self.awg_sequencers:
+            self.device.sequencers[sequencer.identifier].sync_en(True)
 
     @property
     def module_type(self):
@@ -403,10 +408,10 @@ class QbloxModule(AWG):
         for sequencer in sequencers:
             logger.info("Sequence program: \n %s", repr(qpysequence._program))  # pylint: disable=protected-access
             self.device.sequencers[sequencer.identifier].sequence(qpysequence.todict())
-            self.device.sequencers[sequencer.identifier].sync_en(True)
+            # self.device.sequencers[sequencer.identifier].sync_en(True)
             self.sequences[sequencer.identifier] = qpysequence
 
-    def upload(self, port: str):  # TODO: check compatibility with QPrgram
+    def upload(self, port: str):  # TODO: check compatibility with QProgram
         """Upload all the previously compiled programs to its corresponding sequencers.
 
         This method must be called after the method ``compile`` in the compiler

--- a/src/qililab/instruments/qblox/qblox_module.py
+++ b/src/qililab/instruments/qblox/qblox_module.py
@@ -111,16 +111,27 @@ class QbloxModule(AWG):
         for idx, offset in enumerate(self.out_offsets):
             self._set_out_offset(output=idx, value=offset)
 
-    def sync_sequencers(self, port: str) -> None:
+    # def sync_sequencers(self) -> None:
+    #     """Syncs all sequencers."""
+    #     for sequencer in self.awg_sequencers:
+    #         self.device.sequencers[sequencer.identifier].sync_en(True)
+
+    def sync_by_port(self, port: str) -> None:
         """Syncs all sequencers."""
         sequencers = self.get_sequencers_from_chip_port_id(chip_port_id=port)
         for sequencer in sequencers:
             self.device.sequencers[sequencer.identifier].sync_en(True)
 
-    def desync_sequencers(self, port: str) -> None:
+    # TODO: merge both desyncs or decide if desync_sequencers is enough
+    def desync_by_port(self, port: str) -> None:
         """Syncs all sequencers."""
         sequencers = self.get_sequencers_from_chip_port_id(chip_port_id=port)
         for sequencer in sequencers:
+            self.device.sequencers[sequencer.identifier].sync_en(False)
+
+    def desync_sequencers(self) -> None:
+        """Desyncs all sequencers."""
+        for sequencer in self.awg_sequencers:
             self.device.sequencers[sequencer.identifier].sync_en(False)
 
     @property

--- a/src/qililab/instruments/qblox/qblox_module.py
+++ b/src/qililab/instruments/qblox/qblox_module.py
@@ -111,14 +111,16 @@ class QbloxModule(AWG):
         for idx, offset in enumerate(self.out_offsets):
             self._set_out_offset(output=idx, value=offset)
 
-    def sync_sequencers(self) -> None:
+    def sync_sequencers(self, port: str) -> None:
         """Syncs all sequencers."""
-        for sequencer in self.awg_sequencers:
+        sequencers = self.get_sequencers_from_chip_port_id(chip_port_id=port)
+        for sequencer in sequencers:
             self.device.sequencers[sequencer.identifier].sync_en(True)
 
-    def desync_sequencers(self) -> None:
-        """Desyncs all sequencers."""
-        for sequencer in self.awg_sequencers:
+    def desync_sequencers(self, port: str) -> None:
+        """Syncs all sequencers."""
+        sequencers = self.get_sequencers_from_chip_port_id(chip_port_id=port)
+        for sequencer in sequencers:
             self.device.sequencers[sequencer.identifier].sync_en(False)
 
     @property

--- a/src/qililab/instruments/qblox/qblox_module.py
+++ b/src/qililab/instruments/qblox/qblox_module.py
@@ -70,9 +70,9 @@ class QbloxModule(AWG):
                 )
 
             self.awg_sequencers = [
-                (
-                    AWGQbloxSequencer(**sequencer) if isinstance(sequencer, dict) else sequencer
-                )  # pylint: disable=not-a-mapping
+                AWGQbloxSequencer(**sequencer)
+                if isinstance(sequencer, dict)
+                else sequencer  # pylint: disable=not-a-mapping
                 for sequencer in self.awg_sequencers
             ]
             super().__post_init__()
@@ -117,7 +117,6 @@ class QbloxModule(AWG):
         for sequencer in sequencers:
             self.device.sequencers[sequencer.identifier].sync_en(True)
 
-    # TODO: merge both desyncs or decide if desync_sequencers is enough
     def desync_by_port(self, port: str) -> None:
         """Syncs all sequencers."""
         sequencers = self.get_sequencers_from_chip_port_id(chip_port_id=port)

--- a/src/qililab/instruments/qblox/qblox_module.py
+++ b/src/qililab/instruments/qblox/qblox_module.py
@@ -116,6 +116,7 @@ class QbloxModule(AWG):
         sequencers = self.get_sequencers_from_chip_port_id(chip_port_id=port)
         for sequencer in sequencers:
             self.device.sequencers[sequencer.identifier].sync_en(True)
+        return None
 
     # TODO: merge both desyncs or decide if desync_sequencers is enough
     def desync_by_port(self, port: str) -> None:
@@ -123,6 +124,7 @@ class QbloxModule(AWG):
         sequencers = self.get_sequencers_from_chip_port_id(chip_port_id=port)
         for sequencer in sequencers:
             self.device.sequencers[sequencer.identifier].sync_en(False)
+        return None
 
     def desync_sequencers(self) -> None:
         """Desyncs all sequencers."""

--- a/src/qililab/instruments/qblox/qblox_module.py
+++ b/src/qililab/instruments/qblox/qblox_module.py
@@ -111,15 +111,15 @@ class QbloxModule(AWG):
         for idx, offset in enumerate(self.out_offsets):
             self._set_out_offset(output=idx, value=offset)
 
-    def desync_sequencers(self) -> None:
-        """Desyncs all sequencers."""
-        for sequencer in self.awg_sequencers:
-            self.device.sequencers[sequencer.identifier].sync_en(False)
-
     def sync_sequencers(self) -> None:
         """Syncs all sequencers."""
         for sequencer in self.awg_sequencers:
             self.device.sequencers[sequencer.identifier].sync_en(True)
+
+    def desync_sequencers(self) -> None:
+        """Desyncs all sequencers."""
+        for sequencer in self.awg_sequencers:
+            self.device.sequencers[sequencer.identifier].sync_en(False)
 
     @property
     def module_type(self):
@@ -408,7 +408,6 @@ class QbloxModule(AWG):
         for sequencer in sequencers:
             logger.info("Sequence program: \n %s", repr(qpysequence._program))  # pylint: disable=protected-access
             self.device.sequencers[sequencer.identifier].sequence(qpysequence.todict())
-            # self.device.sequencers[sequencer.identifier].sync_en(True)
             self.sequences[sequencer.identifier] = qpysequence
 
     def upload(self, port: str):  # TODO: check compatibility with QProgram

--- a/src/qililab/instruments/qblox/qblox_module.py
+++ b/src/qililab/instruments/qblox/qblox_module.py
@@ -111,11 +111,6 @@ class QbloxModule(AWG):
         for idx, offset in enumerate(self.out_offsets):
             self._set_out_offset(output=idx, value=offset)
 
-    # def sync_sequencers(self) -> None:
-    #     """Syncs all sequencers."""
-    #     for sequencer in self.awg_sequencers:
-    #         self.device.sequencers[sequencer.identifier].sync_en(True)
-
     def sync_by_port(self, port: str) -> None:
         """Syncs all sequencers."""
         sequencers = self.get_sequencers_from_chip_port_id(chip_port_id=port)

--- a/src/qililab/platform/platform.py
+++ b/src/qililab/platform/platform.py
@@ -654,7 +654,7 @@ class Platform:  # pylint: disable = too-many-public-methods, too-many-instance-
             # sync all rellevant sequences
             for instrument in buses[bus_alias].system_control.instruments:
                 if isinstance(instrument, QbloxModule):
-                    instrument.desync_by_port(buses[bus_alias].port)
+                    instrument.sync_by_port(buses[bus_alias].port)
 
         # Execute sequences
         for bus_alias in sequences:

--- a/src/qililab/platform/platform.py
+++ b/src/qililab/platform/platform.py
@@ -654,7 +654,7 @@ class Platform:  # pylint: disable = too-many-public-methods, too-many-instance-
             # sync all rellevant sequences
             for instrument in buses[bus_alias].system_control.instruments:
                 if isinstance(instrument, QbloxModule):
-                    instrument.sync_sequencers(buses[bus_alias].port)
+                    instrument.sync_by_port(buses[bus_alias].port)
 
         # Execute sequences
         for bus_alias in sequences:
@@ -673,7 +673,7 @@ class Platform:  # pylint: disable = too-many-public-methods, too-many-instance-
         for bus_alias in sequences:
             for instrument in buses[bus_alias].system_control.instruments:
                 if isinstance(instrument, QbloxModule):
-                    instrument.desync_sequencers(buses[bus_alias].port)
+                    instrument.desync_by_port(buses[bus_alias].port)
 
         return results
 

--- a/src/qililab/platform/platform.py
+++ b/src/qililab/platform/platform.py
@@ -651,11 +651,10 @@ class Platform:  # pylint: disable = too-many-public-methods, too-many-instance-
             if bus_alias not in self._qpy_sequence_cache or self._qpy_sequence_cache[bus_alias] != sequence_hash:
                 buses[bus_alias].upload_qpysequence(qpysequence=sequences[bus_alias])
                 self._qpy_sequence_cache[bus_alias] = sequence_hash
-
-        # sync all instruments
-        for instrument in self.instruments.elements:
-            if isinstance(instrument, QbloxModule):
-                instrument.sync_sequencers()
+            # sync all rellevant sequences
+            for instrument in buses[bus_alias].system_control.instruments:
+                if isinstance(instrument, QbloxModule):
+                    instrument.sync_sequencers(buses[bus_alias].port)
 
         # Execute sequences
         for bus_alias in sequences:
@@ -671,10 +670,10 @@ class Platform:  # pylint: disable = too-many-public-methods, too-many-instance-
                     results.append_result(bus=bus_alias, result=bus_result)
 
         # Reset instrument settings
-        for instrument in self.instruments.elements:
-            if isinstance(instrument, QbloxModule):
-                # instrument.clear_cache()
-                instrument.desync_sequencers()
+        for bus_alias in sequences:
+            for instrument in buses[bus_alias].system_control.instruments:
+                if isinstance(instrument, QbloxModule):
+                    instrument.desync_sequencers(buses[bus_alias].port)
 
         return results
 

--- a/src/qililab/platform/platform.py
+++ b/src/qililab/platform/platform.py
@@ -652,9 +652,11 @@ class Platform:  # pylint: disable = too-many-public-methods, too-many-instance-
                 buses[bus_alias].upload_qpysequence(qpysequence=sequences[bus_alias])
                 self._qpy_sequence_cache[bus_alias] = sequence_hash
             # sync all rellevant sequences
-            for instrument in buses[bus_alias].system_control.instruments:
-                if isinstance(instrument, QbloxModule):
-                    instrument.sync_by_port(buses[bus_alias].port)
+            [
+                q.sync_by_port(buses[bus_alias].port)
+                for q in buses[bus_alias].system_control.instruments
+                if isinstance(q, QbloxModule)
+            ]
 
         # Execute sequences
         for bus_alias in sequences:
@@ -671,11 +673,11 @@ class Platform:  # pylint: disable = too-many-public-methods, too-many-instance-
 
         # Reset instrument settings
         for bus_alias in sequences:
-            qblox_modules = filter(
-                lambda instrument: isinstance(instrument, QbloxModule), buses[bus_alias].system_control.instruments
-            )
-            for instrument in qblox_modules:
-                instrument.desync_by_port(buses[bus_alias].port)
+            [
+                q.desync_by_port(buses[bus_alias].port)
+                for q in buses[bus_alias].system_control.instruments
+                if isinstance(q, QbloxModule)
+            ]
 
         return results
 

--- a/src/qililab/platform/platform.py
+++ b/src/qililab/platform/platform.py
@@ -671,8 +671,9 @@ class Platform:  # pylint: disable = too-many-public-methods, too-many-instance-
 
         # Reset instrument settings
         for bus_alias in sequences:
-            for instrument in buses[bus_alias].system_control.instruments:
-                if isinstance(instrument, QbloxModule): instrument.desync_by_port(buses[bus_alias].port)
+            qblox_modules = filter(lambda instrument: isinstance(instrument, QbloxModule), buses[bus_alias].system_control.instruments)
+            for instrument in qblox_modules:
+                instrument.desync_by_port(buses[bus_alias].port)
 
         return results
 

--- a/src/qililab/platform/platform.py
+++ b/src/qililab/platform/platform.py
@@ -652,7 +652,7 @@ class Platform:  # pylint: disable = too-many-public-methods, too-many-instance-
                 buses[bus_alias].upload_qpysequence(qpysequence=sequences[bus_alias])
                 self._qpy_sequence_cache[bus_alias] = sequence_hash
             # sync all rellevant sequences
-            [
+            _ = [
                 q.sync_by_port(buses[bus_alias].port)
                 for q in buses[bus_alias].system_control.instruments
                 if isinstance(q, QbloxModule)
@@ -673,7 +673,7 @@ class Platform:  # pylint: disable = too-many-public-methods, too-many-instance-
 
         # Reset instrument settings
         for bus_alias in sequences:
-            [
+            _ = [
                 q.desync_by_port(buses[bus_alias].port)
                 for q in buses[bus_alias].system_control.instruments
                 if isinstance(q, QbloxModule)

--- a/src/qililab/platform/platform.py
+++ b/src/qililab/platform/platform.py
@@ -652,11 +652,9 @@ class Platform:  # pylint: disable = too-many-public-methods, too-many-instance-
                 buses[bus_alias].upload_qpysequence(qpysequence=sequences[bus_alias])
                 self._qpy_sequence_cache[bus_alias] = sequence_hash
             # sync all rellevant sequences
-            _ = [
-                q.sync_by_port(buses[bus_alias].port)
-                for q in buses[bus_alias].system_control.instruments
-                if isinstance(q, QbloxModule)
-            ]
+            for instrument in buses[bus_alias].system_control.instruments:
+                if isinstance(instrument, QbloxModule):
+                    instrument.desync_by_port(buses[bus_alias].port)
 
         # Execute sequences
         for bus_alias in sequences:
@@ -673,11 +671,9 @@ class Platform:  # pylint: disable = too-many-public-methods, too-many-instance-
 
         # Reset instrument settings
         for bus_alias in sequences:
-            _ = [
-                q.desync_by_port(buses[bus_alias].port)
-                for q in buses[bus_alias].system_control.instruments
-                if isinstance(q, QbloxModule)
-            ]
+            for instrument in buses[bus_alias].system_control.instruments:
+                if isinstance(instrument, QbloxModule):
+                    instrument.desync_by_port(buses[bus_alias].port)
 
         return results
 

--- a/src/qililab/platform/platform.py
+++ b/src/qililab/platform/platform.py
@@ -575,9 +575,9 @@ class Platform:  # pylint: disable = too-many-public-methods, too-many-instance-
         buses_dict = {RUNCARD.BUSES: self.buses.to_dict() if self.buses is not None else None}
         instrument_dict = {RUNCARD.INSTRUMENTS: self.instruments.to_dict() if self.instruments is not None else None}
         instrument_controllers_dict = {
-            RUNCARD.INSTRUMENT_CONTROLLERS: (
-                self.instrument_controllers.to_dict() if self.instrument_controllers is not None else None
-            ),
+            RUNCARD.INSTRUMENT_CONTROLLERS: self.instrument_controllers.to_dict()
+            if self.instrument_controllers is not None
+            else None,
         }
 
         return (

--- a/src/qililab/platform/platform.py
+++ b/src/qililab/platform/platform.py
@@ -653,7 +653,6 @@ class Platform:  # pylint: disable = too-many-public-methods, too-many-instance-
                 self._qpy_sequence_cache[bus_alias] = sequence_hash
 
         # sync all instruments
-        # TODO: check what are those instruments while debugging
         for instrument in self.instruments.elements:
             if isinstance(instrument, QbloxModule):
                 instrument.sync_sequencers()

--- a/src/qililab/platform/platform.py
+++ b/src/qililab/platform/platform.py
@@ -672,8 +672,7 @@ class Platform:  # pylint: disable = too-many-public-methods, too-many-instance-
         # Reset instrument settings
         for bus_alias in sequences:
             for instrument in buses[bus_alias].system_control.instruments:
-                if isinstance(instrument, QbloxModule):
-                    instrument.desync_by_port(buses[bus_alias].port)
+                if isinstance(instrument, QbloxModule): instrument.desync_by_port(buses[bus_alias].port)
 
         return results
 

--- a/src/qililab/platform/platform.py
+++ b/src/qililab/platform/platform.py
@@ -22,11 +22,11 @@ from queue import Queue
 
 from qibo.gates import M
 from qibo.models import Circuit
+from qiboconnection.api import API
 from qm import generate_qua_script
 from qpysequence import Sequence as QpySequence
 from ruamel.yaml import YAML
 
-from qiboconnection.api import API
 from qililab.chip import Chip
 from qililab.circuit_transpiler import CircuitTranspiler
 from qililab.config import logger

--- a/src/qililab/platform/platform.py
+++ b/src/qililab/platform/platform.py
@@ -575,9 +575,9 @@ class Platform:  # pylint: disable = too-many-public-methods, too-many-instance-
         buses_dict = {RUNCARD.BUSES: self.buses.to_dict() if self.buses is not None else None}
         instrument_dict = {RUNCARD.INSTRUMENTS: self.instruments.to_dict() if self.instruments is not None else None}
         instrument_controllers_dict = {
-            RUNCARD.INSTRUMENT_CONTROLLERS: self.instrument_controllers.to_dict()
-            if self.instrument_controllers is not None
-            else None,
+            RUNCARD.INSTRUMENT_CONTROLLERS: (
+                self.instrument_controllers.to_dict() if self.instrument_controllers is not None else None
+            ),
         }
 
         return (
@@ -671,7 +671,9 @@ class Platform:  # pylint: disable = too-many-public-methods, too-many-instance-
 
         # Reset instrument settings
         for bus_alias in sequences:
-            qblox_modules = filter(lambda instrument: isinstance(instrument, QbloxModule), buses[bus_alias].system_control.instruments)
+            qblox_modules = filter(
+                lambda instrument: isinstance(instrument, QbloxModule), buses[bus_alias].system_control.instruments
+            )
             for instrument in qblox_modules:
                 instrument.desync_by_port(buses[bus_alias].port)
 

--- a/tests/.pylintrc
+++ b/tests/.pylintrc
@@ -20,4 +20,4 @@ disable=
     missing-class-docstring,
     missing-function-docstring,
     import-error,
-    R0912
+    too-many-branches

--- a/tests/.pylintrc
+++ b/tests/.pylintrc
@@ -20,4 +20,4 @@ disable=
     missing-class-docstring,
     missing-function-docstring,
     import-error,
-    too-many-branches
+    R0912

--- a/tests/.pylintrc
+++ b/tests/.pylintrc
@@ -19,4 +19,5 @@ disable=
     too-many-public-methods,
     missing-class-docstring,
     missing-function-docstring,
-    import-error
+    import-error,
+    R0912

--- a/tests/instruments/qblox/test_qblox_module.py
+++ b/tests/instruments/qblox/test_qblox_module.py
@@ -172,6 +172,22 @@ class TestQbloxModule:  # pylint: disable=too-few-public-methods
         # sequences2 qubit index is 1
         assert qrm.sequences[1] is sequences2[0]
 
+    def test_sync_by_port(self):
+        """Test sync_by_port method."""
+        qrm_settings = copy.deepcopy(Galadriel.qblox_qrm_0)
+        qrm_settings.pop("name")
+        qrm = DummyQRM(settings=qrm_settings)
+        qrm.sync_by_port(port="feedline_input")
+        qrm.device.sequencers[0].sync_en.assert_called_once_with(True)
+        
+    def test_desync_by_port(self):
+        """Test desync_by_port method."""
+        qrm_settings = copy.deepcopy(Galadriel.qblox_qrm_0)
+        qrm_settings.pop("name")
+        qrm = DummyQRM(settings=qrm_settings)
+        qrm.sync_by_port(port="feedline_input")
+        qrm.device.sequencers[0].sync_en.assert_called_once_with(False)
+    
     def test_upload_qpysequence(self, qpysequence: Sequence):
         """Test upload_qpysequence method."""
         qrm_settings = copy.deepcopy(Galadriel.qblox_qrm_0)

--- a/tests/instruments/qblox/test_qblox_module.py
+++ b/tests/instruments/qblox/test_qblox_module.py
@@ -1,4 +1,5 @@
 """Tests for the Qblox Module class."""
+
 import copy
 import re
 from unittest.mock import MagicMock, patch
@@ -178,16 +179,16 @@ class TestQbloxModule:  # pylint: disable=too-few-public-methods
         qrm_settings.pop("name")
         qrm = DummyQRM(settings=qrm_settings)
         qrm.sync_by_port(port="feedline_input")
-        qrm.device.sequencers[0].sync_en.assert_called_once_with(True)
-        
+        qrm.device.sequencers[0].sync_en.assert_called_with(True)
+
     def test_desync_by_port(self):
         """Test desync_by_port method."""
         qrm_settings = copy.deepcopy(Galadriel.qblox_qrm_0)
         qrm_settings.pop("name")
         qrm = DummyQRM(settings=qrm_settings)
-        qrm.sync_by_port(port="feedline_input")
-        qrm.device.sequencers[0].sync_en.assert_called_once_with(False)
-    
+        qrm.desync_by_port(port="feedline_input")
+        qrm.device.sequencers[0].sync_en.assert_called_with(False)
+
     def test_upload_qpysequence(self, qpysequence: Sequence):
         """Test upload_qpysequence method."""
         qrm_settings = copy.deepcopy(Galadriel.qblox_qrm_0)

--- a/tests/platform/test_platform.py
+++ b/tests/platform/test_platform.py
@@ -1,5 +1,4 @@
 """Tests for the Platform class."""
-
 import copy
 import io
 import re

--- a/tests/platform/test_platform.py
+++ b/tests/platform/test_platform.py
@@ -13,8 +13,6 @@ from qibo import gates
 from qibo.models import Circuit
 from qpysequence import Sequence
 from ruamel.yaml import YAML
-from tests.data import Galadriel, SauronQuantumMachines
-from tests.test_utils import build_platform
 
 from qililab import save_platform
 from qililab.chip import Chip, Qubit
@@ -34,6 +32,8 @@ from qililab.settings.gate_event_settings import GateEventSettings
 from qililab.system_control import ReadoutSystemControl
 from qililab.typings.enums import InstrumentName, Parameter
 from qililab.waveforms import IQPair, Square
+from tests.data import Galadriel, SauronQuantumMachines
+from tests.test_utils import build_platform
 
 
 @pytest.fixture(name="platform")

--- a/tests/platform/test_platform.py
+++ b/tests/platform/test_platform.py
@@ -1,4 +1,5 @@
 """Tests for the Platform class."""
+
 import copy
 import io
 import re
@@ -12,6 +13,8 @@ from qibo import gates
 from qibo.models import Circuit
 from qpysequence import Sequence
 from ruamel.yaml import YAML
+from tests.data import Galadriel, SauronQuantumMachines
+from tests.test_utils import build_platform
 
 from qililab import save_platform
 from qililab.chip import Chip, Qubit
@@ -31,8 +34,6 @@ from qililab.settings.gate_event_settings import GateEventSettings
 from qililab.system_control import ReadoutSystemControl
 from qililab.typings.enums import InstrumentName, Parameter
 from qililab.waveforms import IQPair, Square
-from tests.data import Galadriel, SauronQuantumMachines
-from tests.test_utils import build_platform
 
 
 @pytest.fixture(name="platform")
@@ -348,7 +349,8 @@ class TestMethods:
             patch.object(Bus, "upload_qpysequence") as upload,
             patch.object(Bus, "run") as run,
             patch.object(Bus, "acquire_qprogram_results") as acquire_qprogram_results,
-            patch.object(QbloxModule, "desync_sequencers") as desync,
+            patch.object(QbloxModule, "sync_by_port") as sync_port,
+            patch.object(QbloxModule, "desync_by_port") as desync_port,
         ):
             acquire_qprogram_results.return_value = [123]
             first_execution_results = platform.execute_qprogram(qprogram=qprogram)
@@ -364,7 +366,8 @@ class TestMethods:
         # assert run executed all three times (6 because there are 2 buses)
         assert run.call_count == 6
         assert acquire_qprogram_results.call_count == 3  # only readout buses
-        assert desync.call_count == 9
+        assert sync_port.call_count == 6  # called as many times as run
+        assert desync_port.call_count == 6
         assert first_execution_results.results["feedline_input_output_bus"] == [123]
         assert second_execution_results.results["feedline_input_output_bus"] == [456]
 


### PR DESCRIPTION
Moved the sync outside of upload_qpysequence in Qblox_module into an independent function sync_sequencers located in the same .py file mirroring the function desync_sequencers and added 3 lines in platform.py to also mirror the desync and sync every time the execution is ran.