### PR TITLE
changes for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## 0.26.1 (2024-04-26)
+
+### Bug fixes
+
+- Hotfix for the 2readout problem
+  [#720](https://github.com/qilimanjaro-tech/qililab/pull/720)
+
 ## 0.25.1 (2024-03-26)
 
 ### Bug fixes

--- a/src/qililab/config/version.py
+++ b/src/qililab/config/version.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 """Version number (major.minor.patch[-label])"""
-__version__ = "0.25.1"
+__version__ = "0.26.1"


### PR DESCRIPTION
This PR brings a release for Qililab including a hotfix necessary to work with two readout buses in the same QRM in the Qblox cluster.