### PR TITLE
[QHC-543] Remove `path` argument, from `build_platfom()`

### DIFF
--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -130,7 +130,7 @@
 
 ### Deprecations / Removals
 
-- [#729](https://github.com/qilimanjaro-tech/qililab/pull/729) Remove the already deprecated `path` argument, from `build_platform()`.
+- [#739](https://github.com/qilimanjaro-tech/qililab/pull/739) Remove the already deprecated `path` argument, from `build_platform()`.
 
 ### Documentation
 

--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -130,6 +130,8 @@
 
 ### Deprecations / Removals
 
+- [#729](https://github.com/qilimanjaro-tech/qililab/pull/729) Remove the already deprecated `path` argument, from `build_platform()`.
+
 ### Documentation
 
 ### Bug fixes

--- a/src/qililab/data_management.py
+++ b/src/qililab/data_management.py
@@ -225,7 +225,7 @@ def build_platform(runcard: str | dict, connection: API | None = None, new_drive
     """
     if not isinstance(runcard, (str, dict)):
         raise ValueError(
-            f"Mandatory `runcard` argument in `build_platform()`, is not a supported type: (str, dict), is type: {type(runcard)}."
+            f"Incorrect type for `runcard` argument in `build_platform()`. Expected (str | dict), got: {type(runcard)}"
         )
 
     if new_drivers:

--- a/src/qililab/data_management.py
+++ b/src/qililab/data_management.py
@@ -15,7 +15,6 @@
 import os
 from datetime import datetime
 from pathlib import Path
-from warnings import warn
 
 import h5py
 import numpy as np
@@ -174,7 +173,7 @@ def save_platform(path: str, platform: Platform) -> str:
 
 
 def build_platform(
-    runcard: str | dict | None = None, path: str | None = None, connection: API | None = None, new_drivers: bool = False
+    runcard: str | dict | None = None, connection: API | None = None, new_drivers: bool = False
 ) -> Platform:
     """Builds a :class:`.Platform` object, given a :ref:`runcard <runcards>`.
 
@@ -205,7 +204,6 @@ def build_platform(
         You can find more information about the complete structure of such dictionary, in the :ref:`Runcards <runcards>` section of the documentation.
 
     Args:
-        path (str): Path to the platform's runcard YAML file. This argument is deprecated and will be removed soon.
         runcard (str | dict): Path to the platform's runcard YAML file, or direct dictionary of the platform's runcard info.
         connection (API | None, optional): Qiboconnection's API class used to block access to the Platform when connected to it.
             Defaults to None.
@@ -227,17 +225,13 @@ def build_platform(
         >>> platform.name
         galadriel
     """
-    if path is None and runcard is None:
-        raise ValueError("`runcard` argument (str | dict) has not been passed to the `build_platform()` function.")
-    if path is not None:
-        if runcard is not None:
-            raise ValueError("Use only the `runcard` argument, `path` argument is deprecated.")
-        warn(
-            "`path` argument is deprecated and will be removed soon. Use the `runcard` argument instead.",
-            DeprecationWarning,
-            stacklevel=2,
+    if runcard is None:
+        raise ValueError("Mandatory `runcard` argument `(str | dict)` not been passed to `build_platform()`.")
+
+    if not isinstance(runcard, (str, dict)):
+        raise ValueError(
+            f"`runcard` argument in `build_platform()`, is not a supported type: (str, dict), is type: {type(runcard)}."
         )
-        runcard = path
 
     if new_drivers:
         raise NotImplementedError("New drivers are not supported yet.")

--- a/src/qililab/data_management.py
+++ b/src/qililab/data_management.py
@@ -172,9 +172,7 @@ def save_platform(path: str, platform: Platform) -> str:
     return str(new_path)
 
 
-def build_platform(
-    runcard: str | dict | None = None, connection: API | None = None, new_drivers: bool = False
-) -> Platform:
+def build_platform(runcard: str | dict, connection: API | None = None, new_drivers: bool = False) -> Platform:
     """Builds a :class:`.Platform` object, given a :ref:`runcard <runcards>`.
 
     Such runcard can be passed in one of the following two ways:
@@ -225,12 +223,9 @@ def build_platform(
         >>> platform.name
         galadriel
     """
-    if runcard is None:
-        raise ValueError("Mandatory `runcard` argument `(str | dict)` not been passed to `build_platform()`.")
-
     if not isinstance(runcard, (str, dict)):
         raise ValueError(
-            f"`runcard` argument in `build_platform()`, is not a supported type: (str, dict), is type: {type(runcard)}."
+            f"Mandatory `runcard` argument in `build_platform()`, is not a supported type: (str, dict), is type: {type(runcard)}."
         )
 
     if new_drivers:

--- a/tests/test_data_management.py
+++ b/tests/test_data_management.py
@@ -65,7 +65,7 @@ class TestBuildPlatformCornerCases:
             (msg,) = wrong_runcard_error.value.args
             assert (
                 msg
-                == f"Mandatory `runcard` argument in `build_platform()`, is not a supported type: (str, dict), is type: {type(runcard)}."
+                == f"Incorrect type for `runcard` argument in `build_platform()`. Expected (str | dict), got: {type(runcard)}"
             )
 
     def test_build_method_with_new_drivers(self):

--- a/tests/test_data_management.py
+++ b/tests/test_data_management.py
@@ -1,4 +1,5 @@
 """Unit tests for all the methods for data management."""
+
 import copy
 import os
 from pathlib import Path
@@ -20,28 +21,15 @@ from tests.test_utils import build_platform
 class TestPlatformData:
     """Unit tests for the `build_platform` function.."""
 
-    def test_build_platform_passing_a_path_to_old_path_argument(self, mock_open: MagicMock, mock_load: MagicMock):
-        """Test build method."""
-        with pytest.warns() as record:
-            platform = ql.build_platform(path="_")
-        assert isinstance(platform, Platform)
-        assert len(record) == 1
-        assert (
-            str(record[0].message)
-            == "`path` argument is deprecated and will be removed soon. Use the `runcard` argument instead."
-        )
-        mock_load.assert_called_once()
-        mock_open.assert_called_once()
-
     def test_build_platform_passing_a_path_to_runcard_argument(self, mock_open: MagicMock, mock_load: MagicMock):
-        """Test build method."""
+        """Test build method, with a string path."""
         platform = ql.build_platform(runcard="_")
         assert isinstance(platform, Platform)
         mock_load.assert_called_once()
         mock_open.assert_called_once()
 
     def test_build_platform_passing_a_dict_to_runcard_argument(self, mock_open: MagicMock, mock_load: MagicMock):
-        """Test build method."""
+        """Test build method, with a direct dict."""
         platform = ql.build_platform(runcard=copy.deepcopy(Galadriel.runcard))
         assert isinstance(platform, Platform)
         mock_load.assert_not_called()
@@ -69,21 +57,16 @@ class TestPlatformData:
 class TestBuildPlatformCornerCases:
     """Unit tests for the corner cases of the `build_platform` function.."""
 
-    def test_build_method_with_no_arguments(self):
-        """Test build method with the new drivers."""
-        with pytest.raises(ValueError) as no_arg_error:
-            ql.build_platform()
-        # We do it like this only for this case, best practice is to use match=... like in the following tests.
-        (msg,) = no_arg_error.value.args
-        assert msg == "`runcard` argument (str | dict) has not been passed to the `build_platform()` function."
-
-    def test_build_method_with_old_path_and_new_runcard_arguments(self):
-        """Test build method with the new drivers."""
-        with pytest.raises(
-            ValueError,
-            match="Use only the `runcard` argument, `path` argument is deprecated.",
-        ):
-            _ = ql.build_platform(runcard="_", path="_")
+    def test_build_platform_passing_invalid_runcard_argument(self):
+        """Test build method, with invalid argument."""
+        for runcard in [None, 1, 1.0, True, False, [], ()]:
+            with pytest.raises(ValueError) as wrong_runcard_error:
+                ql.build_platform(runcard=runcard)
+            (msg,) = wrong_runcard_error.value.args
+            assert (
+                msg
+                == f"Mandatory `runcard` argument in `build_platform()`, is not a supported type: (str, dict), is type: {type(runcard)}."
+            )
 
     def test_build_method_with_new_drivers(self):
         """Test build method with the new drivers."""


### PR DESCRIPTION
Removing deprecated argument (`path` from `build_platform`), we should have deleted, some versions ago already 👌 