### PR TITLE
Qhc 804 add blocks mapping to qblox compiler

### DIFF
--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -2,6 +2,10 @@
 
 ### New features since last release
 
+- Updated to latest qblox-instruments version. Changed some deprecated code from the new version and the QcmQrm into the more generic Module class.
+
+[#836](https://github.com/qilimanjaro-tech/qililab/pull/836)
+
 - Support GRES in %%submit_job magic method
 
 [#828](https://github.com/qilimanjaro-tech/qililab/pull/828)

--- a/examples/calibrations/ringup.yml
+++ b/examples/calibrations/ringup.yml
@@ -1,0 +1,27 @@
+!Calibration
+blocks:
+  measurement: !Block
+    _uuid: !UUID {int: 51382213198160002539890685064316003974}
+    elements:
+    - !Play
+      _uuid: !UUID {int: 214683360525838151494422436614319566592}
+      bus: readout
+      wait_time: null
+      waveform: !IQPair
+        I: !Square {amplitude: 1.0, duration: 2000}
+        Q: !Square {amplitude: 0.0, duration: 2000}
+    - !Measure
+      _uuid: !UUID {int: 249620897697541826616041194897618541375}
+      bus: readout
+      demodulation: true
+      rotation: null
+      save_adc: false
+      waveform: !IQPair
+        I: !Square {amplitude: 1.0, duration: 2000}
+        Q: !Square {amplitude: 0.0, duration: 2000}
+      weights: !IQPair
+        I: !Square {amplitude: 1.0, duration: 2000}
+        Q: !Square {amplitude: 0.0, duration: 2000}
+crosstalk_matrix: {}
+waveforms: {}
+weights: {}

--- a/examples/measurement_block.ipynb
+++ b/examples/measurement_block.ipynb
@@ -1,0 +1,77 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2024-11-26 12:05:10,004 - qm - INFO     - Starting session: 82151a6a-adb6-4a37-82b3-771e802d1578\n"
+     ]
+    }
+   ],
+   "source": [
+    "import qililab as ql"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "calibration = ql.Calibration.load_from(\"./calibrations/ringup.yml\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "FileNotFoundError",
+     "evalue": "[Errno 2] No such file or directory: 'runcard.yml'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mFileNotFoundError\u001b[0m                         Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[5], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m platform \u001b[39m=\u001b[39m ql\u001b[39m.\u001b[39;49mbuild_platform(runcard\u001b[39m=\u001b[39;49m\u001b[39m\"\u001b[39;49m\u001b[39mruncard.yml\u001b[39;49m\u001b[39m\"\u001b[39;49m)\n\u001b[1;32m      2\u001b[0m platform\u001b[39m.\u001b[39mconnect()\n\u001b[1;32m      3\u001b[0m platform\u001b[39m.\u001b[39minitial_setup()\n",
+      "File \u001b[0;32m~/github/qililab/src/qililab/data_management.py:231\u001b[0m, in \u001b[0;36mbuild_platform\u001b[0;34m(runcard, new_drivers)\u001b[0m\n\u001b[1;32m    228\u001b[0m     \u001b[39mraise\u001b[39;00m \u001b[39mNotImplementedError\u001b[39;00m(\u001b[39m\"\u001b[39m\u001b[39mNew drivers are not supported yet.\u001b[39m\u001b[39m\"\u001b[39m)\n\u001b[1;32m    230\u001b[0m \u001b[39mif\u001b[39;00m \u001b[39misinstance\u001b[39m(runcard, \u001b[39mstr\u001b[39m):\n\u001b[0;32m--> 231\u001b[0m     \u001b[39mwith\u001b[39;00m \u001b[39mopen\u001b[39;49m(file\u001b[39m=\u001b[39;49mruncard, mode\u001b[39m=\u001b[39;49m\u001b[39m\"\u001b[39;49m\u001b[39mr\u001b[39;49m\u001b[39m\"\u001b[39;49m, encoding\u001b[39m=\u001b[39;49m\u001b[39m\"\u001b[39;49m\u001b[39mutf8\u001b[39;49m\u001b[39m\"\u001b[39;49m) \u001b[39mas\u001b[39;00m file:\n\u001b[1;32m    232\u001b[0m         yaml \u001b[39m=\u001b[39m YAML(typ\u001b[39m=\u001b[39m\u001b[39m\"\u001b[39m\u001b[39msafe\u001b[39m\u001b[39m\"\u001b[39m)\n\u001b[1;32m    233\u001b[0m         runcard \u001b[39m=\u001b[39m yaml\u001b[39m.\u001b[39mload(stream\u001b[39m=\u001b[39mfile)\n",
+      "\u001b[0;31mFileNotFoundError\u001b[0m: [Errno 2] No such file or directory: 'runcard.yml'"
+     ]
+    }
+   ],
+   "source": [
+    "platform = ql.build_platform(runcard=\"./runcards/contralto_saruman.yml\")\n",
+    "platform.connect()\n",
+    "platform.initial_setup()\n",
+    "platform.turn_on_instruments()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "new_new_qililab",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/runcards/contralto_saruman.yml
+++ b/examples/runcards/contralto_saruman.yml
@@ -1,0 +1,1196 @@
+name: contralto_saruman
+
+digital:
+  minimum_clock_time: 4
+  delay_before_readout: 4
+  topology: [[0, 2], [1, 2]]
+  gates:
+    M(0):
+    - bus: readout_q0_bus
+      pulse:
+        amplitude: 0.3
+        phase: 0
+        duration: 1100
+        shape:
+          name: rectangular
+      wait_time: 0
+    Drag(0):
+    - bus: drive_q0_bus
+      pulse:
+        amplitude: 0.09
+        phase: 0
+        duration: 40
+        shape:
+          name: drag
+          num_sigmas: 4
+          drag_coefficient: 0.0
+      wait_time: 0
+    M(1):
+    - bus: readout_q1_bus
+      pulse:
+        amplitude: 0.005
+        phase: 0
+        duration: 1000
+        shape:
+          name: rectangular
+      wait_time: 0
+    Drag(1):
+    - bus: drive_q1_bus
+      pulse:
+        amplitude: 0.1
+        phase: 0
+        duration: 40
+        shape:
+          name: drag
+          num_sigmas: 4
+          drag_coefficient: 0.0
+      wait_time: 0
+    M(2):
+    - bus: readout_q2_bus
+      pulse:
+        amplitude: 0.05
+        phase: 0
+        duration: 1200
+        shape:
+          name: rectangular
+      wait_time: 0
+    Drag(2):
+    - bus: drive_q2_bus
+      pulse:
+        amplitude: 0.0800294849776628
+        phase: 0
+        duration: 40
+        shape:
+          name: drag
+          num_sigmas: 4
+          drag_coefficient: -0.701105877213066
+      wait_time: 0
+    M(3):
+    - bus: readout_q3_bus
+      pulse:
+        amplitude: 0.14
+        phase: 0
+        duration: 600
+        shape:
+          name: rectangular
+      wait_time: 0
+    Drag(3):
+    - bus: drive_q3_bus
+      pulse:
+        amplitude: 0.81
+        phase: 0
+        duration: 40
+        shape:
+          name: drag
+          num_sigmas: 4
+          drag_coefficient: 0.0
+      wait_time: 0
+    M(4):
+    - bus: readout_q4_bus
+      pulse:
+        amplitude: 0.06
+        phase: 0
+        duration: 1450
+        shape:
+          name: rectangular
+      wait_time: 0
+    Drag(4):
+    - bus: drive_q4_bus
+      pulse:
+        amplitude: 0.42203210282437376
+        phase: 0
+        duration: 40
+        shape:
+          name: drag
+          num_sigmas: 4
+          drag_coefficient: 0.0
+      wait_time: 0
+    M(5):
+    - bus: readout_q5_bus
+      pulse:
+        amplitude: 0.084
+        phase: 0
+        duration: 1200
+        shape:
+          name: rectangular
+      wait_time: 0
+    Drag(5):
+    - bus: drive_q5_bus
+      pulse:
+        amplitude: 0.11699763555266803
+        phase: 0
+        duration: 40
+        shape:
+          name: drag
+          num_sigmas: 4
+          drag_coefficient: -1.603317473874127
+      wait_time: 0
+    M(6):
+    - bus: readout_q6_bus
+      pulse:
+        amplitude: 0.5
+        phase: 0
+        duration: 1100
+        shape:
+          name: rectangular
+      wait_time: 0
+    Drag(6):
+    - bus: drive_q6_bus
+      pulse:
+        amplitude: 0.2582073143992086
+        phase: 0
+        duration: 40
+        shape:
+          name: drag
+          num_sigmas: 4
+          drag_coefficient: 0.0
+      wait_time: 0
+    M(7):
+    - bus: readout_q7_bus
+      pulse:
+        amplitude: 0.5
+        phase: 0
+        duration: 1000
+        shape:
+          name: rectangular
+      wait_time: 0
+    Drag(7):
+    - bus: drive_q7_bus
+      pulse:
+        amplitude: 0.45
+        phase: 0
+        duration: 200
+        shape:
+          name: drag
+          num_sigmas: 4
+          drag_coefficient: 0.0
+      wait_time: 0
+    M(8):
+    - bus: readout_q8_bus
+      pulse:
+        amplitude: 0.0275
+        phase: 0
+        duration: 1350
+        shape:
+          name: rectangular
+      wait_time: 0
+    Drag(8):
+    - bus: drive_q8_bus
+      pulse:
+        amplitude: 0.7794436553880829
+        phase: 0
+        duration: 70
+        shape:
+          name: drag
+          num_sigmas: 4
+          drag_coefficient: 0.0
+      wait_time: 0
+    M(9):
+    - bus: readout_q9_bus
+      pulse:
+        amplitude: 0.03
+        phase: 0
+        duration: 1200
+        shape:
+          name: rectangular
+      wait_time: 0
+    Drag(9):
+    - bus: drive_q9_bus
+      pulse:
+        amplitude: 0.7689656971068248
+        phase: 0
+        duration: 100
+        shape:
+          name: drag
+          num_sigmas: 4
+          drag_coefficient: 1.6948356555250759
+      wait_time: 0
+    M(10):
+    - bus: readout_q10_bus
+      pulse:
+        amplitude: 0.02
+        phase: 0
+        duration: 600
+        shape:
+          name: rectangular
+      wait_time: 0
+    Drag(10):
+    - bus: drive_q10_bus
+      pulse:
+        amplitude: 0.8333333333333334
+        phase: 0
+        duration: 100
+        shape:
+          name: drag
+          num_sigmas: 4
+          drag_coefficient: 0.0
+      wait_time: 0
+    M(11):
+    - bus: readout_q11_bus
+      pulse:
+        amplitude: 0.06
+        phase: 0
+        duration: 1450
+        shape:
+          name: rectangular
+      wait_time: 0
+    Drag(11):
+    - bus: drive_q11_bus
+      pulse:
+        amplitude: 0.39
+        phase: 0
+        duration: 20
+        shape:
+          name: drag
+          num_sigmas: 4
+          drag_coefficient: 0.0
+      wait_time: 0
+    M(12):
+    - bus: readout_q12_bus
+      pulse:
+        amplitude: 0.004
+        phase: 0
+        duration: 1450
+        shape:
+          name: rectangular
+      wait_time: 0
+    Drag(12):
+    - bus: drive_q12_bus
+      pulse:
+        amplitude: 0.4666666666666667
+        phase: 0
+        duration: 20
+        shape:
+          name: drag
+          num_sigmas: 4
+          drag_coefficient: 0.0
+      wait_time: 0
+    M(13):
+    - bus: readout_q13_bus
+      pulse:
+        amplitude: 0.06
+        phase: 0
+        duration: 1450
+        shape:
+          name: rectangular
+      wait_time: 0
+    Drag(13):
+    - bus: drive_q13_bus
+      pulse:
+        amplitude: 0.21666666666666667
+        phase: 0
+        duration: 40
+        shape:
+          name: drag
+          num_sigmas: 4
+          drag_coefficient: 0.0
+      wait_time: 0
+    M(14):
+    - bus: readout_q14_bus
+      pulse:
+        amplitude: 0.06
+        phase: 0
+        duration: 1450
+        shape:
+          name: rectangular
+      wait_time: 0
+    Drag(14):
+    - bus: drive_q14_bus
+      pulse:
+        amplitude: 0.2
+        phase: 0
+        duration: 40
+        shape:
+          name: drag
+          num_sigmas: 4
+          drag_coefficient: 0.0
+      wait_time: 0
+    M(15):
+    - bus: readout_q15_bus
+      pulse:
+        amplitude: 0.06
+        phase: 0
+        duration: 1450
+        shape:
+          name: rectangular
+      wait_time: 0
+    Drag(15):
+    - bus: drive_q15_bus
+      pulse:
+        amplitude: 0.42203210282437376
+        phase: 0
+        duration: 40
+        shape:
+          name: drag
+          num_sigmas: 4
+          drag_coefficient: 0.0
+      wait_time: 0
+    CZ(8,5):
+    - bus: flux_q5_bus
+      pulse:
+        amplitude: 0.25326819341457385
+        phase: 0
+        duration: 37
+        shape:
+          name: rectangular
+        options:
+          q2_phase_correction: 0.13209531567724994
+          q4_phase_correction: 4.383143867822417
+      wait_time: 0
+    CZ(2,3):
+    - bus: flux_q3_bus
+      pulse:
+        amplitude: 0.40383424505801674
+        phase: 0
+        duration: 40
+        shape:
+          name: rectangular
+        options:
+          q2_phase_correction: 0.02736337729444749
+          q3_phase_correction: 4.996988524732117
+      wait_time: 0
+    CZ(0,2):
+    - bus: flux_q2_bus
+      pulse:
+        amplitude: 0.29030992367519076
+        phase: 0
+        duration: 32
+        shape:
+          name: rectangular
+        options:
+          q0_phase_correction: 0.04657474288915329
+          q2_phase_correction: 0.699572519801396
+      wait_time: 0
+    - bus: flux_q1_bus
+      pulse:
+        amplitude: 0.5
+        phase: 0
+        duration: 50
+        shape:
+          name: rectangular
+      wait_time: 0
+    CZ(1,2):
+    - bus: flux_q2_bus
+      pulse:
+        amplitude: 0.29685366875858216
+        phase: 0
+        duration: 32
+        shape:
+          name: rectangular
+        options:
+          q1_phase_correction: 0.06005184023506173
+          q2_phase_correction: 2.3145323313665687
+      wait_time: 8
+    - bus: flux_q0_bus
+      pulse:
+        amplitude: 0.5
+        phase: 0
+        duration: 50
+        shape:
+          name: rectangular
+      wait_time: 0
+  buses:
+    readout_q0_bus:
+      line: readout
+      qubits: [0]
+    readout_q1_bus:
+      line: readout
+      qubits: [1]
+    readout_q2_bus:
+      line: readout
+      qubits: [2]
+    readout_q3_bus:
+      line: readout
+      qubits: [3]
+    readout_q4_bus:
+      line: readout
+      qubits: [4]
+    readout_q5_bus:
+      line: readout
+      qubits: [5]
+    readout_q6_bus:
+      line: readout
+      qubits: [6]
+    readout_q7_bus:
+      line: readout
+      qubits: [7]
+    readout_q8_bus:
+      line: readout
+      qubits: [8]
+    readout_q9_bus:
+      line: readout
+      qubits: [9]
+    drive_q0_bus:
+      line: drive
+      qubits: [0]
+    drive_q1_bus:
+      line: drive
+      qubits: [1]
+    drive_q2_bus:
+      line: drive
+      qubits: [2]
+    drive_q3_bus:
+      line: drive
+      qubits: [3]
+    drive_q4_bus:
+      line: drive
+      qubits: [4]
+    drive_q5_bus:
+      line: drive
+      qubits: [5]
+    drive_q6_bus:
+      line: drive
+      qubits: [6]
+    drive_q7_bus:
+      line: drive
+      qubits: [7]
+    drive_q8_bus:
+      line: drive
+      qubits: [8]
+    drive_q9_bus:
+      line: drive
+      qubits: [9]
+    flux_q0_bus:
+      line: flux
+      qubits: [0]
+    flux_q1_bus:
+      line: flux
+      qubits: [1]
+    flux_q2_bus:
+      line: flux
+      qubits: [2]
+    flux_q3_bus:
+      line: flux
+      qubits: [3]
+    flux_q4_bus:
+      line: flux
+      qubits: [4]
+    flux_q5_bus:
+      line: flux
+      qubits: [5]
+    flux_q6_bus:
+      line: flux
+      qubits: [6]
+    flux_q7_bus:
+      line: flux
+      qubits: [7]
+    flux_q8_bus:
+      line: flux
+      qubits: [8]
+    flux_q9_bus:
+      line: flux
+      qubits: [9]
+
+buses:
+- alias: readout_q0_bus
+  instruments: [QRM-RF1]
+  channels: [0]
+- alias: readout_q1_bus
+  instruments: [QRM-RF1]
+  channels: [1]
+- alias: readout_q2_bus
+  instruments: [QRM-RF1]
+  channels: [2]
+- alias: readout_q3_bus
+  instruments: [QRM-RF1]
+  channels: [3]
+- alias: readout_q4_bus
+  instruments: [QRM-RF2]
+  channels: [0]
+- alias: readout_q5_bus
+  instruments: [QRM-RF2]
+  channels: [1]
+- alias: readout_q6_bus
+  instruments: [QRM-RF2]
+  channels: [2]
+- alias: readout_q7_bus
+  instruments: [QRM-RF3]
+  channels: [0]
+- alias: readout_q8_bus
+  instruments: [QRM-RF3]
+  channels: [1]
+- alias: readout_q9_bus
+  instruments: [QRM-RF3]
+  channels: [2]
+- alias: drive_q0_bus
+  instruments: [QCM-RF1]
+  channels: [0]
+- alias: flux_q0_bus
+  instruments: [QCM1]
+  channels: [0]
+- alias: drive_q1_bus
+  instruments: [QCM-RF1]
+  channels: [1]
+- alias: flux_q1_bus
+  instruments: [QCM1]
+  channels: [1]
+- alias: drive_q2_bus
+  instruments: [QCM-RF2]
+  channels: [0]
+- alias: flux_q2_bus
+  instruments: [QCM1]
+  channels: [2]
+- alias: drive_q3_bus
+  instruments: [QCM-RF2]
+  channels: [1]
+- alias: flux_q3_bus
+  instruments: [QCM1]
+  channels: [3]
+- alias: drive_q4_bus
+  instruments: [QCM-RF3]
+  channels: [0]
+- alias: flux_q4_bus
+  instruments: [QCM2]
+  channels: [0]
+- alias: drive_q5_bus
+  instruments: [QCM-RF3]
+  channels: [1]
+- alias: flux_q5_bus
+  instruments: [QCM2]
+  channels: [1]
+- alias: drive_q6_bus
+  instruments: [QCM-RF4]
+  channels: [0]
+- alias: flux_q6_bus
+  instruments: [QCM2]
+  channels: [2]
+- alias: drive_q7_bus
+  instruments: [QCM-RF4]
+  channels: [1]
+- alias: flux_q7_bus
+  instruments: [QCM2]
+  channels: [3]
+- alias: drive_q8_bus
+  instruments: [QCM-RF5]
+  channels: [0]
+- alias: flux_q8_bus
+  instruments: [QCM3]
+  channels: [0]
+- alias: drive_q9_bus
+  instruments: [QCM-RF5]
+  channels: [1]
+- alias: flux_q9_bus
+  instruments: [QCM3]
+  channels: [1]
+
+instruments:
+- name: QCM
+  alias: QCM1
+  out_offsets:
+  - 0.0
+  - 0.0
+  - 0.0
+  - 0.0
+  awg_sequencers:
+  - identifier: 0
+    outputs:
+    - 0
+    intermediate_frequency: 0.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+  - identifier: 1
+    outputs:
+    - 1
+    intermediate_frequency: 0.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+  - identifier: 2
+    outputs:
+    - 2
+    intermediate_frequency: 0.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+  - identifier: 3
+    outputs:
+    - 3
+    intermediate_frequency: 0.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+- name: QCM
+  alias: QCM2
+  out_offsets:
+  - 0.0
+  - -0.791623
+  - 0.0
+  - -0.3
+  awg_sequencers:
+  - identifier: 0
+    outputs:
+    - 0
+    intermediate_frequency: 0.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+  - identifier: 1
+    outputs:
+    - 1
+    intermediate_frequency: 0.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+  - identifier: 2
+    outputs:
+    - 2
+    intermediate_frequency: 0.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+  - identifier: 3
+    outputs:
+    - 3
+    intermediate_frequency: 0.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+- name: QCM
+  alias: QCM3
+  out_offsets:
+  - 0.1596
+  - 0.08
+  - 0.0
+  - 0.0
+  awg_sequencers:
+  - identifier: 0
+    outputs:
+    - 0
+    intermediate_frequency: 0.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+  - identifier: 1
+    outputs:
+    - 1
+    intermediate_frequency: 0.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+  - identifier: 2
+    outputs:
+    - 2
+    intermediate_frequency: 0.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+  - identifier: 3
+    outputs:
+    - 3
+    intermediate_frequency: 0.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+- name: QRM-RF
+  alias: QRM-RF1
+  out0_in0_lo_freq: 7375000000.0
+  out0_in0_lo_en: true
+  out0_att: 30
+  in0_att: 0
+  out0_offset_path0: 0.0
+  out0_offset_path1: 0.0
+  awg_sequencers:
+  - identifier: 0
+    outputs:
+    - 0
+    intermediate_frequency: -218000000.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+    scope_acquire_trigger_mode: sequencer
+    scope_hardware_averaging: true
+    sampling_rate: 1000000000.0
+    hardware_demodulation: true
+    integration_length: 1100
+    integration_mode: ssb
+    sequence_timeout: 60
+    acquisition_timeout: 60
+    scope_store_enabled: false
+    threshold: 0.00019330455351026057
+    threshold_rotation: 5.201538252600354
+    time_of_flight: 200
+  - identifier: 1
+    outputs:
+    - 0
+    intermediate_frequency: -93300000.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+    scope_acquire_trigger_mode: sequencer
+    scope_hardware_averaging: true
+    sampling_rate: 1000000000.0
+    hardware_demodulation: true
+    integration_length: 800
+    integration_mode: ssb
+    sequence_timeout: 60
+    acquisition_timeout: 60
+    scope_store_enabled: false
+    threshold: -0.0013627152056984203
+    threshold_rotation: 353.12433100338825
+    time_of_flight: 200
+  - identifier: 2
+    outputs:
+    - 0
+    intermediate_frequency: 160050000.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+    scope_acquire_trigger_mode: sequencer
+    scope_hardware_averaging: true
+    sampling_rate: 1000000000.0
+    hardware_demodulation: true
+    integration_length: 1450
+    integration_mode: ssb
+    sequence_timeout: 60
+    acquisition_timeout: 60
+    scope_store_enabled: false
+    threshold: 0.0041298097225328555
+    threshold_rotation: 215.88559722553708
+    time_of_flight: 200
+  - identifier: 3
+    outputs:
+    - 0
+    intermediate_frequency: 158700000.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+    scope_acquire_trigger_mode: sequencer
+    scope_hardware_averaging: true
+    sampling_rate: 1000000000.0
+    hardware_demodulation: true
+    integration_length: 1200
+    integration_mode: ssb
+    sequence_timeout: 60
+    acquisition_timeout: 60
+    scope_store_enabled: false
+    threshold: 0.0012626504245012637
+    threshold_rotation: 302.69806249880776
+    time_of_flight: 200
+- name: QRM-RF
+  alias: QRM-RF2
+  out0_in0_lo_freq: 7315000000.0
+  out0_in0_lo_en: true
+  out0_att: 26
+  in0_att: 0
+  out0_offset_path0: 0.0
+  out0_offset_path1: 0.0
+  awg_sequencers:
+  - identifier: 0
+    outputs:
+    - 0
+    intermediate_frequency: -144000000.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+    scope_acquire_trigger_mode: sequencer
+    scope_hardware_averaging: true
+    sampling_rate: 1000000000.0
+    hardware_demodulation: true
+    integration_length: 1100
+    integration_mode: ssb
+    sequence_timeout: 60
+    acquisition_timeout: 60
+    scope_store_enabled: false
+    threshold: 0.00019330455351026057
+    threshold_rotation: 5.201538252600354
+    time_of_flight: 200
+  - identifier: 1
+    outputs:
+    - 0
+    intermediate_frequency: 110100000.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+    scope_acquire_trigger_mode: sequencer
+    scope_hardware_averaging: true
+    sampling_rate: 1000000000.0
+    hardware_demodulation: true
+    integration_length: 800
+    integration_mode: ssb
+    sequence_timeout: 60
+    acquisition_timeout: 60
+    scope_store_enabled: false
+    threshold: 0.006255581643445415
+    threshold_rotation: 254.69395079446838
+    time_of_flight: 200
+  - identifier: 2
+    outputs:
+    - 0
+    intermediate_frequency: 33700000.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+    scope_acquire_trigger_mode: sequencer
+    scope_hardware_averaging: true
+    sampling_rate: 1000000000.0
+    hardware_demodulation: true
+    integration_length: 1400
+    integration_mode: ssb
+    sequence_timeout: 60
+    acquisition_timeout: 60
+    scope_store_enabled: false
+    threshold: 0.001313140102544695
+    threshold_rotation: 185.5597106455339
+    time_of_flight: 200
+- name: QRM-RF
+  alias: QRM-RF3
+  out0_in0_lo_freq: 7315000000.0
+  out0_in0_lo_en: true
+  out0_att: 30
+  in0_att: 0
+  out0_offset_path0: 0.0
+  out0_offset_path1: 0.0
+  awg_sequencers:
+  - identifier: 0
+    outputs:
+    - 0
+    intermediate_frequency: -151400000.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+    scope_acquire_trigger_mode: sequencer
+    scope_hardware_averaging: true
+    sampling_rate: 1000000000.0
+    hardware_demodulation: true
+    integration_length: 1100
+    integration_mode: ssb
+    sequence_timeout: 60
+    acquisition_timeout: 60
+    scope_store_enabled: false
+    threshold: 0.00019330455351026057
+    threshold_rotation: 5.201538252600354
+    time_of_flight: 200
+  - identifier: 1
+    outputs:
+    - 0
+    intermediate_frequency: -35400000.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+    scope_acquire_trigger_mode: sequencer
+    scope_hardware_averaging: true
+    sampling_rate: 1000000000.0
+    hardware_demodulation: true
+    integration_length: 800
+    integration_mode: ssb
+    sequence_timeout: 60
+    acquisition_timeout: 60
+    scope_store_enabled: false
+    threshold: -0.0013627152056984203
+    threshold_rotation: 353.12433100338825
+    time_of_flight: 200
+  - identifier: 2
+    outputs:
+    - 0
+    intermediate_frequency: 113050000.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+    scope_acquire_trigger_mode: sequencer
+    scope_hardware_averaging: true
+    sampling_rate: 1000000000.0
+    hardware_demodulation: true
+    integration_length: 1450
+    integration_mode: ssb
+    sequence_timeout: 60
+    acquisition_timeout: 60
+    scope_store_enabled: false
+    threshold: -0.0021901530052229946
+    threshold_rotation: 34.548303895322995
+    time_of_flight: 200
+- name: QCM-RF
+  alias: QCM-RF1
+  out0_lo_freq: 6700000000.0
+  out0_lo_en: true
+  out0_att: 10
+  out0_offset_path0: 0.0
+  out0_offset_path1: 0.0
+  out1_lo_freq: 6000000000.0
+  out1_lo_en: true
+  out1_att: 10
+  out1_offset_path0: 0.0
+  out1_offset_path1: 0.0
+  awg_sequencers:
+  - identifier: 0
+    outputs:
+    - 0
+    intermediate_frequency: -62677972.561033
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+  - identifier: 1
+    outputs:
+    - 1
+    intermediate_frequency: -172000000.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+- name: QCM-RF
+  alias: QCM-RF2
+  out0_lo_freq: 5700000000.0
+  out0_lo_en: true
+  out0_att: 0
+  out0_offset_path0: 0.0
+  out0_offset_path1: 0.0
+  out1_lo_freq: 6000000000.0
+  out1_lo_en: true
+  out1_att: 0
+  out1_offset_path0: 0.0
+  out1_offset_path1: 0.0
+  awg_sequencers:
+  - identifier: 0
+    outputs:
+    - 0
+    intermediate_frequency: -95000000.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+  - identifier: 1
+    outputs:
+    - 1
+    intermediate_frequency: -136000000.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+- name: QCM-RF
+  alias: QCM-RF3
+  out0_lo_freq: 5080000000.0
+  out0_lo_en: false
+  out0_att: 10
+  out0_offset_path0: 0.0
+  out0_offset_path1: 0.0
+  out1_lo_freq: 5980000000.0
+  out1_lo_en: true
+  out1_att: 10
+  out1_offset_path0: 0.0
+  out1_offset_path1: 0.0
+  awg_sequencers:
+  - identifier: 0
+    outputs:
+    - 0
+    intermediate_frequency: -250000000.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+  - identifier: 1
+    outputs:
+    - 1
+    intermediate_frequency: -202000000.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+- name: QCM-RF
+  alias: QCM-RF4
+  out0_lo_freq: 5080000000.0
+  out0_lo_en: false
+  out0_att: 10
+  out0_offset_path0: 0.0
+  out0_offset_path1: 0.0
+  out1_lo_freq: 5980000000.0
+  out1_lo_en: true
+  out1_att: 10
+  out1_offset_path0: 0.0
+  out1_offset_path1: 0.0
+  awg_sequencers:
+  - identifier: 0
+    outputs:
+    - 0
+    intermediate_frequency: -250000000.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+  - identifier: 1
+    outputs:
+    - 1
+    intermediate_frequency: -202000000.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+- name: QCM-RF
+  alias: QCM-RF5
+  out0_lo_freq: 5080000000.0
+  out0_lo_en: false
+  out0_att: 10
+  out0_offset_path0: 0.0
+  out0_offset_path1: 0.0
+  out1_lo_freq: 5980000000.0
+  out1_lo_en: true
+  out1_att: 10
+  out1_offset_path0: 0.0
+  out1_offset_path1: 0.0
+  awg_sequencers:
+  - identifier: 0
+    outputs:
+    - 0
+    intermediate_frequency: -250000000.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+  - identifier: 1
+    outputs:
+    - 1
+    intermediate_frequency: -202000000.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+
+instrument_controllers:
+- name: qblox_cluster
+  alias: cluster_controller_0
+  connection:
+    name: tcp_ip
+    address: 192.168.4.24
+  modules:
+  - alias: QRM-RF1
+    slot_id: 1
+  - alias: QRM-RF2
+    slot_id: 2
+  - alias: QRM-RF3
+    slot_id: 3
+  - alias: QCM1
+    slot_id: 6
+  - alias: QCM2
+    slot_id: 7
+  - alias: QCM3
+    slot_id: 8
+  - alias: QCM-RF1
+    slot_id: 13
+  - alias: QCM-RF2
+    slot_id: 14
+  - alias: QCM-RF3
+    slot_id: 15
+  - alias: QCM-RF4
+    slot_id: 17
+  - alias: QCM-RF5
+    slot_id: 18
+  reset: true
+  reference_clock: internal

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pandas==1.5.3
 qibo==0.2.12
-qblox-instruments==0.11.2
+qblox-instruments==0.14.2
 qcodes==0.42.0
 qcodes_contrib_drivers==0.18.0
 PyVISA-py==0.7.1

--- a/src/qililab/instruments/qblox/qblox_qcm_rf.py
+++ b/src/qililab/instruments/qblox/qblox_qcm_rf.py
@@ -17,7 +17,7 @@
 from dataclasses import dataclass, field
 from typing import ClassVar
 
-from qblox_instruments.qcodes_drivers.qcm_qrm import QcmQrm
+from qblox_instruments.qcodes_drivers.module import Module as QcmQrm
 
 from qililab.instruments.decorators import check_device_initialized, log_set_parameter
 from qililab.instruments.utils import InstrumentFactory

--- a/src/qililab/instruments/qblox/qblox_qrm.py
+++ b/src/qililab/instruments/qblox/qblox_qrm.py
@@ -135,11 +135,11 @@ class QbloxQRM(QbloxModule):
         for sequencer in self.awg_sequencers:
             if sequencer.identifier in self.sequences:
                 sequencer_id = sequencer.identifier
-                flags = self.device.get_sequencer_state(
+                flags = self.device.get_sequencer_status(
                     sequencer=sequencer_id, timeout=cast(QbloxADCSequencer, sequencer).sequence_timeout
                 )
                 logger.info("Sequencer[%d] flags: \n%s", sequencer_id, flags)
-                self.device.get_acquisition_state(
+                self.device.get_acquisition_status(
                     sequencer=sequencer_id, timeout=cast(QbloxADCSequencer, sequencer).acquisition_timeout
                 )
 
@@ -180,7 +180,7 @@ class QbloxQRM(QbloxModule):
                 (sequencer for sequencer in self.awg_sequencers if sequencer.identifier == channel_id), None
             )
             if sequencer is not None and sequencer.identifier in self.sequences:
-                self.device.get_acquisition_state(
+                self.device.get_acquisition_status(
                     sequencer=sequencer.identifier,
                     timeout=cast(QbloxADCSequencer, sequencer).acquisition_timeout,
                 )

--- a/src/qililab/instruments/qblox/qblox_qrm_rf.py
+++ b/src/qililab/instruments/qblox/qblox_qrm_rf.py
@@ -17,7 +17,7 @@
 from dataclasses import dataclass, field
 from typing import ClassVar
 
-from qblox_instruments.qcodes_drivers.qcm_qrm import QcmQrm
+from qblox_instruments.qcodes_drivers.module import Module as QcmQrm
 
 from qililab.instruments.decorators import check_device_initialized, log_set_parameter
 from qililab.instruments.utils import InstrumentFactory

--- a/src/qililab/qprogram/qblox_compiler.py
+++ b/src/qililab/qprogram/qblox_compiler.py
@@ -147,6 +147,7 @@ class QbloxCompiler:
             Measure: self._handle_measure,
             Acquire: self._handle_acquire,
             Play: self._handle_play,
+            Block: self._handle_block,
         }
 
         self._qprogram: QProgram
@@ -603,6 +604,9 @@ class QbloxCompiler:
                 component=QPyInstructions.Play(index_I, index_Q, wait_time=duration)
             )
             self._buses[element.bus].marked_for_sync = True
+            
+    def _handle_block(self, element: Block):
+        pass
 
     @staticmethod
     def _get_reference_operation_of_loop(loop: Loop | ForLoop, starting_block: Block | None = None):

--- a/src/qililab/typings/instruments/qcm_qrm.py
+++ b/src/qililab/typings/instruments/qcm_qrm.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """Class QcmQrm"""
-from qblox_instruments.qcodes_drivers.qcm_qrm import QcmQrm as Driver_QcmQrm
+from qblox_instruments.qcodes_drivers.module import Module as Driver_QcmQrm
 
 from qililab.typings.instruments.device import Device
 

--- a/tests/instruments/qblox/test_qblox_qcm.py
+++ b/tests/instruments/qblox/test_qblox_qcm.py
@@ -30,7 +30,7 @@ def fixture_qrm(platform: Platform):
     qcm = cast(QbloxQCM, platform.get_element(alias="qcm"))
 
     sequencer_mock_spec = [
-        *Sequencer._get_required_parent_attr_names(),
+        *Sequencer._get_required_parent_qtm_attr_names(),
         "sync_en",
         "gain_awg_path0",
         "gain_awg_path1",
@@ -55,7 +55,7 @@ def fixture_qrm(platform: Platform):
     ]
 
     module_mock_spec = [
-        *QcmQrm._get_required_parent_attr_names(),
+        *QcmQrm._get_required_parent_qtm_attr_names(),
         "reference_source",
         "sequencer0",
         "sequencer1",

--- a/tests/instruments/qblox/test_qblox_qcm.py
+++ b/tests/instruments/qblox/test_qblox_qcm.py
@@ -16,7 +16,7 @@ from qililab.data_management import build_platform
 from qililab.typings import Parameter
 from typing import cast
 from qblox_instruments.qcodes_drivers.sequencer import Sequencer
-from qblox_instruments.qcodes_drivers.qcm_qrm import QcmQrm
+from qblox_instruments.qcodes_drivers.module import Module as QcmQrm
 
 
 @pytest.fixture(name="platform")

--- a/tests/instruments/qblox/test_qblox_qcm.py
+++ b/tests/instruments/qblox/test_qblox_qcm.py
@@ -30,7 +30,7 @@ def fixture_qrm(platform: Platform):
     qcm = cast(QbloxQCM, platform.get_element(alias="qcm"))
 
     sequencer_mock_spec = [
-        *Sequencer._get_required_parent_qtm_attr_names(),
+        *Sequencer._get_required_parent_attr_names(),
         "sync_en",
         "gain_awg_path0",
         "gain_awg_path1",

--- a/tests/instruments/qblox/test_qblox_qcm_rf.py
+++ b/tests/instruments/qblox/test_qblox_qcm_rf.py
@@ -30,7 +30,7 @@ def fixture_qrm(platform: Platform):
     qcm_rf = cast(QbloxQCMRF, platform.get_element(alias="qcm-rf"))
 
     sequencer_mock_spec = [
-        *Sequencer._get_required_parent_attr_names(),
+        *Sequencer._get_required_parent_qtm_attr_names(),
         "sync_en",
         "gain_awg_path0",
         "gain_awg_path1",
@@ -54,7 +54,7 @@ def fixture_qrm(platform: Platform):
     ]
 
     module_mock_spec = [
-        *QcmQrm._get_required_parent_attr_names(),
+        *QcmQrm._get_required_parent_qtm_attr_names(),
         "reference_source",
         "sequencer0",
         "sequencer1",

--- a/tests/instruments/qblox/test_qblox_qcm_rf.py
+++ b/tests/instruments/qblox/test_qblox_qcm_rf.py
@@ -30,7 +30,7 @@ def fixture_qrm(platform: Platform):
     qcm_rf = cast(QbloxQCMRF, platform.get_element(alias="qcm-rf"))
 
     sequencer_mock_spec = [
-        *Sequencer._get_required_parent_qtm_attr_names(),
+        *Sequencer._get_required_parent_attr_names(),
         "sync_en",
         "gain_awg_path0",
         "gain_awg_path1",

--- a/tests/instruments/qblox/test_qblox_qcm_rf.py
+++ b/tests/instruments/qblox/test_qblox_qcm_rf.py
@@ -16,7 +16,7 @@ from qililab.data_management import build_platform
 from qililab.typings import Parameter
 from typing import cast
 from qblox_instruments.qcodes_drivers.sequencer import Sequencer
-from qblox_instruments.qcodes_drivers.qcm_qrm import QcmQrm
+from qblox_instruments.qcodes_drivers.module import Module as QcmQrm
 
 
 @pytest.fixture(name="platform")

--- a/tests/instruments/qblox/test_qblox_qrm.py
+++ b/tests/instruments/qblox/test_qblox_qrm.py
@@ -376,8 +376,8 @@ class TestQbloxQRM:
 
         qrm.acquire_result()
 
-        assert qrm.device.get_sequencer_state.call_count == 2
-        assert qrm.device.get_acquisition_state.call_count == 2
+        assert qrm.device.get_sequencer_status.call_count == 2
+        assert qrm.device.get_acquisition_status.call_count == 2
         assert qrm.device.store_scope_acquisition.call_count == 1
         assert qrm.device.get_acquisitions.call_count == 2
         assert qrm.device.sequencers[0].sync_en.call_count == 1
@@ -400,7 +400,7 @@ class TestQbloxQRM:
 
         qrm.acquire_qprogram_results(acquisitions=qp_acqusitions, channel_id=0)
 
-        assert qrm.device.get_acquisition_state.call_count == 2
+        assert qrm.device.get_acquisition_status.call_count == 2
         assert qrm.device.store_scope_acquisition.call_count == 1
         assert qrm.device.get_acquisitions.call_count == 2
         assert qrm.device.delete_acquisition_data.call_count == 2

--- a/tests/instruments/qblox/test_qblox_qrm.py
+++ b/tests/instruments/qblox/test_qblox_qrm.py
@@ -16,7 +16,7 @@ from qililab.data_management import build_platform
 from qililab.typings import AcquireTriggerMode, IntegrationMode, Parameter
 from typing import cast
 from qblox_instruments.qcodes_drivers.sequencer import Sequencer
-from qblox_instruments.qcodes_drivers.qcm_qrm import QcmQrm
+from qblox_instruments.qcodes_drivers.module import Module as QcmQrm
 from qililab.qprogram.qblox_compiler import AcquisitionData
 
 

--- a/tests/instruments/qblox/test_qblox_qrm.py
+++ b/tests/instruments/qblox/test_qblox_qrm.py
@@ -31,7 +31,7 @@ def fixture_qrm(platform: Platform) -> QbloxQRM:
     qrm = cast(QbloxQRM, platform.get_element(alias="qrm"))
 
     sequencer_mock_spec = [
-        *Sequencer._get_required_parent_attr_names(),
+        *Sequencer._get_required_parent_qtm_attr_names(),
         "sync_en",
         "gain_awg_path0",
         "gain_awg_path1",
@@ -59,7 +59,7 @@ def fixture_qrm(platform: Platform) -> QbloxQRM:
     ]
 
     module_mock_spec = [
-        *QcmQrm._get_required_parent_attr_names(),
+        *QcmQrm._get_required_parent_qtm_attr_names(),
         "reference_source",
         "sequencer0",
         "sequencer1",

--- a/tests/instruments/qblox/test_qblox_qrm.py
+++ b/tests/instruments/qblox/test_qblox_qrm.py
@@ -31,7 +31,7 @@ def fixture_qrm(platform: Platform) -> QbloxQRM:
     qrm = cast(QbloxQRM, platform.get_element(alias="qrm"))
 
     sequencer_mock_spec = [
-        *Sequencer._get_required_parent_qtm_attr_names(),
+        *Sequencer._get_required_parent_attr_names(),
         "sync_en",
         "gain_awg_path0",
         "gain_awg_path1",

--- a/tests/instruments/qblox/test_qblox_qrm_rf.py
+++ b/tests/instruments/qblox/test_qblox_qrm_rf.py
@@ -30,7 +30,7 @@ def fixture_qrm(platform: Platform):
     qrm_rf = cast(QbloxQRMRF, platform.get_element(alias="qrm-rf"))
 
     sequencer_mock_spec = [
-        *Sequencer._get_required_parent_qtm_attr_names(),
+        *Sequencer._get_required_parent_attr_names(),
         "sync_en",
         "gain_awg_path0",
         "gain_awg_path1",

--- a/tests/instruments/qblox/test_qblox_qrm_rf.py
+++ b/tests/instruments/qblox/test_qblox_qrm_rf.py
@@ -30,7 +30,7 @@ def fixture_qrm(platform: Platform):
     qrm_rf = cast(QbloxQRMRF, platform.get_element(alias="qrm-rf"))
 
     sequencer_mock_spec = [
-        *Sequencer._get_required_parent_attr_names(),
+        *Sequencer._get_required_parent_qtm_attr_names(),
         "sync_en",
         "gain_awg_path0",
         "gain_awg_path1",
@@ -57,7 +57,7 @@ def fixture_qrm(platform: Platform):
     ]
 
     module_mock_spec = [
-        *QcmQrm._get_required_parent_attr_names(),
+        *QcmQrm._get_required_parent_qtm_attr_names(),
         "reference_source",
         "sequencer0",
         "sequencer1",

--- a/tests/instruments/qblox/test_qblox_qrm_rf.py
+++ b/tests/instruments/qblox/test_qblox_qrm_rf.py
@@ -16,7 +16,7 @@ from qililab.data_management import build_platform
 from qililab.typings import Parameter
 from typing import cast
 from qblox_instruments.qcodes_drivers.sequencer import Sequencer
-from qblox_instruments.qcodes_drivers.qcm_qrm import QcmQrm
+from qblox_instruments.qcodes_drivers.module import Module as QcmQrm
 
 
 @pytest.fixture(name="platform")


### PR DESCRIPTION
This PR brings an empty handler for Blocks in QProgram so the new block structure for preparation and measurement can be compiled.