### PR TITLE
Quantum machines 

### DIFF
--- a/src/qililab/qprogram/quantum_machines_compiler.py
+++ b/src/qililab/qprogram/quantum_machines_compiler.py
@@ -245,7 +245,7 @@ class QuantumMachinesCompiler:  # pylint: disable=too-many-instance-attributes, 
         to_positive = stop >= start
         if to_positive:
             return qua.for_(qua_variable, start, qua_variable < stop + step / 2, qua_variable + step)
-        return qua.for_(qua_variable, start, qua_variable > stop - step / 2, qua_variable + step)
+        return qua.for_(qua_variable, start, qua_variable > stop + step / 2, qua_variable + step)
 
     def _handle_loop(self, element: Loop):
         qua_variable = self._qprogram_to_qua_variables[element.variable]

--- a/src/qililab/qprogram/quantum_machines_compiler.py
+++ b/src/qililab/qprogram/quantum_machines_compiler.py
@@ -244,8 +244,8 @@ class QuantumMachinesCompiler:  # pylint: disable=too-many-instance-attributes, 
 
         to_positive = stop >= start
         if to_positive:
-            return qua.for_(qua_variable, start, qua_variable <= stop, qua_variable + step)
-        return qua.for_(qua_variable, start, qua_variable >= stop, qua_variable + step)
+            return qua.for_(qua_variable, start, qua_variable < stop + step / 2, qua_variable + step)
+        return qua.for_(qua_variable, start, qua_variable > stop - step / 2, qua_variable + step)
 
     def _handle_loop(self, element: Loop):
         qua_variable = self._qprogram_to_qua_variables[element.variable]

--- a/tests/qprogram/test_quantum_machines_compiler.py
+++ b/tests/qprogram/test_quantum_machines_compiler.py
@@ -705,7 +705,7 @@ class TestQuantumMachinesCompiler:
 
         # Voltage
         assert float(statements[0].for_.init.statements[0].assign.expression.literal.value) == 0
-        assert float(statements[0].for_.condition.binary_operation.right.literal.value) == 1.0
+        assert float(statements[0].for_.condition.binary_operation.right.literal.value) == 1.05
         assert (
             float(statements[0].for_.update.statements[0].assign.expression.binary_operation.right.literal.value) == 0.1
         )
@@ -741,7 +741,7 @@ class TestQuantumMachinesCompiler:
 
         # Voltage
         assert float(statements[0].for_.init.statements[0].assign.expression.literal.value) == 1.0
-        assert float(statements[0].for_.condition.binary_operation.right.literal.value) == 0
+        assert float(statements[0].for_.condition.binary_operation.right.literal.value) == -0.05
         assert (
             float(statements[0].for_.update.statements[0].assign.expression.binary_operation.right.literal.value)
             == -0.1

--- a/tests/qprogram/test_quantum_machines_compiler.py
+++ b/tests/qprogram/test_quantum_machines_compiler.py
@@ -712,14 +712,14 @@ class TestQuantumMachinesCompiler:
 
         # Frequency
         assert float(statements[1].for_.init.statements[0].assign.expression.literal.value) == 100
-        assert float(statements[1].for_.condition.binary_operation.right.literal.value) == 200
+        assert float(statements[1].for_.condition.binary_operation.right.literal.value) == 205
         assert (
             float(statements[1].for_.update.statements[0].assign.expression.binary_operation.right.literal.value) == 10
         )
 
         # Phase
         assert float(statements[2].for_.init.statements[0].assign.expression.literal.value) == 0 / 360.0
-        assert float(statements[2].for_.condition.binary_operation.right.literal.value) == 90 / 360.0
+        assert float(statements[2].for_.condition.binary_operation.right.literal.value) == 95 / 360.0
         assert (
             float(statements[2].for_.update.statements[0].assign.expression.binary_operation.right.literal.value)
             == 10 / 360.0
@@ -727,7 +727,7 @@ class TestQuantumMachinesCompiler:
 
         # Time
         assert float(statements[3].for_.init.statements[0].assign.expression.literal.value) == 100
-        assert float(statements[3].for_.condition.binary_operation.right.literal.value) == 200
+        assert float(statements[3].for_.condition.binary_operation.right.literal.value) == 205
         assert (
             float(statements[3].for_.update.statements[0].assign.expression.binary_operation.right.literal.value) == 10
         )
@@ -749,14 +749,14 @@ class TestQuantumMachinesCompiler:
 
         # Frequency
         assert float(statements[1].for_.init.statements[0].assign.expression.literal.value) == 200
-        assert float(statements[1].for_.condition.binary_operation.right.literal.value) == 100
+        assert float(statements[1].for_.condition.binary_operation.right.literal.value) == 95
         assert (
             float(statements[1].for_.update.statements[0].assign.expression.binary_operation.right.literal.value) == -10
         )
 
         # Phase
         assert float(statements[2].for_.init.statements[0].assign.expression.literal.value) == 90 / 360.0
-        assert float(statements[2].for_.condition.binary_operation.right.literal.value) == 0 / 360.0
+        assert float(statements[2].for_.condition.binary_operation.right.literal.value) == -5 / 360.0
         assert (
             float(statements[2].for_.update.statements[0].assign.expression.binary_operation.right.literal.value)
             == -10 / 360.0
@@ -764,7 +764,7 @@ class TestQuantumMachinesCompiler:
 
         # Time
         assert float(statements[3].for_.init.statements[0].assign.expression.literal.value) == 200
-        assert float(statements[3].for_.condition.binary_operation.right.literal.value) == 100
+        assert float(statements[3].for_.condition.binary_operation.right.literal.value) == 95
         assert (
             float(statements[3].for_.update.statements[0].assign.expression.binary_operation.right.literal.value) == -10
         )


### PR DESCRIPTION
There was a rounding error involving the signs <= and >= in the compilation of the QUA program's for loops, the error caused results not to generate showcasing a bug.

The signs have been replaced by < and > and the stop value has been replaced by stop +- step/2.

This solution has been checked using the experiment located in qililab-portfolio/experiments/qprogram/flux_vs_flux_pulse.ipynb, if the experiment is executed with a gain step number greater than 9 without this hotfix the results will crash and not return anything.