### PR TITLE
Checking maximum attenuation in RF modules

### DIFF
--- a/examples/runcards/contralto_saruman.yml
+++ b/examples/runcards/contralto_saruman.yml
@@ -1,0 +1,1209 @@
+name: contralto_saruman
+
+digital:
+  minimum_clock_time: 4
+  delay_before_readout: 4
+  topology: [[0, 2], [1, 2]]
+  gates:
+    M(0):
+    - bus: readout_q0_bus
+      pulse:
+        amplitude: 0.3
+        phase: 0
+        duration: 1100
+        shape:
+          name: rectangular
+      wait_time: 0
+    Drag(0):
+    - bus: drive_q0_bus
+      pulse:
+        amplitude: 0.09
+        phase: 0
+        duration: 40
+        shape:
+          name: drag
+          num_sigmas: 4
+          drag_coefficient: 0.0
+      wait_time: 0
+    M(1):
+    - bus: readout_q1_bus
+      pulse:
+        amplitude: 0.005
+        phase: 0
+        duration: 1000
+        shape:
+          name: rectangular
+      wait_time: 0
+    Drag(1):
+    - bus: drive_q1_bus
+      pulse:
+        amplitude: 0.1
+        phase: 0
+        duration: 40
+        shape:
+          name: drag
+          num_sigmas: 4
+          drag_coefficient: 0.0
+      wait_time: 0
+    M(2):
+    - bus: readout_q2_bus
+      pulse:
+        amplitude: 0.05
+        phase: 0
+        duration: 1200
+        shape:
+          name: rectangular
+      wait_time: 0
+    Drag(2):
+    - bus: drive_q2_bus
+      pulse:
+        amplitude: 0.0800294849776628
+        phase: 0
+        duration: 40
+        shape:
+          name: drag
+          num_sigmas: 4
+          drag_coefficient: -0.701105877213066
+      wait_time: 0
+    M(3):
+    - bus: readout_q3_bus
+      pulse:
+        amplitude: 0.14
+        phase: 0
+        duration: 600
+        shape:
+          name: rectangular
+      wait_time: 0
+    Drag(3):
+    - bus: drive_q3_bus
+      pulse:
+        amplitude: 0.81
+        phase: 0
+        duration: 40
+        shape:
+          name: drag
+          num_sigmas: 4
+          drag_coefficient: 0.0
+      wait_time: 0
+    M(4):
+    - bus: readout_q4_bus
+      pulse:
+        amplitude: 0.06
+        phase: 0
+        duration: 1450
+        shape:
+          name: rectangular
+      wait_time: 0
+    Drag(4):
+    - bus: drive_q4_bus
+      pulse:
+        amplitude: 0.42203210282437376
+        phase: 0
+        duration: 40
+        shape:
+          name: drag
+          num_sigmas: 4
+          drag_coefficient: 0.0
+      wait_time: 0
+    M(5):
+    - bus: readout_q5_bus
+      pulse:
+        amplitude: 0.084
+        phase: 0
+        duration: 1200
+        shape:
+          name: rectangular
+      wait_time: 0
+    Drag(5):
+    - bus: drive_q5_bus
+      pulse:
+        amplitude: 0.11699763555266803
+        phase: 0
+        duration: 40
+        shape:
+          name: drag
+          num_sigmas: 4
+          drag_coefficient: -1.603317473874127
+      wait_time: 0
+    M(6):
+    - bus: readout_q6_bus
+      pulse:
+        amplitude: 0.5
+        phase: 0
+        duration: 1100
+        shape:
+          name: rectangular
+      wait_time: 0
+    Drag(6):
+    - bus: drive_q6_bus
+      pulse:
+        amplitude: 0.2582073143992086
+        phase: 0
+        duration: 40
+        shape:
+          name: drag
+          num_sigmas: 4
+          drag_coefficient: 0.0
+      wait_time: 0
+    M(7):
+    - bus: readout_q7_bus
+      pulse:
+        amplitude: 0.5
+        phase: 0
+        duration: 1000
+        shape:
+          name: rectangular
+      wait_time: 0
+    Drag(7):
+    - bus: drive_q7_bus
+      pulse:
+        amplitude: 0.45
+        phase: 0
+        duration: 200
+        shape:
+          name: drag
+          num_sigmas: 4
+          drag_coefficient: 0.0
+      wait_time: 0
+    M(8):
+    - bus: readout_q8_bus
+      pulse:
+        amplitude: 0.0275
+        phase: 0
+        duration: 1350
+        shape:
+          name: rectangular
+      wait_time: 0
+    Drag(8):
+    - bus: drive_q8_bus
+      pulse:
+        amplitude: 0.7794436553880829
+        phase: 0
+        duration: 70
+        shape:
+          name: drag
+          num_sigmas: 4
+          drag_coefficient: 0.0
+      wait_time: 0
+    M(9):
+    - bus: readout_q9_bus
+      pulse:
+        amplitude: 0.03
+        phase: 0
+        duration: 1200
+        shape:
+          name: rectangular
+      wait_time: 0
+    Drag(9):
+    - bus: drive_q9_bus
+      pulse:
+        amplitude: 0.7689656971068248
+        phase: 0
+        duration: 100
+        shape:
+          name: drag
+          num_sigmas: 4
+          drag_coefficient: 1.6948356555250759
+      wait_time: 0
+    M(10):
+    - bus: readout_q10_bus
+      pulse:
+        amplitude: 0.02
+        phase: 0
+        duration: 600
+        shape:
+          name: rectangular
+      wait_time: 0
+    Drag(10):
+    - bus: drive_q10_bus
+      pulse:
+        amplitude: 0.8333333333333334
+        phase: 0
+        duration: 100
+        shape:
+          name: drag
+          num_sigmas: 4
+          drag_coefficient: 0.0
+      wait_time: 0
+    M(11):
+    - bus: readout_q11_bus
+      pulse:
+        amplitude: 0.06
+        phase: 0
+        duration: 1450
+        shape:
+          name: rectangular
+      wait_time: 0
+    Drag(11):
+    - bus: drive_q11_bus
+      pulse:
+        amplitude: 0.39
+        phase: 0
+        duration: 20
+        shape:
+          name: drag
+          num_sigmas: 4
+          drag_coefficient: 0.0
+      wait_time: 0
+    M(12):
+    - bus: readout_q12_bus
+      pulse:
+        amplitude: 0.004
+        phase: 0
+        duration: 1450
+        shape:
+          name: rectangular
+      wait_time: 0
+    Drag(12):
+    - bus: drive_q12_bus
+      pulse:
+        amplitude: 0.4666666666666667
+        phase: 0
+        duration: 20
+        shape:
+          name: drag
+          num_sigmas: 4
+          drag_coefficient: 0.0
+      wait_time: 0
+    M(13):
+    - bus: readout_q13_bus
+      pulse:
+        amplitude: 0.06
+        phase: 0
+        duration: 1450
+        shape:
+          name: rectangular
+      wait_time: 0
+    Drag(13):
+    - bus: drive_q13_bus
+      pulse:
+        amplitude: 0.21666666666666667
+        phase: 0
+        duration: 40
+        shape:
+          name: drag
+          num_sigmas: 4
+          drag_coefficient: 0.0
+      wait_time: 0
+    M(14):
+    - bus: readout_q14_bus
+      pulse:
+        amplitude: 0.06
+        phase: 0
+        duration: 1450
+        shape:
+          name: rectangular
+      wait_time: 0
+    Drag(14):
+    - bus: drive_q14_bus
+      pulse:
+        amplitude: 0.2
+        phase: 0
+        duration: 40
+        shape:
+          name: drag
+          num_sigmas: 4
+          drag_coefficient: 0.0
+      wait_time: 0
+    M(15):
+    - bus: readout_q15_bus
+      pulse:
+        amplitude: 0.06
+        phase: 0
+        duration: 1450
+        shape:
+          name: rectangular
+      wait_time: 0
+    Drag(15):
+    - bus: drive_q15_bus
+      pulse:
+        amplitude: 0.42203210282437376
+        phase: 0
+        duration: 40
+        shape:
+          name: drag
+          num_sigmas: 4
+          drag_coefficient: 0.0
+      wait_time: 0
+    CZ(8,5):
+    - bus: flux_q5_bus
+      pulse:
+        amplitude: 0.25326819341457385
+        phase: 0
+        duration: 37
+        shape:
+          name: rectangular
+        options:
+          q2_phase_correction: 0.13209531567724994
+          q4_phase_correction: 4.383143867822417
+      wait_time: 0
+    CZ(2,3):
+    - bus: flux_q3_bus
+      pulse:
+        amplitude: 0.40383424505801674
+        phase: 0
+        duration: 40
+        shape:
+          name: rectangular
+        options:
+          q2_phase_correction: 0.02736337729444749
+          q3_phase_correction: 4.996988524732117
+      wait_time: 0
+    CZ(0,2):
+    - bus: flux_q2_bus
+      pulse:
+        amplitude: 0.29030992367519076
+        phase: 0
+        duration: 32
+        shape:
+          name: rectangular
+        options:
+          q0_phase_correction: 0.04657474288915329
+          q2_phase_correction: 0.699572519801396
+      wait_time: 0
+    - bus: flux_q1_bus
+      pulse:
+        amplitude: 0.5
+        phase: 0
+        duration: 50
+        shape:
+          name: rectangular
+      wait_time: 0
+    CZ(1,2):
+    - bus: flux_q2_bus
+      pulse:
+        amplitude: 0.29685366875858216
+        phase: 0
+        duration: 32
+        shape:
+          name: rectangular
+        options:
+          q1_phase_correction: 0.06005184023506173
+          q2_phase_correction: 2.3145323313665687
+      wait_time: 8
+    - bus: flux_q0_bus
+      pulse:
+        amplitude: 0.5
+        phase: 0
+        duration: 50
+        shape:
+          name: rectangular
+      wait_time: 0
+  buses:
+    readout_q0_bus:
+      line: readout
+      qubits: [0]
+    readout_q1_bus:
+      line: readout
+      qubits: [1]
+    readout_q2_bus:
+      line: readout
+      qubits: [2]
+    readout_q3_bus:
+      line: readout
+      qubits: [3]
+    readout_q4_bus:
+      line: readout
+      qubits: [4]
+    readout_q5_bus:
+      line: readout
+      qubits: [5]
+    readout_q6_bus:
+      line: readout
+      qubits: [6]
+    readout_q7_bus:
+      line: readout
+      qubits: [7]
+    readout_q8_bus:
+      line: readout
+      qubits: [8]
+    readout_q9_bus:
+      line: readout
+      qubits: [9]
+    drive_q0_bus:
+      line: drive
+      qubits: [0]
+    drive_q1_bus:
+      line: drive
+      qubits: [1]
+    drive_q2_bus:
+      line: drive
+      qubits: [2]
+    drive_q3_bus:
+      line: drive
+      qubits: [3]
+    drive_q4_bus:
+      line: drive
+      qubits: [4]
+    drive_q5_bus:
+      line: drive
+      qubits: [5]
+    drive_q6_bus:
+      line: drive
+      qubits: [6]
+    drive_q7_bus:
+      line: drive
+      qubits: [7]
+    drive_q8_bus:
+      line: drive
+      qubits: [8]
+    drive_q9_bus:
+      line: drive
+      qubits: [9]
+    flux_q0_bus:
+      line: flux
+      qubits: [0]
+    flux_q1_bus:
+      line: flux
+      qubits: [1]
+    flux_q2_bus:
+      line: flux
+      qubits: [2]
+    flux_q3_bus:
+      line: flux
+      qubits: [3]
+    flux_q4_bus:
+      line: flux
+      qubits: [4]
+    flux_q5_bus:
+      line: flux
+      qubits: [5]
+    flux_q6_bus:
+      line: flux
+      qubits: [6]
+    flux_q7_bus:
+      line: flux
+      qubits: [7]
+    flux_q8_bus:
+      line: flux
+      qubits: [8]
+    flux_q9_bus:
+      line: flux
+      qubits: [9]
+
+buses:
+- alias: readout_q0_bus
+  instruments: [QRM-RF1]
+  channels: [0]
+- alias: readout_q1_bus
+  instruments: [QRM-RF1]
+  channels: [1]
+- alias: readout_q2_bus
+  instruments: [QRM-RF1]
+  channels: [2]
+- alias: readout_q3_bus
+  instruments: [QRM-RF1]
+  channels: [3]
+- alias: readout_q4_bus
+  instruments: [QRM-RF2]
+  channels: [0]
+- alias: readout_q5_bus
+  instruments: [QRM-RF2]
+  channels: [1]
+- alias: readout_q6_bus
+  instruments: [QRM-RF2]
+  channels: [2]
+- alias: readout_q7_bus
+  instruments: [QRM-RF3]
+  channels: [0]
+- alias: readout_q8_bus
+  instruments: [QRM-RF3]
+  channels: [1]
+- alias: readout_q9_bus
+  instruments: [QRM-RF3]
+  channels: [2]
+- alias: drive_q0_bus
+  instruments: [QCM-RF1]
+  channels: [0]
+- alias: flux_q0_bus
+  instruments: [QCM1]
+  channels: [0]
+- alias: drive_q1_bus
+  instruments: [QCM-RF1]
+  channels: [1]
+- alias: flux_q1_bus
+  instruments: [QCM1]
+  channels: [1]
+- alias: drive_q2_bus
+  instruments: [QCM-RF2]
+  channels: [0]
+- alias: flux_q2_bus
+  instruments: [QCM1]
+  channels: [2]
+- alias: drive_q3_bus
+  instruments: [QCM-RF2]
+  channels: [1]
+- alias: flux_q3_bus
+  instruments: [QCM1]
+  channels: [3]
+- alias: drive_q4_bus
+  instruments: [QCM-RF3]
+  channels: [0]
+- alias: flux_q4_bus
+  instruments: [QCM2]
+  channels: [0]
+- alias: drive_q5_bus
+  instruments: [QCM-RF3]
+  channels: [1]
+- alias: flux_q5_bus
+  instruments: [QCM2]
+  channels: [1]
+- alias: drive_q6_bus
+  instruments: [QCM-RF4]
+  channels: [0]
+- alias: flux_q6_bus
+  instruments: [QCM2]
+  channels: [2]
+- alias: drive_q7_bus
+  instruments: [QCM-RF4]
+  channels: [1]
+- alias: flux_q7_bus
+  instruments: [QCM2]
+  channels: [3]
+- alias: drive_q8_bus
+  instruments: [QCM-RF5]
+  channels: [0]
+- alias: flux_q8_bus
+  instruments: [QCM3]
+  channels: [0]
+- alias: drive_q9_bus
+  instruments: [QCM-RF5]
+  channels: [1]
+- alias: flux_q9_bus
+  instruments: [QCM3]
+  channels: [1]
+
+instruments:
+- name: QCM
+  alias: QCM1
+  out_offsets:
+  - 0.0
+  - 0.0
+  - 0.0
+  - 0.0
+  awg_sequencers:
+  - identifier: 0
+    outputs:
+    - 0
+    intermediate_frequency: 0.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+  - identifier: 1
+    outputs:
+    - 1
+    intermediate_frequency: 0.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+  - identifier: 2
+    outputs:
+    - 2
+    intermediate_frequency: 0.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+  - identifier: 3
+    outputs:
+    - 3
+    intermediate_frequency: 0.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+- name: QCM
+  alias: QCM2
+  out_offsets:
+  - 0.0
+  - -0.791623
+  - 0.0
+  - -0.3
+  awg_sequencers:
+  - identifier: 0
+    outputs:
+    - 0
+    intermediate_frequency: 0.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+  - identifier: 1
+    outputs:
+    - 1
+    intermediate_frequency: 0.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+  - identifier: 2
+    outputs:
+    - 2
+    intermediate_frequency: 0.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+  - identifier: 3
+    outputs:
+    - 3
+    intermediate_frequency: 0.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+- name: QCM
+  alias: QCM3
+  out_offsets:
+  - 0.1596
+  - 0.08
+  - 0.0
+  - 0.0
+  awg_sequencers:
+  - identifier: 0
+    outputs:
+    - 0
+    intermediate_frequency: 0.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+  - identifier: 1
+    outputs:
+    - 1
+    intermediate_frequency: 0.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+  - identifier: 2
+    outputs:
+    - 2
+    intermediate_frequency: 0.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+  - identifier: 3
+    outputs:
+    - 3
+    intermediate_frequency: 0.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+- name: QRM-RF
+  alias: QRM-RF1
+  out0_in0_lo_freq: 7375000000.0
+  out0_in0_lo_en: true
+  out0_in0_lo_freq_cal_type_default: off
+  out0_att: 30
+  in0_att: 0
+  out0_offset_path0: 0.0
+  out0_offset_path1: 0.0
+  awg_sequencers:
+  - identifier: 0
+    outputs:
+    - 0
+    intermediate_frequency: -218000000.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+    scope_acquire_trigger_mode: sequencer
+    scope_hardware_averaging: true
+    sampling_rate: 1000000000.0
+    hardware_demodulation: true
+    integration_length: 1100
+    integration_mode: ssb
+    sequence_timeout: 60
+    acquisition_timeout: 60
+    scope_store_enabled: false
+    threshold: 0.00019330455351026057
+    threshold_rotation: 5.201538252600354
+    time_of_flight: 200
+  - identifier: 1
+    outputs:
+    - 0
+    intermediate_frequency: -93300000.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+    scope_acquire_trigger_mode: sequencer
+    scope_hardware_averaging: true
+    sampling_rate: 1000000000.0
+    hardware_demodulation: true
+    integration_length: 800
+    integration_mode: ssb
+    sequence_timeout: 60
+    acquisition_timeout: 60
+    scope_store_enabled: false
+    threshold: -0.0013627152056984203
+    threshold_rotation: 353.12433100338825
+    time_of_flight: 200
+  - identifier: 2
+    outputs:
+    - 0
+    intermediate_frequency: 160050000.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+    scope_acquire_trigger_mode: sequencer
+    scope_hardware_averaging: true
+    sampling_rate: 1000000000.0
+    hardware_demodulation: true
+    integration_length: 1450
+    integration_mode: ssb
+    sequence_timeout: 60
+    acquisition_timeout: 60
+    scope_store_enabled: false
+    threshold: 0.0041298097225328555
+    threshold_rotation: 215.88559722553708
+    time_of_flight: 200
+  - identifier: 3
+    outputs:
+    - 0
+    intermediate_frequency: 158700000.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+    scope_acquire_trigger_mode: sequencer
+    scope_hardware_averaging: true
+    sampling_rate: 1000000000.0
+    hardware_demodulation: true
+    integration_length: 1200
+    integration_mode: ssb
+    sequence_timeout: 60
+    acquisition_timeout: 60
+    scope_store_enabled: false
+    threshold: 0.0012626504245012637
+    threshold_rotation: 302.69806249880776
+    time_of_flight: 200
+- name: QRM-RF
+  alias: QRM-RF2
+  out0_in0_lo_freq: 7315000000.0
+  out0_in0_lo_en: true
+  out0_in0_lo_freq_cal_type_default: off
+  out0_att: 26
+  in0_att: 0
+  out0_offset_path0: 0.0
+  out0_offset_path1: 0.0
+  awg_sequencers:
+  - identifier: 0
+    outputs:
+    - 0
+    intermediate_frequency: -144000000.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+    scope_acquire_trigger_mode: sequencer
+    scope_hardware_averaging: true
+    sampling_rate: 1000000000.0
+    hardware_demodulation: true
+    integration_length: 1100
+    integration_mode: ssb
+    sequence_timeout: 60
+    acquisition_timeout: 60
+    scope_store_enabled: false
+    threshold: 0.00019330455351026057
+    threshold_rotation: 5.201538252600354
+    time_of_flight: 200
+  - identifier: 1
+    outputs:
+    - 0
+    intermediate_frequency: 110100000.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+    scope_acquire_trigger_mode: sequencer
+    scope_hardware_averaging: true
+    sampling_rate: 1000000000.0
+    hardware_demodulation: true
+    integration_length: 800
+    integration_mode: ssb
+    sequence_timeout: 60
+    acquisition_timeout: 60
+    scope_store_enabled: false
+    threshold: 0.006255581643445415
+    threshold_rotation: 254.69395079446838
+    time_of_flight: 200
+  - identifier: 2
+    outputs:
+    - 0
+    intermediate_frequency: 33700000.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+    scope_acquire_trigger_mode: sequencer
+    scope_hardware_averaging: true
+    sampling_rate: 1000000000.0
+    hardware_demodulation: true
+    integration_length: 1400
+    integration_mode: ssb
+    sequence_timeout: 60
+    acquisition_timeout: 60
+    scope_store_enabled: false
+    threshold: 0.001313140102544695
+    threshold_rotation: 185.5597106455339
+    time_of_flight: 200
+- name: QRM-RF
+  alias: QRM-RF3
+  out0_in0_lo_freq: 7315000000.0
+  out0_in0_lo_en: true
+  out0_in0_lo_freq_cal_type_default: off
+  out0_att: 30
+  in0_att: 0
+  out0_offset_path0: 0.0
+  out0_offset_path1: 0.0
+  awg_sequencers:
+  - identifier: 0
+    outputs:
+    - 0
+    intermediate_frequency: -151400000.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+    scope_acquire_trigger_mode: sequencer
+    scope_hardware_averaging: true
+    sampling_rate: 1000000000.0
+    hardware_demodulation: true
+    integration_length: 1100
+    integration_mode: ssb
+    sequence_timeout: 60
+    acquisition_timeout: 60
+    scope_store_enabled: false
+    threshold: 0.00019330455351026057
+    threshold_rotation: 5.201538252600354
+    time_of_flight: 200
+  - identifier: 1
+    outputs:
+    - 0
+    intermediate_frequency: -35400000.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+    scope_acquire_trigger_mode: sequencer
+    scope_hardware_averaging: true
+    sampling_rate: 1000000000.0
+    hardware_demodulation: true
+    integration_length: 800
+    integration_mode: ssb
+    sequence_timeout: 60
+    acquisition_timeout: 60
+    scope_store_enabled: false
+    threshold: -0.0013627152056984203
+    threshold_rotation: 353.12433100338825
+    time_of_flight: 200
+  - identifier: 2
+    outputs:
+    - 0
+    intermediate_frequency: 113050000.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+    scope_acquire_trigger_mode: sequencer
+    scope_hardware_averaging: true
+    sampling_rate: 1000000000.0
+    hardware_demodulation: true
+    integration_length: 1450
+    integration_mode: ssb
+    sequence_timeout: 60
+    acquisition_timeout: 60
+    scope_store_enabled: false
+    threshold: -0.0021901530052229946
+    threshold_rotation: 34.548303895322995
+    time_of_flight: 200
+- name: QCM-RF
+  alias: QCM-RF1
+  out0_lo_freq: 6700000000.0
+  out0_lo_en: true
+  out0_lo_freq_cal_type_default: off
+  out0_att: 10
+  out0_offset_path0: 0.0
+  out0_offset_path1: 0.0
+  out1_lo_freq: 6000000000.0
+  out1_lo_en: true
+  out1_lo_freq_cal_type_default: off
+  out1_att: 10
+  out1_offset_path0: 0.0
+  out1_offset_path1: 0.0
+  awg_sequencers:
+  - identifier: 0
+    outputs:
+    - 0
+    intermediate_frequency: -62677972.561033
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+  - identifier: 1
+    outputs:
+    - 1
+    intermediate_frequency: -172000000.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+- name: QCM-RF
+  alias: QCM-RF2
+  out0_lo_freq: 5700000000.0
+  out0_lo_en: true
+  out0_lo_freq_cal_type_default: off
+  out0_att: 0
+  out0_offset_path0: 0.0
+  out0_offset_path1: 0.0
+  out1_lo_freq: 6000000000.0
+  out1_lo_en: true
+  out1_lo_freq_cal_type_default: off
+  out1_att: 0
+  out1_offset_path0: 0.0
+  out1_offset_path1: 0.0
+  awg_sequencers:
+  - identifier: 0
+    outputs:
+    - 0
+    intermediate_frequency: -95000000.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+  - identifier: 1
+    outputs:
+    - 1
+    intermediate_frequency: -136000000.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+- name: QCM-RF
+  alias: QCM-RF3
+  out0_lo_freq: 5080000000.0
+  out0_lo_en: false
+  out0_lo_freq_cal_type_default: off
+  out0_att: 10
+  out0_offset_path0: 0.0
+  out0_offset_path1: 0.0
+  out1_lo_freq: 5980000000.0
+  out1_lo_en: true
+  out1_lo_freq_cal_type_default: off
+  out1_att: 10
+  out1_offset_path0: 0.0
+  out1_offset_path1: 0.0
+  awg_sequencers:
+  - identifier: 0
+    outputs:
+    - 0
+    intermediate_frequency: -250000000.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+  - identifier: 1
+    outputs:
+    - 1
+    intermediate_frequency: -202000000.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+- name: QCM-RF
+  alias: QCM-RF4
+  out0_lo_freq: 5080000000.0
+  out0_lo_en: false
+  out0_lo_freq_cal_type_default: off
+  out0_att: 10
+  out0_offset_path0: 0.0
+  out0_offset_path1: 0.0
+  out1_lo_freq: 5980000000.0
+  out1_lo_en: true
+  out1_lo_freq_cal_type_default: off
+  out1_att: 10
+  out1_offset_path0: 0.0
+  out1_offset_path1: 0.0
+  awg_sequencers:
+  - identifier: 0
+    outputs:
+    - 0
+    intermediate_frequency: -250000000.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+  - identifier: 1
+    outputs:
+    - 1
+    intermediate_frequency: -202000000.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+- name: QCM-RF
+  alias: QCM-RF5
+  out0_lo_freq: 5080000000.0
+  out0_lo_en: false
+  out0_lo_freq_cal_type_default: off
+  out0_att: 10
+  out0_offset_path0: 0.0
+  out0_offset_path1: 0.0
+  out1_lo_freq: 5980000000.0
+  out1_lo_en: true
+  out1_lo_freq_cal_type_default: off
+  out1_att: 10
+  out1_offset_path0: 0.0
+  out1_offset_path1: 0.0
+  awg_sequencers:
+  - identifier: 0
+    outputs:
+    - 0
+    intermediate_frequency: -250000000.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+  - identifier: 1
+    outputs:
+    - 1
+    intermediate_frequency: -202000000.0
+    gain_imbalance: 1.0
+    phase_imbalance: 0.0
+    hardware_modulation: true
+    gain_i: 1.0
+    gain_q: 1.0
+    offset_i: 0.0
+    offset_q: 0.0
+
+instrument_controllers:
+- name: qblox_cluster
+  alias: cluster_controller_0
+  connection:
+    name: tcp_ip
+    address: 192.168.4.24
+  modules:
+  - alias: QRM-RF1
+    slot_id: 1
+  - alias: QRM-RF2
+    slot_id: 2
+  - alias: QRM-RF3
+    slot_id: 3
+  - alias: QCM1
+    slot_id: 6
+  - alias: QCM2
+    slot_id: 7
+  - alias: QCM3
+    slot_id: 8
+  - alias: QCM-RF1
+    slot_id: 13
+  - alias: QCM-RF2
+    slot_id: 14
+  - alias: QCM-RF3
+    slot_id: 15
+  - alias: QCM-RF4
+    slot_id: 17
+  - alias: QCM-RF5
+    slot_id: 18
+  reset: true
+  reference_clock: internal

--- a/examples/test_attenuation.ipynb
+++ b/examples/test_attenuation.ipynb
@@ -1,0 +1,59 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2024-12-02 14:17:52,282 - qm - INFO     - Starting session: eed366f2-b65e-4468-8f8f-839c17c01896\n"
+     ]
+    }
+   ],
+   "source": [
+    "import qililab as ql\n",
+    "\n",
+    "ql.logger.setLevel(40)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "platform_path = \"./runcards/contralto_saruman.yml\"\n",
+    "\n",
+    "platform = ql.build_platform(runcard=platform_path)\n",
+    "platform.connect()\n",
+    "platform.initial_setup()\n",
+    "platform.turn_on_instruments()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "qililab",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/src/qililab/instruments/qblox/qblox_qcm_rf.py
+++ b/src/qililab/instruments/qblox/qblox_qcm_rf.py
@@ -104,6 +104,14 @@ class QbloxQCMRF(QbloxQCM):
 
             parameter = Parameter(f"out{sequencer.outputs[0]}_lo_freq")
 
+        if parameter == Parameter.OUT0_ATT or parameter == Parameter.OUT1_ATT:
+            max_att = self.device.__get_max_out_att_0()
+            if parameter.value > max_att:
+                raise Exception(
+                    f"Attenuation for this module cannot be higher than {max_att}"
+                    "Please specify an attenuation level, multiple of 2, below this value."
+                )
+
         if parameter in self.parameters:
             setattr(self.settings, parameter.value, value)
             if self.is_device_active():

--- a/src/qililab/instruments/qblox/qblox_qcm_rf.py
+++ b/src/qililab/instruments/qblox/qblox_qcm_rf.py
@@ -104,11 +104,19 @@ class QbloxQCMRF(QbloxQCM):
 
             parameter = Parameter(f"out{sequencer.outputs[0]}_lo_freq")
 
-        if parameter == Parameter.OUT0_ATT or parameter == Parameter.OUT1_ATT:
-            max_att = self.device.__get_max_out_att_0()
-            if parameter.value > max_att:
+        if parameter == Parameter.OUT0_ATT:
+            max_att = self.device._get_max_out_att_0()
+            if value > max_att:
                 raise Exception(
-                    f"Attenuation for this module cannot be higher than {max_att}"
+                    f"`{Parameter.OUT0_ATT}` for this module cannot be higher than {max_att}dB.\n"
+                    "Please specify an attenuation level, multiple of 2, below this value."
+                )
+                
+        if parameter == Parameter.OUT1_ATT:
+            max_att = self.device._get_max_out_att_1()
+            if value > max_att:
+                raise Exception(
+                    f"`{Parameter.OUT1_ATT}` for this module cannot be higher than {max_att}dB.\n"
                     "Please specify an attenuation level, multiple of 2, below this value."
                 )
 

--- a/src/qililab/instruments/qblox/qblox_qrm_rf.py
+++ b/src/qililab/instruments/qblox/qblox_qrm_rf.py
@@ -87,6 +87,14 @@ class QbloxQRMRF(QbloxQRM):
         if parameter == Parameter.LO_FREQUENCY:
             parameter = Parameter.OUT0_IN0_LO_FREQ
 
+        if parameter == Parameter.OUT0_ATT:
+            max_att = self.device._get_max_out_att_0()
+            if value > max_att:
+                raise Exception(
+                    f"`{Parameter.OUT0_ATT}` for this module cannot be higher than {max_att}dB.\n"
+                    "Please specify an attenuation level, multiple of 2, below this value."
+                )
+
         if parameter in self.parameters:
             setattr(self.settings, parameter.value, value)
 

--- a/tests/instruments/qblox/test_qblox_qcm_rf.py
+++ b/tests/instruments/qblox/test_qblox_qcm_rf.py
@@ -80,6 +80,8 @@ def fixture_qrm(platform: Platform):
     # Create a mock device using create_autospec to follow the interface of the expected device
     qcm_rf.device = MagicMock()
     qcm_rf.device.mock_add_spec(module_mock_spec)
+    qcm_rf.device._get_max_out_att_0 = MagicMock(return_value=30)
+    qcm_rf.device._get_max_out_att_1 = MagicMock(return_value=30)
 
     qcm_rf.device.sequencers = {
         0: MagicMock(),
@@ -193,6 +195,12 @@ class TestQbloxQCMRF:
 
         with pytest.raises(Exception):
             qcm_rf.set_parameter(Parameter.LO_FREQUENCY, value=5e9, channel_id=None)
+
+        with pytest.raises(Exception):
+            qcm_rf.set_parameter(Parameter.OUT0_ATT, value=40, channel_id=None)
+
+        with pytest.raises(Exception):
+            qcm_rf.set_parameter(Parameter.OUT1_ATT, value=40, channel_id=None)
 
     @pytest.mark.parametrize(
         "parameter, expected_value",

--- a/tests/instruments/qblox/test_qblox_qrm_rf.py
+++ b/tests/instruments/qblox/test_qblox_qrm_rf.py
@@ -83,6 +83,8 @@ def fixture_qrm(platform: Platform):
     # Create a mock device using create_autospec to follow the interface of the expected device
     qrm_rf.device = MagicMock()
     qrm_rf.device.mock_add_spec(module_mock_spec)
+    qrm_rf.device._get_max_out_att_0 = MagicMock(return_value=30)
+    qrm_rf.device._get_max_out_att_1 = MagicMock(return_value=30)
 
     qrm_rf.device.sequencers = {
         0: MagicMock(),
@@ -187,6 +189,9 @@ class TestQbloxQRMRF:
         """Test setting parameters for QCM sequencers using parameterized values."""
         with pytest.raises(ParameterNotFound):
             qrm_rf.set_parameter(parameter, value, channel_id=0)
+  
+        with pytest.raises(Exception):
+            qrm_rf.set_parameter(Parameter.OUT0_ATT, value=40, channel_id=None)
 
     @pytest.mark.parametrize(
         "parameter, expected_value",


### PR DESCRIPTION
This PR brings a check for the maximum attenuation in the RF modules of the Qblox Cluster. If the attenuation in the runcard is set to a higher value than the maximum allowed, it will raise an Exception so experimentalists are aware of the instrumentation limitations in the rack.