### PR TITLE
[QHC-374] Add Calibration for waveforms, Refactor parts of QProgram

### DIFF
--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -4,93 +4,114 @@
 
 - Added `Calibration` class to manage calibrated operations for QProgram, including methods to add (`add_operation`), retrieve (`get_operation`), save (`dump`), and load (`load`) calibration data.
 
-Example:
+  Example:
 
-```
-# Create a Calibration instance
-calibration = Calibration()
+  ```Python
+  # Create a Calibration instance
+  calibration = Calibration()
 
-# Add operations to the calibration
-calibration.add_operation(bus='bus1', operation='op1', waveform=Waveform())
-calibration.add_operation(bus='bus2', operation='op2', waveform=IQPair())
+  # Define waveforms
+  drag_wf = IQPair.DRAG(amplitude=1.0, duration=40, num_sigmas=4.5, drag_coefficient=-2.5)
+  readout_wf = ql.IQPair(I=ql.Square(amplitude=1.0, duration=200), Q=ql.Square(amplitude=0.0, duration=200))
 
-# Save the calibration data to a file
-calibration.dump('calibration_data.yml')
+  # Add waveforms to the calibration as named operations
+  calibration.add_operation(bus='drive_q0_bus', operation='Xpi', waveform=drag_wf)
+  calibration.add_operation(bus='readout_q0_bus', operation='Measure', waveform=readout_wf)
 
-# Load the calibration data from a file
-loaded_calibration = Calibration.load('calibration_data.yml')
-```
+  # Save the calibration data to a file
+  calibration.dump('calibration_data.yml')
 
-[#729](https://github.com/qilimanjaro-tech/qililab/pull/729)
+  # Load the calibration data from a file
+  loaded_calibration = Calibration.load('calibration_data.yml')
+  ```
+
+  The contents of `calibration_data.yml` will be:
+
+  ```YAML
+  !Calibration
+  operations:
+  drive_q0_bus:
+      Xpi: !IQPair
+      I: &id001 !Gaussian {amplitude: 1.0, duration: 40, num_sigmas: 4.5}
+      Q: !DragCorrection
+          drag_coefficient: -2.5
+          waveform: *id001
+  readout_q0_bus:
+      Measure: !IQPair
+      I: !Square {amplitude: 1.0, duration: 200}
+      Q: !Square {amplitude: 0.0, duration: 200}
+  ```
+
+  [#729](https://github.com/qilimanjaro-tech/qililab/pull/729)
 
 - Introduced `qililab.yaml` namespace that exports a single `YAML` instance for common use throughout qililab. Classes can be registered to this instance with the `@yaml.register_class` decorator.
 
-```
-from qililab.yaml import yaml
+  ```Python
+  from qililab.yaml import yaml
 
-@yaml.register_class
-class MyClass:
-    ...
-```
+  @yaml.register_class
+  class MyClass:
+      ...
+  ```
 
-`MyClass` can now be saved to and loaded from a yaml file.
+  `MyClass` can now be saved to and loaded from a yaml file.
 
-```
-from qililab.yaml import yaml
+  ```Python
+  from qililab.yaml import yaml
 
-my_instance = MyClass()
+  my_instance = MyClass()
 
-# Save to file
-with open(file="my_file.yml", mode="w", encoding="utf-8") as stream:
-    yaml.dump(data=my_instance, stream=stream)
+  # Save to file
+  with open(file="my_file.yml", mode="w", encoding="utf-8") as stream:
+      yaml.dump(data=my_instance, stream=stream)
 
-# Load from file
-with open(file="my_file.yml", mode="r", encoding="utf8") as stream:
-    loaded_instance = yaml.load(stream)
-```
+  # Load from file
+  with open(file="my_file.yml", mode="r", encoding="utf8") as stream:
+      loaded_instance = yaml.load(stream)
+  ```
 
-[#729](https://github.com/qilimanjaro-tech/qililab/pull/729)
+  [#729](https://github.com/qilimanjaro-tech/qililab/pull/729)
 
 ### Improvements
 
 - Introduced `QProgram.with_bus_mapping` method to remap buses within the QProgram.
 
-Example:
+  Example:
 
-```
-# Define the bus mapping
-bus_mapping = {"drive": "drive_q0"}
+  ```Python
+  # Define the bus mapping
+  bus_mapping = {"drive": "drive_q0"}
 
-# Apply the bus mapping to a QProgram instance
-mapped_qprogram = qprogram.with_bus_mapping(bus_mapping=bus_mapping)
-```
+  # Apply the bus mapping to a QProgram instance
+  mapped_qprogram = qprogram.with_bus_mapping(bus_mapping=bus_mapping)
+  ```
 
-[#729](https://github.com/qilimanjaro-tech/qililab/pull/729)
+  [#729](https://github.com/qilimanjaro-tech/qililab/pull/729)
 
 - Introduced `QProgram.with_calibration` method to apply calibration to operations within the QProgram.
 
-Example:
+  Example:
 
-```
-# Load the calibration data from a file
-calibration = Calibration.load('calibration_data.yml')
+  ```Python
+  # Load the calibration data from a file
+  calibration = Calibration.load('calibration_data.yml')
 
-# Apply the calibration to a QProgram instance
-calibrated_qprogram = qprogram.with_calibration(calibration=calibration)
-```
+  # Apply the calibration to a QProgram instance
+  calibrated_qprogram = qprogram.with_calibration(calibration=calibration)
+  ```
 
-[#729](https://github.com/qilimanjaro-tech/qililab/pull/729)
+  [#729](https://github.com/qilimanjaro-tech/qililab/pull/729)
 
 - Extended `Platform.execute_qprogram` method to accept a calibration instance.
 
-```
-# Load the calibration data from a file
-calibration = Calibration.load('calibration_data.yml')
+  ```Python
+  # Load the calibration data from a file
+  calibration = Calibration.load('calibration_data.yml')
 
-platform.execute_qprogram(qprogram=qprogram, calibration=calibration)
-```
+  platform.execute_qprogram(qprogram=qprogram, calibration=calibration)
+  ```
 
-[#729](https://github.com/qilimanjaro-tech/qililab/pull/729)
+  [#729](https://github.com/qilimanjaro-tech/qililab/pull/729)
 
 ### Breaking changes
 

--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -2,7 +2,82 @@
 
 ### New features since last release
 
+- Added `Calibration` class to manage calibrated operations for QProgram, including methods to add (`add_operation`), retrieve (`get_operation`), save (`dump`), and load (`load`) calibration data.
+
+Example:
+
+```
+# Create a Calibration instance
+calibration = Calibration()
+
+# Add operations to the calibration
+calibration.add_operation(bus='bus1', operation='op1', waveform=Waveform())
+calibration.add_operation(bus='bus2', operation='op2', waveform=IQPair())
+
+# Save the calibration data to a file
+calibration.dump('calibration_data.yml')
+
+# Load the calibration data from a file
+loaded_calibration = Calibration.load('calibration_data.yml')
+```
+
+[#729](https://github.com/qilimanjaro-tech/qililab/pull/729)
+
+- Introduced `qililab.yaml` namespace that exports a single `YAML` instance for common use throughout qililab. Classes can be registered to this instance with the `@yaml.register_class` decorator.
+
+```
+from qililab.yaml import yaml
+
+@yaml.register_class
+class MyClass:
+    ...
+```
+
+`MyClass` can now be saved to and loaded from a yaml file.
+
+```
+from qililab.yaml import yaml
+
+my_instance = MyClass()
+
+with open(file="my_file.yml", mode="w", encoding="utf-8") as stream:
+    yaml.dump(data=my_instance, stream=stream)
+
+with open(file="my_file.yml", mode="r", encoding="utf8") as stream:
+    loaded_instance = yaml.load(stream)
+```
+
+[#729](https://github.com/qilimanjaro-tech/qililab/pull/729)
+
 ### Improvements
+
+- Introduced `QProgram.with_bus_mapping` method to remap buses within the QProgram.
+
+Example:
+
+```
+# Define the bus mapping
+bus_mapping = {"drive": "drive_q0"}
+
+# Apply the bus mapping to a QProgram instance
+mapped_qprogram = qprogram.with_bus_mapping(bus_mapping=bus_mapping)
+```
+
+[#729](https://github.com/qilimanjaro-tech/qililab/pull/729)
+
+- Introduced `QProgram.with_calibration` method to apply calibration to operations within the QProgram.
+
+Example:
+
+```
+# Load the calibration data from a file
+calibration = Calibration.load('calibration_data.yml')
+
+# Apply the calibration to a QProgram instance
+calibrated_qprogram = qprogram.with_calibration(calibration=calibration)
+```
+
+[#729](https://github.com/qilimanjaro-tech/qililab/pull/729)
 
 ### Breaking changes
 

--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -40,9 +40,11 @@ from qililab.yaml import yaml
 
 my_instance = MyClass()
 
+# Save to file
 with open(file="my_file.yml", mode="w", encoding="utf-8") as stream:
     yaml.dump(data=my_instance, stream=stream)
 
+# Load from file
 with open(file="my_file.yml", mode="r", encoding="utf8") as stream:
     loaded_instance = yaml.load(stream)
 ```

--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -81,6 +81,17 @@ calibrated_qprogram = qprogram.with_calibration(calibration=calibration)
 
 [#729](https://github.com/qilimanjaro-tech/qililab/pull/729)
 
+- Extended `Platform.execute_qprogram` method to accept a calibration instance.
+
+```
+# Load the calibration data from a file
+calibration = Calibration.load('calibration_data.yml')
+
+platform.execute_qprogram(qprogram=qprogram, calibration=calibration)
+```
+
+[#729](https://github.com/qilimanjaro-tech/qililab/pull/729)
+
 ### Breaking changes
 
 ### Deprecations / Removals

--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -2,7 +2,7 @@
 
 ### New features since last release
 
-- Added `Calibration` class to manage calibrated operations for QProgram, including methods to add (`add_operation`), retrieve (`get_operation`), save (`dump`), and load (`load`) calibration data.
+- Added `Calibration` class to manage calibrated operations for QProgram, including methods to add (`add_operation`), check (`has_operation`), retrieve (`get_operation`), save (`dump`), and load (`load`) calibration data.
 
   Example:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 qiboconnection
 pandas==1.5.3
 qibo==0.1.12
-PyYAML==6.0
 qblox-instruments==0.11.2
 qcodes==0.42.0
 qcodes_contrib_drivers==0.18.0
@@ -16,5 +15,5 @@ papermill==2.4.0
 qm-qua==1.1.6
 qualang-tools==0.15.2
 networkx==3.1
-ruamel.yaml==0.18.2
+ruamel.yaml==0.18.6
 submitit==1.5.0

--- a/src/qililab/__init__.py
+++ b/src/qililab/__init__.py
@@ -25,7 +25,7 @@ from .config import __version__, logger
 from .data_management import build_platform, load_results, save_platform, save_results
 from .execute_circuit import execute
 from .experiment import Experiment
-from .qprogram import Domain, QbloxCompiler, QProgram, QuantumMachinesCompiler
+from .qprogram import Domain, QbloxCompiler, QProgram, QuantumMachinesCompiler, Calibration
 from .result import Results, stream_results
 from .typings import ExperimentOptions, ExperimentSettings, Parameter
 from .utils import Loop

--- a/src/qililab/__init__.py
+++ b/src/qililab/__init__.py
@@ -25,7 +25,7 @@ from .config import __version__, logger
 from .data_management import build_platform, load_results, save_platform, save_results
 from .execute_circuit import execute
 from .experiment import Experiment
-from .qprogram import Domain, QbloxCompiler, QProgram, QuantumMachinesCompiler, Calibration
+from .qprogram import Calibration, Domain, QbloxCompiler, QProgram, QuantumMachinesCompiler
 from .result import Results, stream_results
 from .typings import ExperimentOptions, ExperimentSettings, Parameter
 from .utils import Loop

--- a/src/qililab/platform/platform.py
+++ b/src/qililab/platform/platform.py
@@ -634,7 +634,7 @@ class Platform:  # pylint: disable = too-many-public-methods, too-many-instance-
             )
         raise NotImplementedError("Executing QProgram in a mixture of instruments is not supported.")
 
-    def _execute_qprogram_with_qblox(
+    def _execute_qprogram_with_qblox(  # pylint: disable=too-many-locals
         self,
         qprogram: QProgram,
         bus_mapping: dict[str, str] | None = None,

--- a/src/qililab/platform/platform.py
+++ b/src/qililab/platform/platform.py
@@ -314,8 +314,6 @@ class Platform:  # pylint: disable = too-many-public-methods, too-many-instance-
         self._qpy_sequence_cache: dict[str, str] = {}
         """Dictionary for caching qpysequences."""
 
-        self._calibration: Calibration = Calibration()
-
     def connect(self):
         """Connects to all the instruments and blocks the connection for other users.
 
@@ -587,14 +585,6 @@ class Platform:  # pylint: disable = too-many-public-methods, too-many-instance-
             str: Name of the platform.
         """
         return str(YAML().dump(self.to_dict(), io.BytesIO()))
-
-    def load_calibration(self, file: str) -> None:
-        """Load calibration from file.
-
-        Args:
-            file (str): The YAML file containing the calibration.
-        """
-        self._calibration = Calibration.load(file)
 
     def execute_qprogram(
         self,

--- a/src/qililab/qprogram/__init__.py
+++ b/src/qililab/qprogram/__init__.py
@@ -34,6 +34,7 @@ Compilers
 
     ~QbloxCompiler
 """
+from .calibration import Calibration
 from .qblox_compiler import QbloxCompiler
 from .qprogram import QProgram
 from .quantum_machines_compiler import QuantumMachinesCompiler

--- a/src/qililab/qprogram/calibration.py
+++ b/src/qililab/qprogram/calibration.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+from qililab.waveforms import IQPair, Waveform
+from qililab.yaml import yaml
+
+
+@yaml.register_class
+class Calibration:
+    def __init__(self) -> None:
+        self.operations: dict[str, dict[str, Waveform | IQPair]] = {}
+
+    def add_operation(self, bus: str, operation: str, waveform: Waveform | IQPair):
+        if bus not in self.operations:
+            self.operations[bus] = {}
+        self.operations[bus][operation] = waveform
+
+    def get_operation(self, bus: str, operation: str):
+        if bus not in self.operations or operation not in self.operations[bus]:
+            raise TypeError()
+        return self.operations[bus][operation]
+
+    def dump(self, file: str):
+        path = Path(file) if file.endswith(".yml") or file.endswith(".yaml") else Path(f"{file}.yml")
+
+        with open(file=path, mode="w", encoding="utf-8") as stream:
+            yaml.dump(data=self, stream=stream)
+
+        return str(path)
+
+    @classmethod
+    def load(cls, file: str):
+        with open(file=file, mode="r", encoding="utf8") as stream:
+            data = yaml.load(stream)
+        if not isinstance(data, cls):
+            raise TypeError()
+        return data

--- a/src/qililab/qprogram/calibration.py
+++ b/src/qililab/qprogram/calibration.py
@@ -6,56 +6,100 @@ from qililab.yaml import yaml
 
 @yaml.register_class
 class Calibration:
-    """A class to manage calibration operations for various buses."""
+    """A class to manage calibration data."""
 
     def __init__(self) -> None:
         """Initialize a Calibration instance."""
-        self.operations: dict[str, dict[str, Waveform | IQPair]] = {}
+        self.waveforms: dict[str, dict[str, Waveform | IQPair]] = {}
+        self.weights: dict[str, dict[str, IQPair]] = {}
 
-    def add_operation(self, bus: str, operation: str, waveform: Waveform | IQPair):
-        """Add a waveform or IQPair operation to the specified bus.
+    def add_waveform(self, bus: str, name: str, waveform: Waveform | IQPair):
+        """Add a waveform or IQPair for the specified bus.
 
         Args:
             bus (str): The bus to which the operation will be added.
             operation (str): The name of the operation to add.
             waveform (Waveform | IQPair): The waveform or IQPair instance representing the operation.
         """
-        if bus not in self.operations:
-            self.operations[bus] = {}
-        self.operations[bus][operation] = waveform
+        if bus not in self.waveforms:
+            self.waveforms[bus] = {}
+        self.waveforms[bus][name] = waveform
 
-    def has_operation(self, bus: str, operation: str) -> bool:
-        """Check if there is an associated operation with bus.
+    def add_weights(self, bus: str, name: str, weights: IQPair):
+        """Add a weight for the specified bus.
 
         Args:
-            bus (str): The bus to check the operation.
-            operation (str): The name of the operation to check.
+            bus (str): The bus to which the operation will be added.
+            operation (str): The name of the operation to add.
+            waveform (Waveform | IQPair): The waveform or IQPair instance representing the operation.
+        """
+        if bus not in self.weights:
+            self.weights[bus] = {}
+        self.weights[bus][name] = weights
+
+    def has_waveform(self, bus: str, name: str) -> bool:
+        """Check if there is an associated waveform for the bus.
+
+        Args:
+            bus (str): The bus to check for the waveform.
+            operation (str): The name of the waveform to check.
 
         Returns:
-            bool: True, if there is an associated operation with bus. False otherwise.
+            bool: True if there is an associated waveform with the bus, False otherwise.
         """
-        if bus not in self.operations or operation not in self.operations[bus]:
+        if bus not in self.waveforms or name not in self.waveforms[bus]:
             return False
         return True
 
-    def get_operation(self, bus: str, operation: str):
-        """Retrieve a specific operation from a bus.
+    def has_weights(self, bus: str, name: str) -> bool:
+        """Check if there are associated weights for the bus.
 
         Args:
-            bus (str): The bus from which to retrieve the operation.
-            operation (str): The name of the operation to retrieve.
-
-        Raises:
-            KeyError: If the specified bus or operation does not exist.
+            bus (str): The bus to check for the weights.
+            operation (str): The name of the weights to check.
 
         Returns:
-            Waveform | IQPair: The waveform or IQPair associated with the specified operation.
+            bool: True if there are associated weights with the bus, False otherwise.
         """
-        if bus not in self.operations or operation not in self.operations[bus]:
-            raise KeyError("The specified bus or operation does not exist.")
-        return self.operations[bus][operation]
+        if bus not in self.weights or name not in self.weights[bus]:
+            return False
+        return True
 
-    def dump(self, file: str):
+    def get_waveform(self, bus: str, name: str):
+        """Retrieve waveform for the bus.
+
+        Args:
+            bus (str): The bus to check for the waveform.
+            name (str): The name of the operation to retrieve.
+
+        Raises:
+            KeyError: If the waveform does not exist for the bus.
+
+        Returns:
+            Waveform | IQPair: The waveform associated with the bus.
+        """
+        if bus not in self.waveforms or name not in self.waveforms[bus]:
+            raise KeyError(f"The waveform {name} does not exist for the bus {bus}.")
+        return self.waveforms[bus][name]
+
+    def get_weights(self, bus: str, name: str):
+        """Retrieve weights for the bus.
+
+        Args:
+            bus (str): The bus to check for the weights.
+            name (str): The name of the weights to retrieve.
+
+        Raises:
+            KeyError: If the weights do not exist for the bus.
+
+        Returns:
+            IQPair: The weights associated with the bus.
+        """
+        if bus not in self.weights or name not in self.weights[bus]:
+            raise KeyError(f"The weights {name} do not exist for the bus {bus}.")
+        return self.weights[bus][name]
+
+    def save_to(self, file: str):
         """Dump the current calibration data to a YAML file.
 
         Args:
@@ -70,7 +114,7 @@ class Calibration:
         return file
 
     @classmethod
-    def load(cls, file: str):
+    def load_from(cls, file: str):
         """Load calibration data from a YAML file.
 
         Args:

--- a/src/qililab/qprogram/calibration.py
+++ b/src/qililab/qprogram/calibration.py
@@ -6,20 +6,51 @@ from qililab.yaml import yaml
 
 @yaml.register_class
 class Calibration:
+    """A class to manage calibration operations for various buses."""
+
     def __init__(self) -> None:
+        """Initialize a Calibration instance."""
         self.operations: dict[str, dict[str, Waveform | IQPair]] = {}
 
     def add_operation(self, bus: str, operation: str, waveform: Waveform | IQPair):
+        """Add a waveform or IQPair operation to the specified bus.
+
+        Args:
+            bus (str): The bus to which the operation will be added.
+            operation (str): The name of the operation to add.
+            waveform (Waveform | IQPair): The waveform or IQPair instance representing the operation.
+        """
         if bus not in self.operations:
             self.operations[bus] = {}
         self.operations[bus][operation] = waveform
 
     def get_operation(self, bus: str, operation: str):
+        """Retrieve a specific operation from a bus.
+
+        Args:
+            bus (str): The bus from which to retrieve the operation.
+            operation (str): The name of the operation to retrieve.
+
+        Raises:
+            KeyError: If the specified bus or operation does not exist.
+
+        Returns:
+            Waveform | IQPair: The waveform or IQPair associated with the specified operation.
+        """
         if bus not in self.operations or operation not in self.operations[bus]:
-            raise TypeError()
+            raise KeyError("The specified bus or operation does not exist.")
         return self.operations[bus][operation]
 
     def dump(self, file: str):
+        """Dump the current calibration data to a YAML file.
+
+        Args:
+            file (str): The file path where the calibration data will be saved. If the file extension
+                        is not provided, it defaults to '.yml'.
+
+        Returns:
+            str: The path of the saved file.
+        """
         path = Path(file) if file.endswith(".yml") or file.endswith(".yaml") else Path(f"{file}.yml")
 
         with open(file=path, mode="w", encoding="utf-8") as stream:
@@ -29,8 +60,19 @@ class Calibration:
 
     @classmethod
     def load(cls, file: str):
+        """Load calibration data from a YAML file.
+
+        Args:
+            file (str): The file path from which to load the calibration data.
+
+        Raises:
+            TypeError: If the loaded data is not an instance of the Calibration class.
+
+        Returns:
+            Calibration: An instance of the Calibration class with data loaded from the file.
+        """
         with open(file=file, mode="r", encoding="utf8") as stream:
             data = yaml.load(stream)
         if not isinstance(data, cls):
-            raise TypeError()
+            raise TypeError("The loaded data is not an instance of the Calibration class.")
         return data

--- a/src/qililab/qprogram/calibration.py
+++ b/src/qililab/qprogram/calibration.py
@@ -65,12 +65,9 @@ class Calibration:
         Returns:
             str: The path of the saved file.
         """
-        path = Path(file) if file.endswith(".yml") or file.endswith(".yaml") else Path(f"{file}.yml")
+        yaml.dump(self, Path(file))
 
-        with open(file=path, mode="w", encoding="utf-8") as stream:
-            yaml.dump(data=self, stream=stream)
-
-        return str(path)
+        return file
 
     @classmethod
     def load(cls, file: str):
@@ -85,8 +82,7 @@ class Calibration:
         Returns:
             Calibration: An instance of the Calibration class with data loaded from the file.
         """
-        with open(file=file, mode="r", encoding="utf8") as stream:
-            data = yaml.load(stream)
+        data = yaml.load(Path(file))
         if not isinstance(data, cls):
             raise TypeError("The loaded data is not an instance of the Calibration class.")
         return data

--- a/src/qililab/qprogram/calibration.py
+++ b/src/qililab/qprogram/calibration.py
@@ -24,6 +24,20 @@ class Calibration:
             self.operations[bus] = {}
         self.operations[bus][operation] = waveform
 
+    def has_operation(self, bus: str, operation: str) -> bool:
+        """Check if there is an associated operation with bus.
+
+        Args:
+            bus (str): The bus to check the operation.
+            operation (str): The name of the operation to check.
+
+        Returns:
+            bool: True, if there is an associated operation with bus. False otherwise.
+        """
+        if bus not in self.operations or operation not in self.operations[bus]:
+            return False
+        return True
+
     def get_operation(self, bus: str, operation: str):
         """Retrieve a specific operation from a bus.
 

--- a/src/qililab/qprogram/operations/__init__.py
+++ b/src/qililab/qprogram/operations/__init__.py
@@ -15,7 +15,7 @@
 from .acquire import Acquire
 from .measure import Measure, MeasureWithNamedOperation
 from .operation import Operation
-from .play import Play, PlayWithNamedOperation
+from .play import Play, PlayWithCalibratedWaveform
 from .reset_phase import ResetPhase
 from .set_frequency import SetFrequency
 from .set_gain import SetGain

--- a/src/qililab/qprogram/operations/__init__.py
+++ b/src/qililab/qprogram/operations/__init__.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 from .acquire import Acquire
-from .measure import Measure
+from .measure import Measure, MeasureWithNamedOperation
 from .operation import Operation
-from .play import Play, PlayCalibratedOperation
+from .play import Play, PlayWithNamedOperation
 from .reset_phase import ResetPhase
 from .set_frequency import SetFrequency
 from .set_gain import SetGain

--- a/src/qililab/qprogram/operations/__init__.py
+++ b/src/qililab/qprogram/operations/__init__.py
@@ -15,7 +15,7 @@
 from .acquire import Acquire
 from .measure import Measure
 from .operation import Operation
-from .play import Play
+from .play import Play, PlayCalibratedOperation
 from .reset_phase import ResetPhase
 from .set_frequency import SetFrequency
 from .set_gain import SetGain

--- a/src/qililab/qprogram/operations/measure.py
+++ b/src/qililab/qprogram/operations/measure.py
@@ -35,3 +35,12 @@ class Measure(Operation):  # pylint: disable=missing-class-docstring
         wf_I: Waveform = self.waveform.I
         wf_Q: Waveform = self.waveform.Q
         return wf_I, wf_Q
+
+
+@dataclass(frozen=True)
+class MeasureWithNamedOperation(Operation):  # pylint: disable=missing-class-docstring
+    bus: str
+    operation: str
+    weights: IQPair | tuple[IQPair, IQPair] | tuple[IQPair, IQPair, IQPair, IQPair] | None
+    demodulation: bool
+    save_raw_adc: bool

--- a/src/qililab/qprogram/operations/play.py
+++ b/src/qililab/qprogram/operations/play.py
@@ -20,13 +20,6 @@ from qililab.waveforms import IQPair, Waveform
 
 
 @dataclass(frozen=True)
-class PlayCalibratedOperation(Operation):  # pylint: disable=missing-class-docstring
-    bus: str
-    operation: str
-    wait_time: int | None = None
-
-
-@dataclass(frozen=True)
 class Play(Operation):  # pylint: disable=missing-class-docstring
     bus: str
     waveform: Waveform | IQPair
@@ -62,3 +55,10 @@ class Play(Operation):  # pylint: disable=missing-class-docstring
             set[Variable]: The set of variables used in operation.
         """
         return super().get_variables() | self.get_waveform_variables()
+
+
+@dataclass(frozen=True)
+class PlayWithNamedOperation(Operation):  # pylint: disable=missing-class-docstring
+    bus: str
+    operation: str
+    wait_time: int | None = None

--- a/src/qililab/qprogram/operations/play.py
+++ b/src/qililab/qprogram/operations/play.py
@@ -20,6 +20,13 @@ from qililab.waveforms import IQPair, Waveform
 
 
 @dataclass(frozen=True)
+class PlayCalibratedOperation(Operation):  # pylint: disable=missing-class-docstring
+    bus: str
+    operation: str
+    wait_time: int | None = None
+
+
+@dataclass(frozen=True)
 class Play(Operation):  # pylint: disable=missing-class-docstring
     bus: str
     waveform: Waveform | IQPair

--- a/src/qililab/qprogram/operations/play.py
+++ b/src/qililab/qprogram/operations/play.py
@@ -58,7 +58,7 @@ class Play(Operation):  # pylint: disable=missing-class-docstring
 
 
 @dataclass(frozen=True)
-class PlayWithNamedOperation(Operation):  # pylint: disable=missing-class-docstring
+class PlayWithCalibratedWaveform(Operation):  # pylint: disable=missing-class-docstring
     bus: str
     operation: str
     wait_time: int | None = None

--- a/src/qililab/qprogram/qblox_compiler.py
+++ b/src/qililab/qprogram/qblox_compiler.py
@@ -24,6 +24,7 @@ import qpysequence.program.instructions as QPyInstructions
 from qpysequence.utils.constants import INST_MAX_WAIT
 
 from qililab.qprogram.blocks import Average, Block, ForLoop, InfiniteLoop, Loop, Parallel
+from qililab.qprogram.calibration import Calibration
 from qililab.qprogram.operations import (
     Acquire,
     Operation,
@@ -104,11 +105,12 @@ class QbloxCompiler:  # pylint: disable=too-few-public-methods
         }
 
         self._qprogram: QProgram
-        self._bus_mapping: dict[str, str] | None
         self._buses: dict[str, BusCompilationInfo]
         self._sync_counter: int
 
-    def compile(self, qprogram: QProgram, bus_mapping: dict[str, str] | None = None) -> dict[str, QPy.Sequence]:
+    def compile(
+        self, qprogram: QProgram, bus_mapping: dict[str, str] | None = None, calibration: Calibration | None = None
+    ) -> dict[str, QPy.Sequence]:
         """Compile QProgram to qpysequence.Sequence
 
         Args:
@@ -138,7 +140,11 @@ class QbloxCompiler:  # pylint: disable=too-few-public-methods
                 self._buses[bus].qprogram_block_stack.pop()
 
         self._qprogram = qprogram
-        self._bus_mapping = bus_mapping
+        if bus_mapping is not None:
+            self._qprogram = self._qprogram.with_bus_mapping(bus_mapping=bus_mapping)
+        if calibration is not None:
+            self._qprogram = self._qprogram.with_calibration(calibration=calibration)
+
         self._sync_counter = 0
         self._buses = self._populate_buses()
 
@@ -151,10 +157,7 @@ class QbloxCompiler:  # pylint: disable=too-few-public-methods
             self._buses[bus].qpy_sequence._program.compile()
 
         # Return a dictionary with bus names as keys and the compiled Sequence as values.
-        return {
-            self._bus_mapping[bus] if self._bus_mapping and bus in self._bus_mapping else bus: bus_info.qpy_sequence
-            for bus, bus_info in self._buses.items()
-        }
+        return {bus: bus_info.qpy_sequence for bus, bus_info in self._buses.items()}
 
     def _populate_buses(self):
         """Map each bus in the QProgram to a BusCompilationInfo instance.

--- a/src/qililab/qprogram/qblox_compiler.py
+++ b/src/qililab/qprogram/qblox_compiler.py
@@ -144,6 +144,10 @@ class QbloxCompiler:  # pylint: disable=too-few-public-methods
             self._qprogram = self._qprogram.with_bus_mapping(bus_mapping=bus_mapping)
         if calibration is not None:
             self._qprogram = self._qprogram.with_calibration(calibration=calibration)
+        if self._qprogram.has_named_operations():
+            raise RuntimeError(
+                "Cannot compile to hardware-native instructions because QProgram contains named operations that are not mapped. Provide a calibration instance containing all necessary mappings."
+            )
 
         self._sync_counter = 0
         self._buses = self._populate_buses()

--- a/src/qililab/qprogram/qprogram.py
+++ b/src/qililab/qprogram/qprogram.py
@@ -209,8 +209,8 @@ class QProgram(DictSerializable):  # pylint: disable=too-many-public-methods
                 if isinstance(element, Block):
                     traverse(element)
                 elif isinstance(element, PlayCalibratedOperation):
-                    waveform = calibration.get_operation(bus=element.bus, operation=element.operation)
-                    if waveform is not None:
+                    if calibration.has_operation(bus=element.bus, operation=element.operation):
+                        waveform = calibration.get_operation(bus=element.bus, operation=element.operation)
                         play_operation = Play(bus=element.bus, waveform=waveform, wait_time=element.wait_time)
                         block.elements[index] = play_operation
 

--- a/src/qililab/qprogram/qprogram.py
+++ b/src/qililab/qprogram/qprogram.py
@@ -185,13 +185,25 @@ class QProgram(DictSerializable):  # pylint: disable=too-many-public-methods
         traverse(copied_qprogram.body)
 
         # Apply the mapping to _buses property
-        copied_qprogram._buses.symmetric_difference_update(
+        copied_qprogram._buses.symmetric_difference_update(  # pylint: disable=protected-access
             {item for pair in bus_mapping.items() for item in pair}
-        )  # pylint: disable=protected-access
-
+        )
         return copied_qprogram
 
     def with_calibration(self, calibration: Calibration):
+        """Apply calibration to the operations within the QProgram.
+
+        This method traverses the elements of the QProgram, replacing any
+        named operations with the corresponding calibrated waveforms specified
+        in the given Calibration instance.
+
+        Args:
+            calibration (Calibration): The calibration data to apply to the operations.
+
+        Returns:
+            QProgram: A new instance of QProgram with calibrated operations.
+        """
+
         def traverse(block: Block):
             for index, element in enumerate(block.elements):
                 if isinstance(element, Block):

--- a/src/qililab/qprogram/qprogram.py
+++ b/src/qililab/qprogram/qprogram.py
@@ -40,7 +40,7 @@ from qililab.utils import DictSerializable
 from qililab.waveforms import IQPair, Waveform
 
 
-class QProgram(DictSerializable):
+class QProgram(DictSerializable):  # pylint: disable=too-many-public-methods
     """QProgram is a hardware-agnostic pulse-level programming interface for describing quantum programs.
 
     This class provides an interface for building quantum programs,
@@ -185,7 +185,9 @@ class QProgram(DictSerializable):
         traverse(copied_qprogram.body)
 
         # Apply the mapping to _buses property
-        copied_qprogram._buses.symmetric_difference_update({item for pair in bus_mapping.items() for item in pair})
+        copied_qprogram._buses.symmetric_difference_update(
+            {item for pair in bus_mapping.items() for item in pair}
+        )  # pylint: disable=protected-access
 
         return copied_qprogram
 

--- a/src/qililab/qprogram/qprogram.py
+++ b/src/qililab/qprogram/qprogram.py
@@ -27,7 +27,7 @@ from qililab.qprogram.operations import (
     Measure,
     MeasureWithNamedOperation,
     Play,
-    PlayWithNamedOperation,
+    PlayWithCalibratedWaveform,
     ResetPhase,
     SetFrequency,
     SetGain,
@@ -150,7 +150,7 @@ class QProgram(DictSerializable):  # pylint: disable=too-many-public-methods
                 if isinstance(element, Block):
                     if traverse(element):
                         return True
-                elif isinstance(element, (PlayWithNamedOperation, MeasureWithNamedOperation)):
+                elif isinstance(element, (PlayWithCalibratedWaveform, MeasureWithNamedOperation)):
                     return True
             return False
 
@@ -209,7 +209,7 @@ class QProgram(DictSerializable):  # pylint: disable=too-many-public-methods
             for index, element in enumerate(block.elements):
                 if isinstance(element, Block):
                     traverse(element)
-                elif isinstance(element, PlayWithNamedOperation) and calibration.has_waveform(
+                elif isinstance(element, PlayWithCalibratedWaveform) and calibration.has_waveform(
                     bus=element.bus, name=element.operation
                 ):
                     waveform = calibration.get_waveform(bus=element.bus, name=element.operation)
@@ -373,7 +373,7 @@ class QProgram(DictSerializable):  # pylint: disable=too-many-public-methods
             waveform (Waveform | IQPair | str): The waveform, IQPair, or alias of named waveform to play.
         """
         operation = (
-            PlayWithNamedOperation(bus=bus, operation=waveform, wait_time=wait_time)
+            PlayWithCalibratedWaveform(bus=bus, operation=waveform, wait_time=wait_time)
             if isinstance(waveform, str)
             else Play(bus=bus, waveform=waveform, wait_time=wait_time)
         )

--- a/src/qililab/qprogram/qprogram.py
+++ b/src/qililab/qprogram/qprogram.py
@@ -209,16 +209,16 @@ class QProgram(DictSerializable):  # pylint: disable=too-many-public-methods
             for index, element in enumerate(block.elements):
                 if isinstance(element, Block):
                     traverse(element)
-                elif isinstance(element, PlayWithNamedOperation) and calibration.has_operation(
-                    bus=element.bus, operation=element.operation
+                elif isinstance(element, PlayWithNamedOperation) and calibration.has_waveform(
+                    bus=element.bus, name=element.operation
                 ):
-                    waveform = calibration.get_operation(bus=element.bus, operation=element.operation)
+                    waveform = calibration.get_waveform(bus=element.bus, name=element.operation)
                     play_operation = Play(bus=element.bus, waveform=waveform, wait_time=element.wait_time)
                     block.elements[index] = play_operation
-                elif isinstance(element, MeasureWithNamedOperation) and calibration.has_operation(
-                    bus=element.bus, operation=element.operation
+                elif isinstance(element, MeasureWithNamedOperation) and calibration.has_waveform(
+                    bus=element.bus, name=element.operation
                 ):
-                    waveform = calibration.get_operation(bus=element.bus, operation=element.operation)
+                    waveform = calibration.get_waveform(bus=element.bus, name=element.operation)
                     measure_operation = Measure(
                         bus=element.bus,
                         waveform=waveform,

--- a/src/qililab/qprogram/quantum_machines_compiler.py
+++ b/src/qililab/qprogram/quantum_machines_compiler.py
@@ -24,6 +24,7 @@ from qualang_tools.config.integration_weights_tools import convert_integration_w
 
 from qililab.qprogram.blocks import Average, Block, ForLoop, Loop, Parallel
 from qililab.qprogram.blocks.infinite_loop import InfiniteLoop
+from qililab.qprogram.calibration import Calibration
 from qililab.qprogram.operations import Measure, Play, ResetPhase, SetFrequency, SetGain, SetPhase, Sync, Wait
 from qililab.qprogram.qprogram import QProgram
 from qililab.qprogram.variable import Domain, Variable
@@ -93,7 +94,6 @@ class QuantumMachinesCompiler:  # pylint: disable=too-many-instance-attributes, 
         }
 
         self._qprogram: QProgram
-        self._bus_mapping: dict[str, str] | None
         self._qprogram_block_stack: deque[Block]
         self._qprogram_to_qua_variables: dict[Variable, qua.QuaVariableType]
         self._measurements: list[_MeasurementCompilationInfo]
@@ -101,7 +101,7 @@ class QuantumMachinesCompiler:  # pylint: disable=too-many-instance-attributes, 
         self._buses: dict[str, _BusCompilationInfo]
 
     def compile(
-        self, qprogram: QProgram, bus_mapping: dict[str, str] | None = None
+        self, qprogram: QProgram, bus_mapping: dict[str, str] | None = None, calibration: Calibration | None = None
     ) -> tuple[qua.Program, dict, list[MeasurementInfo]]:
         """Compile QProgram to QUA's Program.
 
@@ -129,7 +129,10 @@ class QuantumMachinesCompiler:  # pylint: disable=too-many-instance-attributes, 
             self._qprogram_block_stack.pop()
 
         self._qprogram = qprogram
-        self._bus_mapping = bus_mapping
+        if bus_mapping is not None:
+            self._qprogram = self._qprogram.with_bus_mapping(bus_mapping=bus_mapping)
+        if calibration is not None:
+            self._qprogram = self._qprogram.with_calibration(calibration=calibration)
 
         self._qprogram_block_stack = deque()
         self._qprogram_to_qua_variables = {}
@@ -198,10 +201,7 @@ class QuantumMachinesCompiler:  # pylint: disable=too-many-instance-attributes, 
     def _populate_buses(self):
         """Map each bus in the QProgram to a BusCompilationInfo instance."""
 
-        buses = set(
-            self._bus_mapping[bus] if self._bus_mapping and bus in self._bus_mapping else bus
-            for bus in self._qprogram.buses
-        )
+        buses = self._qprogram.buses
         self._configuration["elements"] = {bus: {"operations": {}} for bus in buses}
         self._buses = {bus: _BusCompilationInfo() for bus in buses}
 
@@ -264,44 +264,39 @@ class QuantumMachinesCompiler:  # pylint: disable=too-many-instance-attributes, 
         return qua.for_(variable, 0, variable < element.shots, variable + 1)
 
     def _handle_set_frequency(self, element: SetFrequency):
-        bus = self._bus_mapping[element.bus] if self._bus_mapping and element.bus in self._bus_mapping else element.bus
         frequency = (
             self._qprogram_to_qua_variables[element.frequency]
             if isinstance(element.frequency, Variable)
             else element.frequency
         )
-        qua.update_frequency(element=bus, new_frequency=frequency)
+        qua.update_frequency(element=element.bus, new_frequency=frequency)
 
     def _handle_set_phase(self, element: SetPhase):
-        bus = self._bus_mapping[element.bus] if self._bus_mapping and element.bus in self._bus_mapping else element.bus
         phase = (
             self._qprogram_to_qua_variables[element.phase]
             if isinstance(element.phase, Variable)
             else element.phase / self.PHASE_COEFF
         )
-        qua.frame_rotation_2pi(phase, bus)
+        qua.frame_rotation_2pi(phase, element.bus)
 
     def _handle_reset_phase(self, element: ResetPhase):
-        bus = self._bus_mapping[element.bus] if self._bus_mapping and element.bus in self._bus_mapping else element.bus
-        qua.reset_frame(bus)
+        qua.reset_frame(element.bus)
 
     def _handle_set_gain(self, element: SetGain):
-        bus = self._bus_mapping[element.bus] if self._bus_mapping and element.bus in self._bus_mapping else element.bus
         gain = self._qprogram_to_qua_variables[element.gain] if isinstance(element.gain, Variable) else element.gain
         # QUA doesn't have a method for setting the gain directly.
         # Instead, it uses an amplitude multiplication with `amp()`.
         # Thus, we store the current gain to multiply with in the next play instructions.
-        self._buses[bus].current_gain = gain
+        self._buses[element.bus].current_gain = gain
 
     def _handle_play(self, element: Play):
-        bus = self._bus_mapping[element.bus] if self._bus_mapping and element.bus in self._bus_mapping else element.bus
         waveform_I, waveform_Q = element.get_waveforms()
         waveform_variables = element.get_waveform_variables()
         duration = waveform_I.get_duration()
 
         gain = (
-            qua.amp(self._buses[bus].current_gain * self.VOLTAGE_COEFF)
-            if self._buses[bus].current_gain is not None
+            qua.amp(self._buses[element.bus].current_gain * self.VOLTAGE_COEFF)
+            if self._buses[element.bus].current_gain is not None
             else None
         )
 
@@ -309,22 +304,21 @@ class QuantumMachinesCompiler:  # pylint: disable=too-many-instance-attributes, 
             waveform_I_name = self.__add_waveform_to_configuration(waveform_I)
             waveform_Q_name = self.__add_waveform_to_configuration(waveform_Q) if waveform_Q else None
             pulse_name = self.__add_or_update_control_pulse_to_configuration(waveform_I_name, waveform_Q_name, duration)
-            operation_name = self.__add_pulse_to_element_operations(bus, pulse_name)
+            operation_name = self.__add_pulse_to_element_operations(element.bus, pulse_name)
             pulse = operation_name * gain if gain is not None else operation_name
-            qua.play(pulse, bus)
+            qua.play(pulse, element.bus)
 
     def _handle_measure(
         self, element: Measure
     ):  # pylint: disable=too-many-locals, too-many-branches, too-many-statements
-        bus = self._bus_mapping[element.bus] if self._bus_mapping and element.bus in self._bus_mapping else element.bus
         waveform_I, waveform_Q = element.get_waveforms()
 
         waveform_I_name = self.__add_waveform_to_configuration(waveform_I)
         waveform_Q_name = self.__add_waveform_to_configuration(waveform_Q)
 
         gain = (
-            qua.amp(self._buses[bus].current_gain * self.VOLTAGE_COEFF)
-            if self._buses[bus].current_gain is not None
+            qua.amp(self._buses[element.bus].current_gain * self.VOLTAGE_COEFF)
+            if self._buses[element.bus].current_gain is not None
             else None
         )
 
@@ -337,7 +331,7 @@ class QuantumMachinesCompiler:  # pylint: disable=too-many-instance-attributes, 
             pulse_name = self.__add_or_update_measurement_pulse_to_configuration(
                 waveform_I_name, waveform_Q_name, duration=waveform_I.get_duration(), integration_weights=[]
             )
-            operation_name = self.__add_pulse_to_element_operations(bus, pulse_name)
+            operation_name = self.__add_pulse_to_element_operations(element.bus, pulse_name)
             pulse = operation_name * gain if gain is not None else operation_name
             qua.measure(pulse, element.bus, stream_raw_adc)
         elif isinstance(element.weights, IQPair):
@@ -347,12 +341,12 @@ class QuantumMachinesCompiler:  # pylint: disable=too-many-instance-attributes, 
             pulse_name = self.__add_or_update_measurement_pulse_to_configuration(
                 waveform_I_name, waveform_Q_name, duration=waveform_I.get_duration(), integration_weights=[weight_I]
             )
-            operation_name = self.__add_pulse_to_element_operations(bus, pulse_name)
+            operation_name = self.__add_pulse_to_element_operations(element.bus, pulse_name)
             pulse = operation_name * gain if gain is not None else operation_name
             if element.demodulation:
-                qua.measure(pulse, bus, stream_raw_adc, qua.demod.full(weight_I, variable_I, "out1"))
+                qua.measure(pulse, element.bus, stream_raw_adc, qua.demod.full(weight_I, variable_I, "out1"))
             else:
-                qua.measure(pulse, bus, stream_raw_adc, qua.integration.full(weight_I, variable_I, "out1"))
+                qua.measure(pulse, element.bus, stream_raw_adc, qua.integration.full(weight_I, variable_I, "out1"))
             qua.save(variable_I, stream_I)
         elif isinstance(element.weights, tuple) and len(element.weights) == 2:
             variable_I = qua.declare(qua.fixed)
@@ -367,12 +361,12 @@ class QuantumMachinesCompiler:  # pylint: disable=too-many-instance-attributes, 
                 duration=waveform_I.get_duration(),
                 integration_weights=[weight_I, weight_Q],
             )
-            operation_name = self.__add_pulse_to_element_operations(bus, pulse_name)
+            operation_name = self.__add_pulse_to_element_operations(element.bus, pulse_name)
             pulse = operation_name * gain if gain is not None else operation_name
             if element.demodulation:
                 qua.measure(
                     pulse,
-                    bus,
+                    element.bus,
                     stream_raw_adc,
                     qua.demod.full(weight_I, variable_I, "out1"),
                     qua.demod.full(weight_Q, variable_Q, "out2"),
@@ -380,7 +374,7 @@ class QuantumMachinesCompiler:  # pylint: disable=too-many-instance-attributes, 
             else:
                 qua.measure(
                     pulse,
-                    bus,
+                    element.bus,
                     stream_raw_adc,
                     qua.integration.full(weight_I, variable_I, "out1"),
                     qua.integration.full(weight_Q, variable_Q, "out2"),
@@ -402,12 +396,12 @@ class QuantumMachinesCompiler:  # pylint: disable=too-many-instance-attributes, 
                 duration=waveform_I.get_duration(),
                 integration_weights=[weight_A, weight_B, weight_C, weight_D],
             )
-            operation_name = self.__add_pulse_to_element_operations(bus, pulse_name)
+            operation_name = self.__add_pulse_to_element_operations(element.bus, pulse_name)
             pulse = operation_name * gain if gain is not None else operation_name
             if element.demodulation:
                 qua.measure(
                     pulse,
-                    bus,
+                    element.bus,
                     stream_raw_adc,
                     qua.dual_demod.full(weight_A, "out1", weight_B, "out2", variable_I),
                     qua.dual_demod.full(weight_C, "out1", weight_D, "out2", variable_Q),
@@ -415,7 +409,7 @@ class QuantumMachinesCompiler:  # pylint: disable=too-many-instance-attributes, 
             else:
                 qua.measure(
                     pulse,
-                    bus,
+                    element.bus,
                     stream_raw_adc,
                     qua.dual_integration.full(weight_A, "out1", weight_B, "out2", variable_I),
                     qua.dual_integration.full(weight_C, "out1", weight_D, "out2", variable_Q),
@@ -423,7 +417,9 @@ class QuantumMachinesCompiler:  # pylint: disable=too-many-instance-attributes, 
             qua.save(variable_I, stream_I)
             qua.save(variable_Q, stream_Q)
 
-        measurement_info = _MeasurementCompilationInfo(bus, variable_I, variable_Q, stream_I, stream_Q, stream_raw_adc)
+        measurement_info = _MeasurementCompilationInfo(
+            element.bus, variable_I, variable_Q, stream_I, stream_Q, stream_raw_adc
+        )
         for block in reversed(self._qprogram_block_stack):
             if isinstance(block, ForLoop):
                 iterations = QuantumMachinesCompiler._calculate_iterations(block.start, block.stop, block.step)
@@ -445,7 +441,6 @@ class QuantumMachinesCompiler:  # pylint: disable=too-many-instance-attributes, 
         self._measurements.append(measurement_info)
 
     def _handle_wait(self, element: Wait):
-        bus = self._bus_mapping[element.bus] if self._bus_mapping and element.bus in self._bus_mapping else element.bus
         duration = (
             self._qprogram_to_qua_variables[element.duration]
             if isinstance(element.duration, Variable)
@@ -456,16 +451,12 @@ class QuantumMachinesCompiler:  # pylint: disable=too-many-instance-attributes, 
             duration / int(self.WAIT_COEFF)
             if isinstance(element.duration, Variable)
             else int(duration / self.WAIT_COEFF),
-            bus,
+            element.bus,
         )
 
     def _handle_sync(self, element: Sync):
         if element.buses:
-            buses = [
-                self._bus_mapping[bus] if self._bus_mapping and bus in self._bus_mapping else bus
-                for bus in element.buses
-            ]
-            qua.align(*buses)
+            qua.align(*element.buses)
         else:
             qua.align()
 

--- a/src/qililab/qprogram/quantum_machines_compiler.py
+++ b/src/qililab/qprogram/quantum_machines_compiler.py
@@ -133,6 +133,10 @@ class QuantumMachinesCompiler:  # pylint: disable=too-many-instance-attributes, 
             self._qprogram = self._qprogram.with_bus_mapping(bus_mapping=bus_mapping)
         if calibration is not None:
             self._qprogram = self._qprogram.with_calibration(calibration=calibration)
+        if self._qprogram.has_named_operations():
+            raise RuntimeError(
+                "Cannot compile to hardware-native instructions because QProgram contains named operations that are not mapped. Provide a calibration instance containing all necessary mappings."
+            )
 
         self._qprogram_block_stack = deque()
         self._qprogram_to_qua_variables = {}

--- a/src/qililab/waveforms/arbitrary.py
+++ b/src/qililab/waveforms/arbitrary.py
@@ -15,9 +15,12 @@
 """Arbitrary waveform."""
 import numpy as np
 
+from qililab.yaml import yaml
+
 from .waveform import Waveform
 
 
+@yaml.register_class
 class Arbitrary(Waveform):  # pylint: disable=too-few-public-methods, disable=missing-class-docstring
     """Arbitrary waveform. Creates a waveform with the passed envelope.
 

--- a/src/qililab/waveforms/drag_correction.py
+++ b/src/qililab/waveforms/drag_correction.py
@@ -17,11 +17,13 @@ import numpy as np
 
 from qililab.qprogram.decorators import requires_domain
 from qililab.qprogram.variable import Domain
+from qililab.yaml import yaml
 
 from .gaussian import Gaussian
 from .waveform import Waveform
 
 
+@yaml.register_class
 class DragCorrection(Waveform):  # pylint: disable=too-few-public-methods
     """Calculates the first order drag correction of the imaginary (Ey) channel of a drive pulse. See https://arxiv.org/abs/0901.0534 (10).
 

--- a/src/qililab/waveforms/flat_top.py
+++ b/src/qililab/waveforms/flat_top.py
@@ -14,14 +14,16 @@
 
 """Square waveform."""
 import numpy as np
-from scipy.special import erf
+from scipy.special import erf  # pylint: disable=no-name-in-module
 
 from qililab.qprogram.decorators import requires_domain
 from qililab.qprogram.variable import Domain
+from qililab.yaml import yaml
 
 from .waveform import Waveform
 
 
+@yaml.register_class
 class FlatTop(Waveform):  # pylint: disable=too-few-public-methods
     """Flat top Gaussian rise waveform.
 

--- a/src/qililab/waveforms/gaussian.py
+++ b/src/qililab/waveforms/gaussian.py
@@ -17,10 +17,12 @@ import numpy as np
 
 from qililab.qprogram.decorators import requires_domain
 from qililab.qprogram.variable import Domain
+from qililab.yaml import yaml
 
 from .waveform import Waveform
 
 
+@yaml.register_class
 # pylint: disable=anomalous-backslash-in-string
 class Gaussian(Waveform):  # pylint: disable=too-few-public-methods
     """Gaussian waveform with peak at duration/2 and spanning for num_sigmas over the pulse duration.

--- a/src/qililab/waveforms/iq_pair.py
+++ b/src/qililab/waveforms/iq_pair.py
@@ -23,9 +23,11 @@ from qililab.utils import DictSerializable
 from qililab.waveforms.drag_correction import DragCorrection
 from qililab.waveforms.gaussian import Gaussian
 from qililab.waveforms.waveform import Waveform
+from qililab.yaml import yaml
 
 
 @dataclass
+@yaml.register_class
 class IQPair(DictSerializable):  # pylint: disable=missing-class-docstring
     """IQPair dataclass, containing the 'in-phase' (I) and 'quadrature' (Q) parts of a signal."""
 

--- a/src/qililab/waveforms/square.py
+++ b/src/qililab/waveforms/square.py
@@ -17,10 +17,12 @@ import numpy as np
 
 from qililab.qprogram.decorators import requires_domain
 from qililab.qprogram.variable import Domain
+from qililab.yaml import yaml
 
 from .waveform import Waveform
 
 
+@yaml.register_class
 class Square(Waveform):  # pylint: disable=too-few-public-methods
     """Square (rectangular) waveform. Given by a constant height line.
 

--- a/src/qililab/waveforms/waveform.py
+++ b/src/qililab/waveforms/waveform.py
@@ -18,8 +18,10 @@ from abc import abstractmethod
 import numpy as np
 
 from qililab.utils import DictSerializable
+from qililab.yaml import yaml
 
 
+@yaml.register_class
 class Waveform(DictSerializable):  # pylint: disable=too-few-public-methods, disable=missing-class-docstring
     """Waveforms describes the pulses envelope's shapes. ``Waveform`` is their abstract base class.
 

--- a/src/qililab/yaml.py
+++ b/src/qililab/yaml.py
@@ -1,0 +1,3 @@
+from ruamel.yaml import YAML
+
+yaml = YAML(typ="safe")

--- a/tests/qprogram/test_calibration.py
+++ b/tests/qprogram/test_calibration.py
@@ -1,0 +1,98 @@
+import os
+
+import pytest
+
+from qililab.qprogram.calibration import Calibration
+from qililab.waveforms import Arbitrary, FlatTop, Gaussian, IQPair, Square
+
+
+class TestCalibration:
+    """Unit tests checking the Calibration attributes and methods."""
+
+    def test_init(self):
+        """Test init method"""
+        calibration = Calibration()
+
+        assert isinstance(calibration, Calibration)
+        assert isinstance(calibration.operations, dict)
+        assert len(calibration.operations) == 0
+
+    def test_add_operation(self):
+        """Test add_operation method"""
+        xpi = Square(1.0, 100)
+        xpi2 = Square(1.0, 50)
+        readout = Square(1.0, 2000)
+
+        calibration = Calibration()
+        calibration.add_operation(bus="drive_bus", operation="Xpi", waveform=xpi)
+
+        assert len(calibration.operations) == 1
+        assert "drive_bus" in calibration.operations
+
+        assert isinstance(calibration.operations["drive_bus"], dict)
+        assert len(calibration.operations["drive_bus"]) == 1
+        assert "Xpi" in calibration.operations["drive_bus"]
+        assert calibration.operations["drive_bus"]["Xpi"] == xpi
+
+        calibration.add_operation(bus="drive_bus", operation="Xpi2", waveform=xpi2)
+        assert len(calibration.operations["drive_bus"]) == 2
+        assert "Xpi2" in calibration.operations["drive_bus"]
+        assert calibration.operations["drive_bus"]["Xpi2"] == xpi2
+
+        calibration.add_operation(bus="readout_bus", operation="readout", waveform=readout)
+        assert len(calibration.operations) == 2
+        assert isinstance(calibration.operations["readout_bus"], dict)
+        assert len(calibration.operations["readout_bus"]) == 1
+        assert "readout" in calibration.operations["readout_bus"]
+        assert calibration.operations["readout_bus"]["readout"] == readout
+
+    def test_get_operation_method(self):
+        """Test get_operation method"""
+        xpi = Square(1.0, 100)
+        xpi2 = Square(1.0, 50)
+
+        calibration = Calibration()
+        calibration.add_operation(bus="drive_bus", operation="Xpi", waveform=xpi)
+        calibration.add_operation(bus="drive_bus", operation="Xpi2", waveform=xpi2)
+
+        retrieved_xpi = calibration.get_operation(bus="drive_bus", operation="Xpi")
+        assert xpi == retrieved_xpi
+
+        retrieved_xpi2 = calibration.get_operation(bus="drive_bus", operation="Xpi2")
+        assert xpi2 == retrieved_xpi2
+
+        with pytest.raises(KeyError):
+            _ = calibration.get_operation(bus="drive_bus", operation="non_existant")
+
+        with pytest.raises(KeyError):
+            _ = calibration.get_operation(bus="non_existant", operation="Xpi")
+
+    def test_dump_load_methods(self):
+        """Test dump and load methods"""
+        calibration = Calibration()
+        calibration.add_operation(bus="drive_bus", operation="Xpi", waveform=Square(1.0, 100))
+        calibration.add_operation(bus="drive_bus", operation="Xpi2", waveform=Square(1.0, 50))
+        calibration.add_operation(bus="readout_bus", operation="readout", waveform=Square(1.0, 2000))
+
+        calibration.dump(file="calibration.yml")
+        loaded_calibration = Calibration.load(file="calibration.yml")
+
+        assert isinstance(loaded_calibration, Calibration)
+
+        xpi = loaded_calibration.get_operation(bus="drive_bus", operation="Xpi")
+        xpi2 = loaded_calibration.get_operation(bus="drive_bus", operation="Xpi2")
+        readout = loaded_calibration.get_operation(bus="readout_bus", operation="readout")
+
+        assert isinstance(xpi, Square)
+        assert xpi.amplitude == 1.0
+        assert xpi.duration == 100
+
+        assert isinstance(xpi2, Square)
+        assert xpi2.amplitude == 1.0
+        assert xpi2.duration == 50
+
+        assert isinstance(readout, Square)
+        assert readout.amplitude == 1.0
+        assert readout.duration == 2000
+
+        os.remove(path="calibration.yml")

--- a/tests/qprogram/test_calibration.py
+++ b/tests/qprogram/test_calibration.py
@@ -47,6 +47,20 @@ class TestCalibration:
         assert "readout" in calibration.operations["readout_bus"]
         assert calibration.operations["readout_bus"]["readout"] == readout
 
+    def test_has_operation_method(self):
+        """Test has_operation method"""
+        xpi = Square(1.0, 100)
+        xpi2 = Square(1.0, 50)
+
+        calibration = Calibration()
+        calibration.add_operation(bus="drive_bus", operation="Xpi", waveform=xpi)
+        calibration.add_operation(bus="drive_bus", operation="Xpi2", waveform=xpi2)
+
+        assert calibration.has_operation(bus="drive_bus", operation="Xpi") is True
+        assert calibration.has_operation(bus="drive_bus", operation="Xpi2") is True
+        assert calibration.has_operation(bus="drive_bus", operation="non_existant") is False
+        assert calibration.has_operation(bus="non_existant", operation="Xpi") is False
+
     def test_get_operation_method(self):
         """Test get_operation method"""
         xpi = Square(1.0, 100)

--- a/tests/qprogram/test_calibration.py
+++ b/tests/qprogram/test_calibration.py
@@ -4,6 +4,7 @@ import pytest
 
 from qililab.qprogram.calibration import Calibration
 from qililab.waveforms import Arbitrary, FlatTop, Gaussian, IQPair, Square
+from qililab.yaml import yaml
 
 
 class TestCalibration:
@@ -94,5 +95,16 @@ class TestCalibration:
         assert isinstance(readout, Square)
         assert readout.amplitude == 1.0
         assert readout.duration == 2000
+
+        os.remove(path="calibration.yml")
+
+        # Test that loading a different yaml produces an error
+        square = Square(1.0, 100)
+
+        with open(file="calibration.yml", mode="w", encoding="utf-8") as stream:
+            yaml.dump(data=square, stream=stream)
+
+        with pytest.raises(TypeError):
+            _ = Calibration.load(file="calibration.yml")
 
         os.remove(path="calibration.yml")

--- a/tests/qprogram/test_calibration.py
+++ b/tests/qprogram/test_calibration.py
@@ -15,88 +15,139 @@ class TestCalibration:
         calibration = Calibration()
 
         assert isinstance(calibration, Calibration)
-        assert isinstance(calibration.operations, dict)
-        assert len(calibration.operations) == 0
+        assert isinstance(calibration.waveforms, dict)
+        assert isinstance(calibration.weights, dict)
+        assert len(calibration.waveforms) == 0
+        assert len(calibration.weights) == 0
 
-    def test_add_operation(self):
+    def test_add_waveform(self):
         """Test add_operation method"""
         xpi = Square(1.0, 100)
         xpi2 = Square(1.0, 50)
         readout = Square(1.0, 2000)
 
         calibration = Calibration()
-        calibration.add_operation(bus="drive_bus", operation="Xpi", waveform=xpi)
+        calibration.add_waveform(bus="drive_bus", name="Xpi", waveform=xpi)
 
-        assert len(calibration.operations) == 1
-        assert "drive_bus" in calibration.operations
+        assert len(calibration.waveforms) == 1
+        assert "drive_bus" in calibration.waveforms
 
-        assert isinstance(calibration.operations["drive_bus"], dict)
-        assert len(calibration.operations["drive_bus"]) == 1
-        assert "Xpi" in calibration.operations["drive_bus"]
-        assert calibration.operations["drive_bus"]["Xpi"] == xpi
+        assert isinstance(calibration.waveforms["drive_bus"], dict)
+        assert len(calibration.waveforms["drive_bus"]) == 1
+        assert "Xpi" in calibration.waveforms["drive_bus"]
+        assert calibration.waveforms["drive_bus"]["Xpi"] == xpi
 
-        calibration.add_operation(bus="drive_bus", operation="Xpi2", waveform=xpi2)
-        assert len(calibration.operations["drive_bus"]) == 2
-        assert "Xpi2" in calibration.operations["drive_bus"]
-        assert calibration.operations["drive_bus"]["Xpi2"] == xpi2
+        calibration.add_waveform(bus="drive_bus", name="Xpi2", waveform=xpi2)
+        assert len(calibration.waveforms["drive_bus"]) == 2
+        assert "Xpi2" in calibration.waveforms["drive_bus"]
+        assert calibration.waveforms["drive_bus"]["Xpi2"] == xpi2
 
-        calibration.add_operation(bus="readout_bus", operation="readout", waveform=readout)
-        assert len(calibration.operations) == 2
-        assert isinstance(calibration.operations["readout_bus"], dict)
-        assert len(calibration.operations["readout_bus"]) == 1
-        assert "readout" in calibration.operations["readout_bus"]
-        assert calibration.operations["readout_bus"]["readout"] == readout
+        calibration.add_waveform(bus="readout_bus", name="readout", waveform=readout)
+        assert len(calibration.waveforms) == 2
+        assert isinstance(calibration.waveforms["readout_bus"], dict)
+        assert len(calibration.waveforms["readout_bus"]) == 1
+        assert "readout" in calibration.waveforms["readout_bus"]
+        assert calibration.waveforms["readout_bus"]["readout"] == readout
 
-    def test_has_operation_method(self):
+    def test_add_weight(self):
+        """Test add_operation method"""
+        weights = IQPair(Square(1.0, 2000), Square(1.0, 2000))
+
+        calibration = Calibration()
+        calibration.add_weights(bus="readout_bus", name="optimal_weights", weights=weights)
+
+        assert len(calibration.weights) == 1
+        assert "readout_bus" in calibration.weights
+
+        assert isinstance(calibration.weights["readout_bus"], dict)
+        assert len(calibration.weights["readout_bus"]) == 1
+        assert "optimal_weights" in calibration.weights["readout_bus"]
+        assert calibration.waveforms["readout_bus"]["optimal_weights"] == weights
+
+    def test_has_waveform_method(self):
         """Test has_operation method"""
         xpi = Square(1.0, 100)
         xpi2 = Square(1.0, 50)
 
         calibration = Calibration()
-        calibration.add_operation(bus="drive_bus", operation="Xpi", waveform=xpi)
-        calibration.add_operation(bus="drive_bus", operation="Xpi2", waveform=xpi2)
+        calibration.add_waveform(bus="drive_bus", name="Xpi", waveform=xpi)
+        calibration.add_waveform(bus="drive_bus", name="Xpi2", waveform=xpi2)
 
-        assert calibration.has_operation(bus="drive_bus", operation="Xpi") is True
-        assert calibration.has_operation(bus="drive_bus", operation="Xpi2") is True
-        assert calibration.has_operation(bus="drive_bus", operation="non_existant") is False
-        assert calibration.has_operation(bus="non_existant", operation="Xpi") is False
+        assert calibration.has_waveform(bus="drive_bus", name="Xpi") is True
+        assert calibration.has_waveform(bus="drive_bus", name="Xpi2") is True
+        assert calibration.has_waveform(bus="drive_bus", name="non_existant") is False
+        assert calibration.has_waveform(bus="non_existant", name="Xpi") is False
 
-    def test_get_operation_method(self):
+    def test_has_weights_method(self):
+        """Test add_operation method"""
+        weights = IQPair(Square(1.0, 2000), Square(1.0, 2000))
+
+        calibration = Calibration()
+        calibration.add_weights(bus="readout_bus", name="optimal_weights", weights=weights)
+
+        assert len(calibration.weights) == 1
+        assert "readout_bus" in calibration.weights
+
+        assert calibration.has_weights(bus="readout_bus", name="optimal_weights") is True
+        assert calibration.has_weights(bus="readout_bus", name="non_existant_weights") is False
+        assert calibration.has_weights(bus="non_existant", name="non_existant_weights") is False
+
+    def test_get_waveform_method(self):
         """Test get_operation method"""
         xpi = Square(1.0, 100)
         xpi2 = Square(1.0, 50)
 
         calibration = Calibration()
-        calibration.add_operation(bus="drive_bus", operation="Xpi", waveform=xpi)
-        calibration.add_operation(bus="drive_bus", operation="Xpi2", waveform=xpi2)
+        calibration.add_waveform(bus="drive_bus", name="Xpi", waveform=xpi)
+        calibration.add_waveform(bus="drive_bus", name="Xpi2", waveform=xpi2)
 
-        retrieved_xpi = calibration.get_operation(bus="drive_bus", operation="Xpi")
+        retrieved_xpi = calibration.get_waveform(bus="drive_bus", name="Xpi")
         assert xpi == retrieved_xpi
 
-        retrieved_xpi2 = calibration.get_operation(bus="drive_bus", operation="Xpi2")
+        retrieved_xpi2 = calibration.get_waveform(bus="drive_bus", name="Xpi2")
         assert xpi2 == retrieved_xpi2
 
         with pytest.raises(KeyError):
-            _ = calibration.get_operation(bus="drive_bus", operation="non_existant")
+            _ = calibration.get_waveform(bus="drive_bus", name="non_existant")
 
         with pytest.raises(KeyError):
-            _ = calibration.get_operation(bus="non_existant", operation="Xpi")
+            _ = calibration.get_waveform(bus="non_existant", name="Xpi")
+
+    def test_get_weights_method(self):
+        """Test add_operation method"""
+        weights = IQPair(Square(1.0, 2000), Square(1.0, 2000))
+
+        calibration = Calibration()
+        calibration.add_weights(bus="readout_bus", name="optimal_weights", weights=weights)
+
+        retrieved_weights = calibration.get_weights(bus="readout_bus", name="optimal_weights")
+        assert retrieved_weights == weights
+
+        with pytest.raises(KeyError):
+            _ = calibration.get_weights(bus="readout_bus", name="non_existant_weights")
+
+        with pytest.raises(KeyError):
+            _ = calibration.get_weights(bus="non_existant_bus", name="optimal_weights")
 
     def test_dump_load_methods(self):
         """Test dump and load methods"""
         calibration = Calibration()
-        calibration.add_operation(bus="drive_bus", operation="Xpi", waveform=Square(1.0, 100))
-        calibration.add_operation(bus="drive_bus", operation="Xpi2", waveform=Square(1.0, 50))
-        calibration.add_operation(bus="readout_bus", operation="readout", waveform=Square(1.0, 2000))
+        calibration.add_waveform(bus="drive_bus", name="Xpi", waveform=Square(1.0, 100))
+        calibration.add_waveform(bus="drive_bus", name="Xpi2", waveform=Square(1.0, 50))
+        calibration.add_waveform(bus="readout_bus", name="readout", waveform=Square(1.0, 2000))
+        calibration.add_weights(
+            bus="readout_bus", name="optimal_weights", weights=IQPair(Square(1.0, 2000), Square(1.0, 2000))
+        )
 
-        calibration.dump(file="calibration.yml")
-        loaded_calibration = Calibration.load(file="calibration.yml")
+        calibration.save_to(file="calibration.yml")
+        loaded_calibration = Calibration.load_from(file="calibration.yml")
 
         assert isinstance(loaded_calibration, Calibration)
 
-        xpi = loaded_calibration.get_operation(bus="drive_bus", operation="Xpi")
-        xpi2 = loaded_calibration.get_operation(bus="drive_bus", operation="Xpi2")
-        readout = loaded_calibration.get_operation(bus="readout_bus", operation="readout")
+        xpi = loaded_calibration.get_waveform(bus="drive_bus", name="Xpi")
+        xpi2 = loaded_calibration.get_waveform(bus="drive_bus", name="Xpi2")
+        readout = loaded_calibration.get_waveform(bus="readout_bus", name="readout")
+        weights = calibration.get_weights(bus="readout_bus", name="optimal_weights")
 
         assert isinstance(xpi, Square)
         assert xpi.amplitude == 1.0
@@ -110,6 +161,14 @@ class TestCalibration:
         assert readout.amplitude == 1.0
         assert readout.duration == 2000
 
+        assert isinstance(weights, IQPair)
+        assert isinstance(weights.I, Square)
+        assert weights.I.amplitude == 1.0
+        assert weights.I.duration == 2000
+        assert isinstance(weights.Q, Square)
+        assert weights.Q.amplitude == 1.0
+        assert weights.Q.duration == 2000
+
         os.remove(path="calibration.yml")
 
         # Test that loading a different yaml produces an error
@@ -119,6 +178,6 @@ class TestCalibration:
             yaml.dump(data=square, stream=stream)
 
         with pytest.raises(TypeError):
-            _ = Calibration.load(file="calibration.yml")
+            _ = Calibration.load_from(file="calibration.yml")
 
         os.remove(path="calibration.yml")

--- a/tests/qprogram/test_calibration.py
+++ b/tests/qprogram/test_calibration.py
@@ -20,8 +20,8 @@ class TestCalibration:
         assert len(calibration.waveforms) == 0
         assert len(calibration.weights) == 0
 
-    def test_add_waveform(self):
-        """Test add_operation method"""
+    def test_add_waveform_method(self):
+        """Test add_waveform method"""
         xpi = Square(1.0, 100)
         xpi2 = Square(1.0, 50)
         readout = Square(1.0, 2000)
@@ -49,8 +49,8 @@ class TestCalibration:
         assert "readout" in calibration.waveforms["readout_bus"]
         assert calibration.waveforms["readout_bus"]["readout"] == readout
 
-    def test_add_weight(self):
-        """Test add_operation method"""
+    def test_add_weights_method(self):
+        """Test add_weights method"""
         weights = IQPair(Square(1.0, 2000), Square(1.0, 2000))
 
         calibration = Calibration()

--- a/tests/qprogram/test_calibration.py
+++ b/tests/qprogram/test_calibration.py
@@ -62,7 +62,7 @@ class TestCalibration:
         assert isinstance(calibration.weights["readout_bus"], dict)
         assert len(calibration.weights["readout_bus"]) == 1
         assert "optimal_weights" in calibration.weights["readout_bus"]
-        assert calibration.waveforms["readout_bus"]["optimal_weights"] == weights
+        assert calibration.weights["readout_bus"]["optimal_weights"] == weights
 
     def test_has_waveform_method(self):
         """Test has_operation method"""

--- a/tests/qprogram/test_qblox_compiler.py
+++ b/tests/qprogram/test_qblox_compiler.py
@@ -325,6 +325,12 @@ class TestQBloxCompiler:
         assert "drive_q0" in sequences
         assert isinstance(sequences["drive_q0"], QPy.Sequence)
 
+    def test_play_named_operation_raises_error_if_operations_not_in_calibration(self, play_named_operation: QProgram):
+        calibration = Calibration()
+        compiler = QbloxCompiler()
+        with pytest.raises(RuntimeError):
+            _ = compiler.compile(play_named_operation, bus_mapping={"drive": "drive_q0"}, calibration=calibration)
+
     def test_no_loops_all_operations(self, no_loops_all_operations: QProgram):
         compiler = QbloxCompiler()
         sequences = compiler.compile(qprogram=no_loops_all_operations)

--- a/tests/qprogram/test_qblox_compiler.py
+++ b/tests/qprogram/test_qblox_compiler.py
@@ -7,16 +7,15 @@ import qpysequence as QPy
 
 from qililab import Calibration, Domain, Gaussian, IQPair, QbloxCompiler, QProgram, Square
 from qililab.qprogram.blocks import ForLoop
-from qililab.qprogram.operations import Acquire, Play
 from tests.test_utils import is_q1asm_equal  # pylint: disable=import-error, no-name-in-module
 
 
 @pytest.fixture(name="calibration")
 def fixture_calibration() -> Calibration:
     calibration = Calibration()
-    calibration.add_operation(bus="drive_q0", operation="Xpi", waveform=Square(1.0, 100))
-    calibration.add_operation(bus="drive_q1", operation="Xpi", waveform=Square(1.0, 150))
-    calibration.add_operation(bus="drive_q2", operation="Xpi", waveform=Square(1.0, 200))
+    calibration.add_waveform(bus="drive_q0", name="Xpi", waveform=Square(1.0, 100))
+    calibration.add_waveform(bus="drive_q1", name="Xpi", waveform=Square(1.0, 150))
+    calibration.add_waveform(bus="drive_q2", name="Xpi", waveform=Square(1.0, 200))
 
     return calibration
 

--- a/tests/qprogram/test_qprogram.py
+++ b/tests/qprogram/test_qprogram.py
@@ -81,7 +81,7 @@ class TestQProgram:
     def test_with_calibration_method(self):
         """Test with_bus_mapping method"""
         calibration = Calibration()
-        calibration.add_operation(bus="drive_q0_bus", operation="Xpi", waveform=Square(1.0, 100))
+        calibration.add_waveform(bus="drive_q0_bus", name="Xpi", waveform=Square(1.0, 100))
 
         qp = QProgram()
         with qp.average(1000):

--- a/tests/qprogram/test_qprogram.py
+++ b/tests/qprogram/test_qprogram.py
@@ -12,8 +12,9 @@ from qililab.qprogram.calibration import Calibration
 from qililab.qprogram.operations import (
     Acquire,
     Measure,
+    MeasureWithNamedOperation,
     Play,
-    PlayCalibratedOperation,
+    PlayWithNamedOperation,
     ResetPhase,
     SetFrequency,
     SetGain,
@@ -85,18 +86,23 @@ class TestQProgram:
         qp = QProgram()
         with qp.average(1000):
             qp.play(bus="drive_q0_bus", waveform="Xpi")
+            qp.measure(bus="drive_q0_bus", waveform="Xpi")
 
         # Check that qp has named operations
         assert qp.has_named_operations() is True
-        assert isinstance(qp.body.elements[0].elements[0], PlayCalibratedOperation)
+        assert isinstance(qp.body.elements[0].elements[0], PlayWithNamedOperation)
         assert qp.body.elements[0].elements[0].operation == "Xpi"
+        assert isinstance(qp.body.elements[0].elements[1], MeasureWithNamedOperation)
+        assert qp.body.elements[0].elements[1].operation == "Xpi"
 
         new_qp = qp.with_calibration(calibration=calibration)
 
         # Check that qp remain unchanged
         assert qp.has_named_operations() is True
-        assert isinstance(qp.body.elements[0].elements[0], PlayCalibratedOperation)
+        assert isinstance(qp.body.elements[0].elements[0], PlayWithNamedOperation)
         assert qp.body.elements[0].elements[0].operation == "Xpi"
+        assert isinstance(qp.body.elements[0].elements[1], MeasureWithNamedOperation)
+        assert qp.body.elements[0].elements[1].operation == "Xpi"
 
         # Check that new_qp has no named operations
         assert new_qp.has_named_operations() is False
@@ -105,6 +111,11 @@ class TestQProgram:
         assert isinstance(play.waveform, Square)
         assert play.waveform.amplitude == 1.0
         assert play.waveform.duration == 100
+        measure = new_qp.body.elements[0].elements[1]
+        assert isinstance(measure, Measure)
+        assert isinstance(measure.waveform, Square)
+        assert measure.waveform.amplitude == 1.0
+        assert measure.waveform.duration == 100
 
     def test_infinite_loop_method(self):
         """Test infinite_loop method"""

--- a/tests/qprogram/test_qprogram.py
+++ b/tests/qprogram/test_qprogram.py
@@ -14,7 +14,7 @@ from qililab.qprogram.operations import (
     Measure,
     MeasureWithNamedOperation,
     Play,
-    PlayWithNamedOperation,
+    PlayWithCalibratedWaveform,
     ResetPhase,
     SetFrequency,
     SetGain,
@@ -90,7 +90,7 @@ class TestQProgram:
 
         # Check that qp has named operations
         assert qp.has_named_operations() is True
-        assert isinstance(qp.body.elements[0].elements[0], PlayWithNamedOperation)
+        assert isinstance(qp.body.elements[0].elements[0], PlayWithCalibratedWaveform)
         assert qp.body.elements[0].elements[0].operation == "Xpi"
         assert isinstance(qp.body.elements[0].elements[1], MeasureWithNamedOperation)
         assert qp.body.elements[0].elements[1].operation == "Xpi"
@@ -99,7 +99,7 @@ class TestQProgram:
 
         # Check that qp remain unchanged
         assert qp.has_named_operations() is True
-        assert isinstance(qp.body.elements[0].elements[0], PlayWithNamedOperation)
+        assert isinstance(qp.body.elements[0].elements[0], PlayWithCalibratedWaveform)
         assert qp.body.elements[0].elements[0].operation == "Xpi"
         assert isinstance(qp.body.elements[0].elements[1], MeasureWithNamedOperation)
         assert qp.body.elements[0].elements[1].operation == "Xpi"

--- a/tests/qprogram/test_quantum_machines_compiler.py
+++ b/tests/qprogram/test_quantum_machines_compiler.py
@@ -434,6 +434,12 @@ class TestQuantumMachinesCompiler:
         play2 = statements[1].play
         assert play2.qe.name == "drive_q0"
 
+    def test_play_named_operation_raises_error_if_operations_not_in_calibration(self, play_named_operation: QProgram):
+        calibration = Calibration()
+        compiler = QuantumMachinesCompiler()
+        with pytest.raises(RuntimeError):
+            _, _, _ = compiler.compile(play_named_operation, bus_mapping={"drive": "drive_q0"}, calibration=calibration)
+
     def test_set_frequency_operation(self, set_frequency_operation: QProgram):
         compiler = QuantumMachinesCompiler()
         qua_program, _, _ = compiler.compile(set_frequency_operation)

--- a/tests/qprogram/test_quantum_machines_compiler.py
+++ b/tests/qprogram/test_quantum_machines_compiler.py
@@ -8,9 +8,9 @@ from qililab.qprogram.blocks import ForLoop, Loop
 @pytest.fixture(name="calibration")
 def fixture_calibration() -> Calibration:
     calibration = Calibration()
-    calibration.add_operation(bus="drive_q0", operation="Xpi", waveform=Square(1.0, 100))
-    calibration.add_operation(bus="drive_q1", operation="Xpi", waveform=Square(1.0, 150))
-    calibration.add_operation(bus="drive_q2", operation="Xpi", waveform=Square(1.0, 200))
+    calibration.add_waveform(bus="drive_q0", name="Xpi", waveform=Square(1.0, 100))
+    calibration.add_waveform(bus="drive_q1", name="Xpi", waveform=Square(1.0, 150))
+    calibration.add_waveform(bus="drive_q2", name="Xpi", waveform=Square(1.0, 200))
 
     return calibration
 

--- a/tests/qprogram/test_quantum_machines_compiler.py
+++ b/tests/qprogram/test_quantum_machines_compiler.py
@@ -1,8 +1,18 @@
 import numpy as np
 import pytest
 
-from qililab import Domain, IQPair, QProgram, QuantumMachinesCompiler, Square
+from qililab import Calibration, Domain, IQPair, QProgram, QuantumMachinesCompiler, Square
 from qililab.qprogram.blocks import ForLoop, Loop
+
+
+@pytest.fixture(name="calibration")
+def fixture_calibration() -> Calibration:
+    calibration = Calibration()
+    calibration.add_operation(bus="drive_q0", operation="Xpi", waveform=Square(1.0, 100))
+    calibration.add_operation(bus="drive_q1", operation="Xpi", waveform=Square(1.0, 150))
+    calibration.add_operation(bus="drive_q2", operation="Xpi", waveform=Square(1.0, 200))
+
+    return calibration
 
 
 @pytest.fixture(name="play_operation")
@@ -29,6 +39,16 @@ def fixture_set_gain_and_play_operation() -> QProgram:
     drag_wf = IQPair.DRAG(amplitude=1.0, duration=100, num_sigmas=5, drag_coefficient=1.5)
     qp = QProgram()
     qp.set_gain(bus="drive", gain=0.5)
+    qp.play(bus="drive", waveform=drag_wf)
+
+    return qp
+
+
+@pytest.fixture(name="play_named_operation")
+def fixture_play_named_operation() -> QProgram:
+    drag_wf = IQPair.DRAG(amplitude=1.0, duration=100, num_sigmas=5, drag_coefficient=1.5)
+    qp = QProgram()
+    qp.play(bus="drive", waveform="Xpi")
     qp.play(bus="drive", waveform=drag_wf)
 
     return qp
@@ -398,6 +418,21 @@ class TestQuantumMachinesCompiler:
         assert play.qe.name == "drive"
         assert play.named_pulse.name in configuration["pulses"]
         assert float(play.amp.v0.literal.value) == 0.5 * 2
+
+    def test_play_named_operation_and_bus_mapping(self, play_named_operation: QProgram, calibration: Calibration):
+        compiler = QuantumMachinesCompiler()
+        qua_program, configuration, _ = compiler.compile(
+            play_named_operation, bus_mapping={"drive": "drive_q0"}, calibration=calibration
+        )
+
+        statements = qua_program._program.script.body.statements
+        assert len(statements) == 2
+
+        play1 = statements[0].play
+        assert play1.qe.name == "drive_q0"
+
+        play2 = statements[1].play
+        assert play2.qe.name == "drive_q0"
 
     def test_set_frequency_operation(self, set_frequency_operation: QProgram):
         compiler = QuantumMachinesCompiler()


### PR DESCRIPTION
- Added `Calibration` class to manage calibrated operations for QProgram, including methods to add (`add_operation`), retrieve (`get_operation`), save (`dump`), and load (`load`) calibration data.
- Introduced `qililab.yaml` namespace that exports a single `YAML` instance for common use throughout qililab. Classes can be registered to this instance with the `@yaml.register_class` decorator.
- Introduced `QProgram.with_bus_mapping` method to remap buses within the QProgram.
- Introduced `QProgram.with_calibration` method to apply calibration to operations within the QProgram.
- Extended `Platform.execute_qprogram` method to accept a calibration instance.

Note: I implemented the calibrated operations only for QProgram's `play` instruction. If we like this implementation it can easily be extended for other instructions as well, e.g. `measure`.