### PR TITLE
remove release and block device qiboconnection

### DIFF
--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -8,6 +8,9 @@
 
 ### Deprecations / Removals
 
+- Remove qiboconnection_api.block_device() and release_device()
+  [#728](https://github.com/qilimanjaro-tech/qililab/pull/728)
+
 ### Documentation
 
 ### Bug fixes

--- a/src/qililab/platform/platform.py
+++ b/src/qililab/platform/platform.py
@@ -314,7 +314,7 @@ class Platform:  # pylint: disable = too-many-public-methods, too-many-instance-
         self._qpy_sequence_cache: dict[str, str] = {}
         """Dictionary for caching qpysequences."""
 
-    def connect(self, manual_override=False):
+    def connect(self):
         """Connects to all the instruments and blocks the connection for other users.
 
         You must be connected in order to set up and turn on instruments, or in order to execute the platform.
@@ -322,10 +322,6 @@ class Platform:  # pylint: disable = too-many-public-methods, too-many-instance-
         To connect, your computer must be in the same network of the instruments specified in the :ref:`runcard <runcards>` (with their corresponding `device_id` and IP's addresses).
 
         Such connection is handled via `qiboconnection's <https://pypi.org/project/qiboconnection>`_ `API` in the ``platform.connection`` attribute.
-
-        Args:
-            manual_override (bool, optional): If ``True``, avoid checking if the device is blocked (surpasses any blocked connection). This will stop any
-                current execution. Defaults to False.
         """
         if self._connected_to_instruments:
             logger.info("Already connected to the instruments")

--- a/src/qililab/platform/platform.py
+++ b/src/qililab/platform/platform.py
@@ -331,9 +331,6 @@ class Platform:  # pylint: disable = too-many-public-methods, too-many-instance-
             logger.info("Already connected to the instruments")
             return
 
-        if self.connection is not None and not manual_override:
-            self.connection.block_device_id(device_id=self.device_id)
-
         self.instrument_controllers.connect()
         self._connected_to_instruments = True
         logger.info("Connected to the instruments")
@@ -375,8 +372,6 @@ class Platform:  # pylint: disable = too-many-public-methods, too-many-instance-
 
     def disconnect(self):
         """Closes the connection to all the instruments."""
-        if self.connection is not None:
-            self.connection.release_device(device_id=self.device_id)
         if not self._connected_to_instruments:
             logger.info("Already disconnected from the instruments")
             return


### PR DESCRIPTION
qiboconnection_api.block_device() and release_device() is totally redundant since Slurm was integrated in our stack.

 As Access is going to remove this functionality from qiboconnection, qililab needs to be updated accordingly.
