### PR TITLE
Qhc 466 bug wait instruction is not compiled proprely on qprogam for

### DIFF
--- a/src/qililab/qprogram/quantum_machines_compiler.py
+++ b/src/qililab/qprogram/quantum_machines_compiler.py
@@ -451,7 +451,13 @@ class QuantumMachinesCompiler:  # pylint: disable=too-many-instance-attributes, 
             if isinstance(element.duration, Variable)
             else max(element.duration, self.MINIMUM_TIME)
         )
-        qua.wait(duration // self.WAIT_COEFF, bus)
+
+        qua.wait(
+            duration / int(self.WAIT_COEFF)
+            if isinstance(element.duration, Variable)
+            else int(duration / self.WAIT_COEFF),
+            bus,
+        )
 
     def _handle_sync(self, element: Sync):
         if element.buses:

--- a/src/qililab/qprogram/quantum_machines_compiler.py
+++ b/src/qililab/qprogram/quantum_machines_compiler.py
@@ -71,6 +71,7 @@ class QuantumMachinesCompiler:  # pylint: disable=too-many-instance-attributes, 
     FREQUENCY_COEFF = 1
     PHASE_COEFF = 2 * np.pi
     VOLTAGE_COEFF = 2
+    WAIT_COEFF = 4
     MINIMUM_TIME = 4
 
     def __init__(self) -> None:
@@ -448,9 +449,9 @@ class QuantumMachinesCompiler:  # pylint: disable=too-many-instance-attributes, 
         duration = (
             self._qprogram_to_qua_variables[element.duration]
             if isinstance(element.duration, Variable)
-            else max(element.duration, self.MINIMUM_TIME)//4
+            else max(element.duration, self.MINIMUM_TIME)
         )
-        qua.wait(duration, bus)
+        qua.wait(duration // self.WAIT_COEFF, bus)
 
     def _handle_sync(self, element: Sync):
         if element.buses:

--- a/src/qililab/qprogram/quantum_machines_compiler.py
+++ b/src/qililab/qprogram/quantum_machines_compiler.py
@@ -448,7 +448,7 @@ class QuantumMachinesCompiler:  # pylint: disable=too-many-instance-attributes, 
         duration = (
             self._qprogram_to_qua_variables[element.duration]
             if isinstance(element.duration, Variable)
-            else max(element.duration, self.MINIMUM_TIME)
+            else max(element.duration, self.MINIMUM_TIME)//4
         )
         qua.wait(duration, bus)
 

--- a/tests/qprogram/test_quantum_machines_compiler.py
+++ b/tests/qprogram/test_quantum_machines_compiler.py
@@ -442,7 +442,7 @@ class TestQuantumMachinesCompiler:
         wait = statements[0].wait
         assert len(wait.qe) == 1
         assert wait.qe[0].name == "drive"
-        assert int(wait.time.literal.value) == 100
+        assert int(wait.time.literal.value) == 100/4
 
     def test_sync_operation(self, sync_operation: QProgram):
         compiler = QuantumMachinesCompiler()

--- a/tests/qprogram/test_quantum_machines_compiler.py
+++ b/tests/qprogram/test_quantum_machines_compiler.py
@@ -442,7 +442,7 @@ class TestQuantumMachinesCompiler:
         wait = statements[0].wait
         assert len(wait.qe) == 1
         assert wait.qe[0].name == "drive"
-        assert int(wait.time.literal.value) == 100/4
+        assert int(wait.time.literal.value) == 100 / 4
 
     def test_sync_operation(self, sync_operation: QProgram):
         compiler = QuantumMachinesCompiler()


### PR DESCRIPTION
Following the description on the QM reference https://docs.quantum-machines.co/1.1.6/qm-qua-sdk/docs/API_references/qua/dsl_main/#qm.qua._dsl.wait, the used by the QM compiler now is divided by 4 which returns the correct amount of ns waited (before it was multiplied by 4)