### PR TITLE
[QHC-669] Add changelog to docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -92,7 +92,7 @@ Qililab Documentation
    code/waveforms
 
 .. toctree::
-   :caption: Realease Notes
+   :caption: Release Notes
    :maxdepth: 1
    :hidden:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -90,3 +90,10 @@ Qililab Documentation
    code/result
    code/transpiler
    code/waveforms
+
+.. toctree::
+   :caption: Realease Notes
+   :maxdepth: 1
+   :hidden:
+
+   changelog


### PR DESCRIPTION
## Before this change, changelog is nowhere to be seen on the docs:
<img width="1414" alt="Screenshot 2024-08-07 at 12 34 12" src="https://github.com/user-attachments/assets/63876ebd-15b5-4ac8-9903-725f934c107e">

## After the change, it gets added in the bottom left corner, like:
<img width="1349" alt="Screenshot 2024-08-07 at 12 33 56" src="https://github.com/user-attachments/assets/c1433511-b5a7-4f1a-9266-a9b0dbea02ed">
