### PR TITLE
[QHC-830] Make `routing` optional & not run by default

### DIFF
--- a/src/qililab/digital/circuit_transpiler.py
+++ b/src/qililab/digital/circuit_transpiler.py
@@ -55,6 +55,7 @@ class CircuitTranspiler:
     def transpile_circuits(
         self,
         circuits: list[Circuit],
+        routing: bool = False,
         placer: Placer | type[Placer] | tuple[type[Placer], dict] | None = None,
         router: Router | type[Router] | tuple[type[Router], dict] | None = None,
         routing_iterations: int = 10,
@@ -115,6 +116,7 @@ class CircuitTranspiler:
 
         Args:
             circuits (list[Circuit]): list of qibo circuits.
+            routing (bool, optional): whether to route the circuits. Defaults to False.
             placer (Placer | type[Placer] | tuple[type[Placer], dict], optional): `Placer` instance, or subclass `type[Placer]` to
                 use, with optionally, its kwargs dict (other than connectivity), both in a tuple. Defaults to `ReverseTraversal`.
             router (Router | type[Router] | tuple[type[Router], dict], optional): `Router` instance, or subclass `type[Router]` to
@@ -127,10 +129,14 @@ class CircuitTranspiler:
         """
 
         # Routing stage;
-        routed_circuits, final_layouts = zip(
-            *(self.route_circuit(circuit, placer, router, iterations=routing_iterations) for circuit in circuits)
-        )
-        logger.info(f"Circuits final layouts: {final_layouts}")
+        if routing:
+            routed_circuits, final_layouts = zip(
+                *(self.route_circuit(circuit, placer, router, iterations=routing_iterations) for circuit in circuits)
+            )
+            logger.info(f"Circuits final layouts: {final_layouts}")
+        else:
+            routed_circuits = tuple(circuits)
+            final_layouts = tuple({i: i for i in range(circuit.nqubits)} for circuit in circuits)
 
         # Optimze qibo gates, cancellating redundant gates, stage:
         if optimize:

--- a/src/qililab/execute_circuit.py
+++ b/src/qililab/execute_circuit.py
@@ -28,6 +28,7 @@ def execute(
     program: Circuit | list[Circuit],
     runcard: str | dict,
     nshots: int = 1,
+    routing: bool = False,
     placer: Placer | type[Placer] | tuple[type[Placer], dict] | None = None,
     router: Router | type[Router] | tuple[type[Router], dict] | None = None,
     routing_iterations: int = 10,
@@ -56,6 +57,7 @@ def execute(
         runcard (str | dict): If a string, path to the YAML file containing the serialization of the Platform to be
             used. If a dictionary, the serialized platform to be used.
         nshots (int, optional): Number of shots to execute. Defaults to 1.
+        routing (bool, optional): whether to route the circuits. Defaults to False.
         placer (Placer | type[Placer] | tuple[type[Placer], dict], optional): `Placer` instance, or subclass `type[Placer]` to
             use`, with optionally, its kwargs dict (other than connectivity), both in a tuple. Defaults to `ReverseTraversal`.
         router (Router | type[Router] | tuple[type[Router], dict], optional): `Router` instance, or subclass `type[Router]` to
@@ -108,6 +110,7 @@ def execute(
                 num_avg=1,
                 repetition_duration=200_000,
                 num_bins=nshots,
+                routing=routing,
                 placer=placer,
                 router=router,
                 routing_iterations=routing_iterations,

--- a/src/qililab/platform/platform.py
+++ b/src/qililab/platform/platform.py
@@ -1005,6 +1005,7 @@ class Platform:
         repetition_duration: int,
         num_bins: int = 1,
         queue: Queue | None = None,
+        routing: bool = False,
         placer: Placer | type[Placer] | tuple[type[Placer], dict] | None = None,
         router: Router | type[Router] | tuple[type[Router], dict] | None = None,
         routing_iterations: int = 10,
@@ -1036,6 +1037,7 @@ class Platform:
             repetition_duration (int): Minimum duration of a single execution.
             num_bins (int, optional): Number of bins used. Defaults to 1.
             queue (Queue, optional): External queue used for asynchronous data handling. Defaults to None.
+            routing (bool, optional): whether to route the circuits. Defaults to False.
             placer (Placer | type[Placer] | tuple[type[Placer], dict], optional): `Placer` instance, or subclass `type[Placer]` to
                 use, with optionally, its kwargs dict (other than connectivity), both in a tuple. Defaults to `ReverseTraversal`.
             router (Router | type[Router] | tuple[type[Router], dict], optional): `Router` instance, or subclass `type[Router]` to
@@ -1054,7 +1056,7 @@ class Platform:
         """
         # Compile pulse schedule
         programs, final_layout = self.compile(
-            program, num_avg, repetition_duration, num_bins, placer, router, routing_iterations, optimize
+            program, num_avg, repetition_duration, num_bins, routing, placer, router, routing_iterations, optimize
         )
 
         # Upload pulse schedule
@@ -1147,6 +1149,7 @@ class Platform:
         num_avg: int,
         repetition_duration: int,
         num_bins: int,
+        routing: bool = False,
         placer: Placer | type[Placer] | tuple[type[Placer], dict] | None = None,
         router: Router | type[Router] | tuple[type[Router], dict] | None = None,
         routing_iterations: int = 10,
@@ -1178,6 +1181,7 @@ class Platform:
             num_avg (int): Number of hardware averages used.
             repetition_duration (int): Minimum duration of a single execution.
             num_bins (int): Number of bins used.
+            routing (bool, optional): whether to route the circuits. Defaults to False.
             placer (Placer | type[Placer] | tuple[type[Placer], dict], optional): `Placer` instance, or subclass `type[Placer]` to
                 use, with optionally, its kwargs dict (other than connectivity), both in a tuple. Defaults to `ReverseTraversal`.
             router (Router | type[Router] | tuple[type[Router], dict], optional): `Router` instance, or subclass `type[Router]` to
@@ -1199,7 +1203,7 @@ class Platform:
             transpiler = CircuitTranspiler(settings=self.digital_compilation_settings)
 
             transpiled_circuits, final_layouts = transpiler.transpile_circuits(
-                [program], placer, router, routing_iterations, optimize
+                [program], routing, placer, router, routing_iterations, optimize
             )
             pulse_schedule, final_layout = transpiled_circuits[0], final_layouts[0]
 

--- a/tests/digital/test_circuit_transpiler.py
+++ b/tests/digital/test_circuit_transpiler.py
@@ -673,8 +673,9 @@ class TestCircuitTranspiler:
         mock_to_pulses.return_value = [mock_schedule]
 
         circuit = random_circuit(5, 10, np.random.default_rng())
+        routing = True
 
-        list_schedules, list_layouts = transpiler.transpile_circuits([circuit]*list_size, placer, router, routing_iterations, optimize=optimize)
+        list_schedules, list_layouts = transpiler.transpile_circuits([circuit]*list_size, routing, placer, router, routing_iterations, optimize=optimize)
 
         # Asserts:
         # The next two functions get called for individual circuits:
@@ -693,6 +694,12 @@ class TestCircuitTranspiler:
         else:
             mock_opt_circuit.assert_not_called()
             mock_opt_trans.assert_not_called()
+
+        # If routing skipped:
+        routing = False
+        mock_route.reset_mock()
+        list_schedules, list_layouts = transpiler.transpile_circuits([circuit]*list_size, routing, placer, router, routing_iterations, optimize=optimize)
+        mock_route.assert_not_called()
 
     @patch("qililab.digital.circuit_router.CircuitRouter.route")
     def test_route_circuit(self, mock_route, digital_settings):


### PR DESCRIPTION
Makes `routing` optional & not run by default.
 (To run the routing, pass flag `routing=True` manually)