### PR TITLE
Identifiers for QM are now converted into strings inside cofig file creation

### DIFF
--- a/src/qililab/instruments/quantum_machines/quantum_machines_cluster.py
+++ b/src/qililab/instruments/quantum_machines/quantum_machines_cluster.py
@@ -454,7 +454,7 @@ class QuantumMachinesCluster(Instrument):
     def turn_on(self):
         """Turns on the instrument."""
         if not self._is_connected_to_qm:
-            self._qm = self._qmm.open_qm(config=self._config, close_other_machines=True)
+            self._qm = self._qmm.open_qm(config=self._config, close_other_machines=False)
             self._compiled_program_cache = {}
             self._is_connected_to_qm = True
 
@@ -489,7 +489,7 @@ class QuantumMachinesCluster(Instrument):
             self._config = cast(DictQuaConfig, merged_configuration)
             # If we are already connected, reopen the connection with the new configuration
             if self._is_connected_to_qm:
-                self._qm = self._qmm.open_qm(config=self._config, close_other_machines=True)  # type: ignore[assignment]
+                self._qm = self._qmm.open_qm(config=self._config, close_other_machines=False)  # type: ignore[assignment]
                 self._compiled_program_cache = {}
 
     def run_octave_calibration(self):

--- a/src/qililab/instruments/quantum_machines/quantum_machines_cluster.py
+++ b/src/qililab/instruments/quantum_machines/quantum_machines_cluster.py
@@ -294,7 +294,7 @@ class QuantumMachinesCluster(Instrument):
             mixers = {}
 
             for element in self.elements:
-                bus_name = element["identifier"]
+                bus_name = str(element["identifier"])
                 element_dict: dict = {"operations": {}}
 
                 # Flux bus
@@ -454,7 +454,7 @@ class QuantumMachinesCluster(Instrument):
     def turn_on(self):
         """Turns on the instrument."""
         if not self._is_connected_to_qm:
-            self._qm = self._qmm.open_qm(config=self._config, close_other_machines=False)
+            self._qm = self._qmm.open_qm(config=self._config, close_other_machines=True)
             self._compiled_program_cache = {}
             self._is_connected_to_qm = True
 
@@ -489,7 +489,7 @@ class QuantumMachinesCluster(Instrument):
             self._config = cast(DictQuaConfig, merged_configuration)
             # If we are already connected, reopen the connection with the new configuration
             if self._is_connected_to_qm:
-                self._qm = self._qmm.open_qm(config=self._config, close_other_machines=False)  # type: ignore[assignment]
+                self._qm = self._qmm.open_qm(config=self._config, close_other_machines=True)  # type: ignore[assignment]
                 self._compiled_program_cache = {}
 
     def run_octave_calibration(self):

--- a/tests/instruments/quantum_machines/test_quantum_machines_cluster.py
+++ b/tests/instruments/quantum_machines/test_quantum_machines_cluster.py
@@ -349,6 +349,69 @@ def fixture_qmm_with_opx1000():
     return qmm
 
 
+@pytest.fixture(name="qmm_int_identifiers")
+def fixture_qmm_int_identifiers():
+    """Fixture that returns an instance a qililab wrapper for Quantum Machines Manager."""
+    settings = {
+        "alias": "qmm",
+        "address": "192.168.0.1",
+        "cluster": "cluster_0",
+        "controllers": [
+            {
+                "name": "con1",
+                "analog_outputs": [
+                    {"port": 1, "filter": {"feedforward": [0, 0, 0], "feedback": [0, 0, 0]}},
+                    {"port": 2},
+                    {"port": 3},
+                    {"port": 4},
+                    {"port": 5},
+                    {"port": 6},
+                    {"port": 7},
+                    {"port": 8},
+                    {"port": 9},
+                    {"port": 10},
+                ],
+                "analog_inputs": [{"port": 1}, {"port": 2}],
+                "digital_outputs": [{"port": 1}, {"port": 2}, {"port": 3}, {"port": 4}, {"port": 5}],
+            }
+        ],
+        "octaves": [],
+        "elements": [
+            {
+                "identifier": 1,
+                "mix_inputs": {
+                    "I": {"controller": "con1", "port": 1},
+                    "Q": {"controller": "con1", "port": 2},
+                    "lo_frequency": 6e9,
+                    "mixer_correction": [1.0, 0.0, 0.0, 1.0],
+                },
+                "intermediate_frequency": 6e9,
+            },
+            {
+                "identifier": 0,
+                "mix_inputs": {
+                    "I": {"controller": "con1", "port": 3},
+                    "Q": {"controller": "con1", "port": 4},
+                    "lo_frequency": 6e9,
+                    "mixer_correction": [1.0, 0.0, 0.0, 1.0],
+                },
+                "outputs": {"out1": {"controller": "con1", "port": 1}, "out2": {"controller": "con1", "port": 2}},
+                "time_of_flight": 40,
+                "smearing": 10,
+                "threshold_rotation": 0.5,
+                "threshold": 0.09,
+                "intermediate_frequency": 6e9,
+            },
+            {"identifier": "flux_q0", "single_input": {"controller": "con1", "port": 5}},
+        ],
+        "run_octave_calibration": False,
+    }
+    qmm = QuantumMachinesCluster(settings=settings)
+    qmm.device = MagicMock
+
+    return qmm
+
+
 @pytest.fixture(name="compilation_config")
 def fixture_compilation_config() -> dict:
     """Fixture that returns a configuration dictionary as the QuantumMachinesCompiler would."""
@@ -420,7 +483,8 @@ class TestQuantumMachinesCluster:
     @patch("qililab.instruments.quantum_machines.quantum_machines_cluster.QuantumMachinesManager")
     @patch("qililab.instruments.Instrument.initial_setup")
     @pytest.mark.parametrize(
-        "qmm_name", ["qmm", "qmm_with_octave", "qmm_with_octave_custom_connectivity", "qmm_with_opx1000"]
+        "qmm_name",
+        ["qmm", "qmm_with_octave", "qmm_with_octave_custom_connectivity", "qmm_with_opx1000", "qmm_int_identifiers"],
     )
     def test_initial_setup(self, mock_instrument_init: MagicMock, mock_init: MagicMock, qmm_name, request):
         """Test QMM class initialization."""
@@ -441,7 +505,8 @@ class TestQuantumMachinesCluster:
         assert qmm._config == qmm.settings.to_qua_config()
 
     @pytest.mark.parametrize(
-        "qmm_name", ["qmm", "qmm_with_octave", "qmm_with_octave_custom_connectivity", "qmm_with_opx1000"]
+        "qmm_name",
+        ["qmm", "qmm_with_octave", "qmm_with_octave_custom_connectivity", "qmm_with_opx1000", "qmm_int_identifiers"],
     )
     def test_settings(self, qmm_name, request):
         """Test QuantumMachinesClusterSettings have been set correctly"""
@@ -454,7 +519,8 @@ class TestQuantumMachinesCluster:
     @patch("qililab.instruments.quantum_machines.quantum_machines_cluster.QuantumMachinesManager")
     @patch("qililab.instruments.quantum_machines.quantum_machines_cluster.QuantumMachine")
     @pytest.mark.parametrize(
-        "qmm_name", ["qmm", "qmm_with_octave", "qmm_with_octave_custom_connectivity", "qmm_with_opx1000"]
+        "qmm_name",
+        ["qmm", "qmm_with_octave", "qmm_with_octave_custom_connectivity", "qmm_with_opx1000", "qmm_int_identifiers"],
     )
     def test_turn_on(self, mock_qmm, mock_qm, qmm_name, request):
         """Test turn_on method"""
@@ -476,7 +542,8 @@ class TestQuantumMachinesCluster:
     @patch("qililab.instruments.quantum_machines.quantum_machines_cluster.QuantumMachinesManager")
     @patch("qililab.instruments.quantum_machines.quantum_machines_cluster.QuantumMachine")
     @pytest.mark.parametrize(
-        "qmm_name", ["qmm", "qmm_with_octave", "qmm_with_octave_custom_connectivity", "qmm_with_opx1000"]
+        "qmm_name",
+        ["qmm", "qmm_with_octave", "qmm_with_octave_custom_connectivity", "qmm_with_opx1000", "qmm_int_identifiers"],
     )
     def test_turn_off(self, mock_qmm, mock_qm, qmm_name, request):
         """Test turn_off method"""


### PR DESCRIPTION
Very small PR. Before if you want to set an identifier as a numeric value qm-qua would crash stating that an int/float value cannot be the alias of an element. Now you can set the channel value to anything (i.e readout bus can have channel 1 also in QM, if you set the element correctly)