### PR TITLE
Implemented an aditional error on IQPair

### DIFF
--- a/src/qililab/waveforms/iq_pair.py
+++ b/src/qililab/waveforms/iq_pair.py
@@ -35,11 +35,11 @@ class IQPair(DictSerializable):  # pylint: disable=missing-class-docstring
     Q: Waveform
 
     def __post_init__(self):
-        if self.I.get_duration() != self.Q.get_duration():
-            raise ValueError("Waveforms of an IQ pair must have the same duration.")
-
         if not isinstance(self.I, Waveform) or not isinstance(self.Q, Waveform):
             raise TypeError("Waveform inside IQPair must have Waveform type.")
+
+        if self.I.get_duration() != self.Q.get_duration():
+            raise ValueError("Waveforms of an IQ pair must have the same duration.")
 
     def get_duration(self) -> int:
         """Get the duration of the waveforms

--- a/src/qililab/waveforms/iq_pair.py
+++ b/src/qililab/waveforms/iq_pair.py
@@ -38,6 +38,9 @@ class IQPair(DictSerializable):  # pylint: disable=missing-class-docstring
         if self.I.get_duration() != self.Q.get_duration():
             raise ValueError("Waveforms of an IQ pair must have the same duration.")
 
+        if not isinstance(self.I, Waveform) or not isinstance(self.Q, Waveform):
+            raise TypeError("Waveform inside IQPair must have Waveform type.")
+
     def get_duration(self) -> int:
         """Get the duration of the waveforms
 

--- a/tests/waveforms/test_iq_pair.py
+++ b/tests/waveforms/test_iq_pair.py
@@ -26,6 +26,14 @@ class TestIQPair:
         with pytest.raises(ValueError, match="Waveforms of an IQ pair must have the same duration."):
             IQPair(I=Square(amplitude=0.5, duration=200), Q=Square(amplitude=1.0, duration=100))
 
+    def test_iq_pair_without_waveform_type_throws_error(self):
+        """Test that waveforms of an IQ pair must have Waveform type."""
+        with pytest.raises(ValueError, match="Waveform inside IQPair must have Waveform type."):
+            IQPair(
+                I=IQPair(I=Square(amplitude=0.5, duration=100), Q=Square(amplitude=1.0, duration=100)),
+                Q=IQPair(I=Square(amplitude=0.5, duration=100), Q=Square(amplitude=1.0, duration=100)),
+            )
+
     def test_drag_method(self):
         """Test __init__ method"""
         drag = IQPair.DRAG(drag_coefficient=0.4, amplitude=0.7, duration=40, num_sigmas=2)

--- a/tests/waveforms/test_iq_pair.py
+++ b/tests/waveforms/test_iq_pair.py
@@ -28,7 +28,7 @@ class TestIQPair:
 
     def test_iq_pair_without_waveform_type_throws_error(self):
         """Test that waveforms of an IQ pair must have Waveform type."""
-        with pytest.raises(ValueError, match="Waveform inside IQPair must have Waveform type."):
+        with pytest.raises(TypeError, match="Waveform inside IQPair must have Waveform type."):
             IQPair(
                 I=IQPair(I=Square(amplitude=0.5, duration=100), Q=Square(amplitude=1.0, duration=100)),
                 Q=IQPair(I=Square(amplitude=0.5, duration=100), Q=Square(amplitude=1.0, duration=100)),


### PR DESCRIPTION
Found a bug on qilitools where an IQPair contained 2 other IQPair (this was a mistake). The error was difficult to trace back because the class IQPair accepted other options beside Waveform without complaining. I added an exception so if you create an IQPair with something other than a Waveform it throws a clear error.