### PR TITLE
Temporal fix for QM timeout error

### DIFF
--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -237,6 +237,10 @@
 
 [#823](https://github.com/qilimanjaro-tech/qililab/pull/823)
 
+- Added a try and except similar to the dataloss error to restart the measurement in case of random timeout issue for quantum machines. This is a temporary fix and will be deleted once the Quantum Machines team fix their issue.
+
+[#832](https://github.com/qilimanjaro-tech/qililab/pull/832)
+
 ### Breaking changes
 
 - Renamed the platform's `execute_anneal_program()` method to `execute_annealing_program()` and updated its parameters. The method now expects `preparation_block` and `measurement_block`, which are strings used to retrieve blocks from the `Calibration`. These blocks are inserted before and after the annealing schedule, respectively.

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ urllib3==1.26.12
 qpysequence==0.10.4
 h5py==3.11.0
 papermill==2.4.0
-qm-qua==1.2.0
+qm-qua==1.2.1a1
 qualang-tools==0.17.6
 networkx==3.2.1
 ruamel.yaml==0.18.6

--- a/src/qililab/platform/platform.py
+++ b/src/qililab/platform/platform.py
@@ -913,7 +913,7 @@ class Platform:
         debug: bool = False,
     ):
         qua, configuration, measurements = output.qua, output.configuration, output.measurements
-        for iteration in np.arange(timeout_tries):  # TODO: This is a temporal fix as QM fixes the dataloss error
+        for iteration in np.arange(timeout_tries):  # TODO: This is a temporal fix as QM fixes the timeout error
             try:
                 cluster.append_configuration(configuration=configuration)
 

--- a/src/qililab/platform/platform.py
+++ b/src/qililab/platform/platform.py
@@ -21,6 +21,9 @@ import ast
 import io
 import re
 import tempfile
+import time
+import traceback
+import warnings
 from contextlib import contextmanager
 from copy import deepcopy
 from dataclasses import asdict
@@ -544,14 +547,14 @@ class Platform:
         instrument_controllers_dict = {RUNCARD.INSTRUMENT_CONTROLLERS: self.instrument_controllers.to_dict()}
         buses_dict = {RUNCARD.BUSES: self.buses.to_dict()}
         digital_dict = {
-            RUNCARD.DIGITAL: self.digital_compilation_settings.to_dict()
-            if self.digital_compilation_settings is not None
-            else None
+            RUNCARD.DIGITAL: (
+                self.digital_compilation_settings.to_dict() if self.digital_compilation_settings is not None else None
+            )
         }
         analog_dict = {
-            RUNCARD.ANALOG: self.analog_compilation_settings.to_dict()
-            if self.analog_compilation_settings is not None
-            else None
+            RUNCARD.ANALOG: (
+                self.analog_compilation_settings.to_dict() if self.analog_compilation_settings is not None else None
+            )
         }
 
         return name_dict | instrument_dict | instrument_controllers_dict | buses_dict | digital_dict | analog_dict
@@ -771,7 +774,10 @@ class Platform:
         raise NotImplementedError("Compiling QProgram for a mixture of instruments is not supported.")
 
     def execute_compilation_output(
-        self, output: QbloxCompilationOutput | QuantumMachinesCompilationOutput, debug: bool = False
+        self,
+        output: QbloxCompilationOutput | QuantumMachinesCompilationOutput,
+        timeout_tries: int = 3,
+        debug: bool = False,
     ):
         if isinstance(output, QbloxCompilationOutput):
             return self._execute_qblox_compilation_output(output=output, debug=debug)
@@ -781,7 +787,9 @@ class Platform:
         if len(instruments) != 1:
             raise NotImplementedError("Executing QProgram in more than one Quantum Machines Cluster is not supported.")
         cluster: QuantumMachinesCluster = cast(QuantumMachinesCluster, next(iter(instruments)))
-        return self._execute_quantum_machines_compilation_output(output=output, cluster=cluster, debug=debug)
+        return self._execute_quantum_machines_compilation_output(
+            output=output, cluster=cluster, timeout_tries=timeout_tries, debug=debug
+        )
 
     def _execute_qblox_compilation_output(self, output: QbloxCompilationOutput, debug: bool = False):
         sequences, acquisitions = output.sequences, output.acquisitions
@@ -830,37 +838,57 @@ class Platform:
         return results
 
     def _execute_quantum_machines_compilation_output(
-        self, output: QuantumMachinesCompilationOutput, cluster: QuantumMachinesCluster, debug: bool = False
+        self,
+        output: QuantumMachinesCompilationOutput,
+        cluster: QuantumMachinesCluster,
+        timeout_tries: int = 3,
+        debug: bool = False,
     ):
         qua, configuration, measurements = output.qua, output.configuration, output.measurements
-        cluster.append_configuration(configuration=configuration)
+        for iteration in np.arange(timeout_tries):  # TODO: This is a temporal fix as QM fixes the dataloss error
+            try:
+                cluster.append_configuration(configuration=configuration)
 
-        if debug:
-            with open("debug_qm_execution.py", "w", encoding="utf-8") as sourceFile:
-                print(generate_qua_script(qua, cluster.config), file=sourceFile)
+                if debug:
+                    with open("debug_qm_execution.py", "w", encoding="utf-8") as sourceFile:
+                        print(generate_qua_script(qua, cluster.config), file=sourceFile)
 
-        compiled_program_id = cluster.compile(program=qua)
-        job = cluster.run_compiled_program(compiled_program_id=compiled_program_id)
+                compiled_program_id = cluster.compile(program=qua)
+                job = cluster.run_compiled_program(compiled_program_id=compiled_program_id)
 
-        acquisitions = cluster.get_acquisitions(job=job)
+                acquisitions = cluster.get_acquisitions(job=job)
 
-        results = QProgramResults()
-        # Doing manual classification of results as QM does not return thresholded values like Qblox
-        for measurement in measurements:
-            measurement_result = QuantumMachinesMeasurementResult(
-                measurement.bus,
-                *[acquisitions[handle] for handle in measurement.result_handles],
-            )
-            measurement_result.set_classification_threshold(measurement.threshold)
-            results.append_result(bus=measurement.bus, result=measurement_result)
+                results = QProgramResults()
+                # Doing manual classification of results as QM does not return thresholded values like Qblox
+                for measurement in measurements:
+                    measurement_result = QuantumMachinesMeasurementResult(
+                        measurement.bus,
+                        *[acquisitions[handle] for handle in measurement.result_handles],
+                    )
+                    measurement_result.set_classification_threshold(measurement.threshold)
+                    results.append_result(bus=measurement.bus, result=measurement_result)
+            except TimeoutError as timeout:
+                warnings.warn(
+                    f"Warning: {timeout} raised, retrying experiment ({iteration+1}/{timeout_tries} available tries)"
+                )
+                warnings.warn(traceback.format_exc())
+                if iteration + 1 != timeout_tries:
+                    time.sleep(1 * timeout_tries)
+                    continue
+                cluster.turn_off()
+                raise timeout
+            except Exception as e:
+                cluster.turn_off()
+                raise e
 
-        return results
+            return results
 
     def execute_qprogram(
         self,
         qprogram: QProgram,
         bus_mapping: dict[str, str] | None = None,
         calibration: Calibration | None = None,
+        timeout_tries: int = 3,
         debug: bool = False,
     ) -> QProgramResults:
         """Execute a :class:`.QProgram` using the platform instruments.
@@ -893,7 +921,7 @@ class Platform:
             The keys correspond to the buses a measurement were performed upon, and the values are the list of measurement results in chronological order.
         """
         output = self.compile_qprogram(qprogram=qprogram, bus_mapping=bus_mapping, calibration=calibration)
-        return self.execute_compilation_output(output=output, debug=debug)
+        return self.execute_compilation_output(output=output, timeout_tries=timeout_tries, debug=debug)
 
     def execute(
         self,

--- a/src/qililab/platform/platform.py
+++ b/src/qililab/platform/platform.py
@@ -935,9 +935,12 @@ class Platform:
                     )
                     measurement_result.set_classification_threshold(measurement.threshold)
                     results.append_result(bus=measurement.bus, result=measurement_result)
+
+                return results
+
             except TimeoutError as timeout:
                 warnings.warn(
-                    f"Warning: {timeout} raised, retrying experiment ({iteration+1}/{timeout_tries} available tries)"
+                    f"Warning: {timeout} raised, retrying experiment ({iteration + 1}/{timeout_tries} available tries)"
                 )
                 warnings.warn(traceback.format_exc())
                 if iteration + 1 != timeout_tries:
@@ -949,7 +952,7 @@ class Platform:
                 cluster.turn_off()
                 raise e
 
-            return results
+        return results
 
     def execute_qprogram(
         self,

--- a/tests/platform/test_platform.py
+++ b/tests/platform/test_platform.py
@@ -776,6 +776,29 @@ class TestMethods:
         assert patched_open.call_count == 1
         assert generate_qua.call_count == 1
 
+    def test_execute_qprogram_with_quantum_machines_raises_error(self, platform_quantum_machines: Platform):
+        """Test that the execute_qprogram method raises the exception if the qprogram failes"""
+
+        error_string = "The QM `config` dictionary does not exist. Please run `initial_setup()` first."
+        escaped_error_str = re.escape(error_string)
+        platform_quantum_machines.compile = MagicMock()  # type: ignore # don't care about compilation
+        platform_quantum_machines.compile.return_value = Exception(escaped_error_str)
+
+        drive_wf = IQPair(I=Square(amplitude=1.0, duration=40), Q=Square(amplitude=0.0, duration=40))
+        readout_wf = IQPair(I=Square(amplitude=1.0, duration=120), Q=Square(amplitude=0.0, duration=120))
+        weights_wf = IQPair(I=Square(amplitude=1.0, duration=2000), Q=Square(amplitude=0.0, duration=2000))
+        qprogram = QProgram()
+        qprogram.play(bus="drive_q0_rf", waveform=drive_wf)
+        qprogram.sync()
+        qprogram.play(bus="readout_q0_rf", waveform=readout_wf)
+        qprogram.measure(bus="readout_q0_rf", waveform=readout_wf, weights=weights_wf)
+
+        with patch.object(QuantumMachinesCluster, "turn_off") as turn_off:
+            with pytest.raises(ValueError, match=escaped_error_str):
+                _ = platform_quantum_machines.execute_qprogram(qprogram=qprogram, debug=True)
+
+        turn_off.assert_called_once_with()
+
     def test_execute(self, platform: Platform, qblox_results: list[dict]):
         """Test that the execute method calls the buses to run and return the results."""
         # Define pulse schedule


### PR DESCRIPTION
I created a try and except similar to the dataloss error to restart the measurement in case of random timeout issue