### PR TITLE
setting to zero only dacs from runcard

### DIFF
--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -14,3 +14,6 @@
 
 - Fixed an issue where appending a configuration to an open QM instance left it hanging. The QM now properly closes before reopening with the updated configuration.
   [#851](https://github.com/qilimanjaro-tech/qililab/pull/851)
+
+- Fixed an issue where turning off voltage/current source instruments would set to zero all dacs instead of only the ones specified in the runcard.
+  [#819](https://github.com/qilimanjaro-tech/qililab/pull/819)

--- a/src/qililab/instruments/qblox/qblox_d5a.py
+++ b/src/qililab/instruments/qblox/qblox_d5a.py
@@ -161,9 +161,9 @@ class QbloxD5a(VoltageSource):
     @check_device_initialized
     def turn_off(self):
         """Stop outputing voltage."""
-        self.device.set_dacs_zero()
         for dac_index in self.settings.dacs:
             channel = self.dac(dac_index=dac_index)
+            channel.voltage(0)
             logger.debug("Dac%d voltage resetted to  %f", dac_index, channel.voltage())
 
     @check_device_initialized

--- a/src/qililab/instruments/qblox/qblox_s4g.py
+++ b/src/qililab/instruments/qblox/qblox_s4g.py
@@ -171,9 +171,9 @@ class QbloxS4g(CurrentSource):
     @check_device_initialized
     def turn_off(self):
         """Stop outputing current."""
-        self.device.set_dacs_zero()
         for dac_index in self.settings.dacs:
             channel = self.dac(dac_index=dac_index)
+            channel.current(0)
             logger.debug("Dac%d current resetted to  %f", dac_index, channel.current())
 
     @check_device_initialized


### PR DESCRIPTION
This PR fixes the bug where all dac channels are set to zero in the current and voltage sources when turning the instrument off.