### PR TITLE
[QHC-547] Add Align gate to transpiler

### DIFF
--- a/src/qililab/circuit_transpiler/gate_decompositions.py
+++ b/src/qililab/circuit_transpiler/gate_decompositions.py
@@ -77,7 +77,7 @@ def translate_gates(ngates: list[gates.Gate]) -> list[gates.Gate]:
     """
 
     # define supported gates (native qpu gates + virtual z + measurement)
-    supported_gates = native_gates() + (gates.RZ, gates.M, Wait)
+    supported_gates = native_gates() + (gates.RZ, gates.M)
 
     # check which gates are native gates and if not all of them are so, translate
     to_translate = [not isinstance(gate, supported_gates) for gate in ngates]
@@ -101,7 +101,7 @@ def native_gates():
     Returns:
         tuple[gates.Gate]: Hardware native gates
     """
-    return (Drag, gates.CZ)
+    return (Drag, gates.CZ, Wait)
 
 
 # Mind that the order of the gates is "the inverse" of the operators

--- a/src/qililab/circuit_transpiler/gate_decompositions.py
+++ b/src/qililab/circuit_transpiler/gate_decompositions.py
@@ -109,6 +109,7 @@ def native_gates():
 # returned as a list must be  [B, A] so that B is applied to |psi> 1st
 qili_dec = GateDecompositions()
 qili_dec.add(gates.I, [gates.RZ(0, 0)])
+qili_dec.add(gates.Align, lambda gate: [Wait(0, gate.parameters[0])])
 qili_dec.add(gates.H, [Drag(0, np.pi / 2, -np.pi / 2), gates.RZ(0, np.pi)])
 qili_dec.add(gates.X, [Drag(0, np.pi, 0)])
 qili_dec.add(

--- a/tests/circuit_transpiler/test_gate_decompositions.py
+++ b/tests/circuit_transpiler/test_gate_decompositions.py
@@ -70,4 +70,4 @@ def test_translate_gates(test_gates: list[gates.Gate]):
 def test_native_gates():
     """Test native gates output is the intended set of gates"""
 
-    assert native_gates() == (Drag, gates.CZ)
+    assert native_gates() == (Drag, gates.CZ, Wait)

--- a/tests/circuit_transpiler/test_gate_decompositions.py
+++ b/tests/circuit_transpiler/test_gate_decompositions.py
@@ -3,13 +3,13 @@ import pytest
 from qibo import gates
 
 from qililab.circuit_transpiler.gate_decompositions import GateDecompositions, native_gates, translate_gates
-from qililab.circuit_transpiler.native_gates import Drag
+from qililab.circuit_transpiler.native_gates import Drag, Wait
 
 
 @pytest.fixture(name="test_gates")
 def get_gates() -> list[gates.Gate]:
     """Fixture that returns a set of gates for the test"""
-    return [gates.X(0), gates.CNOT(0, 1), gates.RY(0, 2.5)]
+    return [gates.X(0), gates.Align(0, 16), gates.CNOT(0, 1), gates.RY(0, 2.5)]
 
 
 def test_gatedecompositions(test_gates: list[gates.Gate]):
@@ -23,9 +23,10 @@ def test_gatedecompositions(test_gates: list[gates.Gate]):
     decomp.add(gates.RY, lambda gate: [gates.U3(0, gate.parameters[0], 2, 0)])
     decomp.add(gates.X, [gates.Y(0), gates.Z(0)])
     decomp.add(gates.CNOT, lambda gate: [gates.SWAP(0, 1)])
+    decomp.add(gates.Align, lambda gate: [Wait(0, gate.parameters[0])])
 
     # decomposed gates from fixture should look like this
-    decomposed_gates = [gates.Y(0), gates.Z(0), gates.SWAP(0, 1), gates.U3(0, 2.5, 2, 0)]
+    decomposed_gates = [gates.Y(0), gates.Z(0), Wait(0, 16), gates.SWAP(0, 1), gates.U3(0, 2.5, 2, 0)]
 
     assert isinstance(decomp.decompositions, dict)
 
@@ -50,6 +51,7 @@ def test_translate_gates(test_gates: list[gates.Gate]):
     # decomposed gates from fixture should look like this
     decomposed_gates = [
         Drag(0, np.pi, 0),
+        Wait(0, 16),
         Drag(1, np.pi / 2, -np.pi / 2),
         gates.RZ(1, np.pi),
         gates.CZ(0, 1),


### PR DESCRIPTION
We are adding the translation of the Qibo gate `Align` to a Qililab `Wait`

Note there is no strictly 'wait' gait in Qibo, you can see in the [documentation](https://qibo.science/qibo/stable/api-reference/qibo.html#qibo.gates.Align) (not very well explained 🤠 ) that this gate acts kinda like a barrier and also adds a wait at the end.