### PR TITLE
[QHC-831] Implement Square Waveform Optmization

### DIFF
--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -2,6 +2,14 @@
 
 ### New features since last release
 
+- We have introduced an optimization in the QbloxCompiler that significantly reduces memory usage when compiling square waveforms. The compiler now uses a heuristic algorithm that segments long waveforms into smaller chunks and loops over them. This optimization follows a two-pass search:
+
+  1. **First Pass**: The compiler tries to find a chunk duration that divides the total waveform length evenly (i.e., remainder = 0).
+  1. **Second Pass**: If no exact divisor is found, it looks for a chunk duration that leaves a remainder of at least 4 ns. This leftover chunk is large enough to be stored or handled separately.
+
+  Each chunk duration is restricted to the range (\[100, 500\]) ns, ensuring that chunks are neither too small (leading to excessive repetitions) nor too large (risking out-of-memory issues). If no duration within (\[100, 500\]) ns meets these remainder constraints, the compiler defaults to using the original waveform in its entirety.
+  [#861](https://github.com/qilimanjaro-tech/qililab/pull/861)
+
 ### Improvements
 
 ### Breaking changes

--- a/src/qililab/qprogram/qblox_compiler.py
+++ b/src/qililab/qprogram/qblox_compiler.py
@@ -717,27 +717,27 @@ class QbloxCompiler:
 
     @staticmethod
     def calculate_square_waveform_optimization_values(duration):
-        def remainder_conditions(pd):
-            rem = duration % pd
-            return rem, (pd >= 4 and (rem == 0 or rem >= 4))
+        def remainder_conditions(chunk_duration):
+            remainder = duration % chunk_duration
+            return remainder, (chunk_duration >= 4 and (remainder == 0 or remainder >= 4))
 
-        def find_piece_duration(condition_func):
-            for pd in range(100, 501):
-                if pd <= duration:
-                    rem, valid = remainder_conditions(pd)
-                    if valid and condition_func(rem):
-                        return pd
+        def find_chunk_duration(condition_func):
+            for chunk_duration in range(100, 501):
+                if chunk_duration <= duration:
+                    remainder, valid = remainder_conditions(chunk_duration)
+                    if valid and condition_func(remainder):
+                        return chunk_duration
             return None
 
         # First try for remainder == 0
-        final_pd = find_piece_duration(lambda rem: rem == 0)
-        if final_pd is not None:
-            return final_pd, duration // final_pd, duration % final_pd
+        final_chunk_duration = find_chunk_duration(lambda rem: rem == 0)
+        if final_chunk_duration is not None:
+            return final_chunk_duration, duration // final_chunk_duration, duration % final_chunk_duration
 
         # If not found, try for remainder ≥ 4
-        final_pd = find_piece_duration(lambda rem: rem >= 4)
-        if final_pd is not None:
-            return final_pd, duration // final_pd, duration % final_pd
+        final_chunk_duration = find_chunk_duration(lambda rem: rem >= 4)
+        if final_chunk_duration is not None:
+            return final_chunk_duration, duration // final_chunk_duration, duration % final_chunk_duration
 
         # If no suitable piece_duration found, fallback to entire duration
         return duration, 1, 0

--- a/src/qililab/qprogram/qblox_compiler.py
+++ b/src/qililab/qprogram/qblox_compiler.py
@@ -612,6 +612,7 @@ class QbloxCompiler:
             self.optimize_square_waveforms
             and isinstance(waveform_I, Square)
             and (waveform_Q is None or isinstance(waveform_Q, Square))
+            and (waveform_I.duration >= 100)
         ):
             duration = waveform_I.duration
             chunk_duration, iterations, remainder = QbloxCompiler.calculate_square_waveform_optimization_values(

--- a/src/qililab/qprogram/qblox_compiler.py
+++ b/src/qililab/qprogram/qblox_compiler.py
@@ -715,23 +715,13 @@ class QbloxCompiler:
         return f"{waveform.__class__.__name__} {hashes}"
 
     @staticmethod
-    def calculate_ideal_coeff(duration):
-        if duration <= 1e3:
-            return 10
-        if duration <= 1e5:
-            return 100
-        if duration <= 1e7:
-            return 1000
-        return 10000
-
-    @staticmethod
     def calculate_square_waveform_optimization_values(duration):
         def remainder_conditions(pd):
             rem = duration % pd
             return rem, (pd >= 4 and (rem == 0 or rem >= 4))
 
         def find_piece_duration(condition_func):
-            for pd in range(100, 1101):
+            for pd in range(100, 501):
                 if pd <= duration:
                     rem, valid = remainder_conditions(pd)
                     if valid and condition_func(rem):

--- a/src/qililab/qprogram/qblox_compiler.py
+++ b/src/qililab/qprogram/qblox_compiler.py
@@ -24,6 +24,7 @@ import qpysequence.program as QPyProgram
 import qpysequence.program.instructions as QPyInstructions
 from qpysequence.utils.constants import INST_MAX_WAIT
 
+from qililab.config import logger
 from qililab.qprogram.blocks import Average, Block, ForLoop, InfiniteLoop, Loop, Parallel
 from qililab.qprogram.calibration import Calibration
 from qililab.qprogram.operations import (
@@ -42,7 +43,7 @@ from qililab.qprogram.operations import (
 )
 from qililab.qprogram.qprogram import QProgram
 from qililab.qprogram.variable import Variable
-from qililab.waveforms import IQPair, Waveform
+from qililab.waveforms import IQPair, Square, Waveform
 
 
 @dataclass
@@ -107,6 +108,7 @@ class BusCompilationInfo:
         self.next_acquisition_index = 0
         self.loop_counter = 0
         self.average_counter = 0
+        self.square_optimization_counter = 0
 
         # Syncing durations
         self.static_duration = 0
@@ -162,6 +164,7 @@ class QbloxCompiler:
         times_of_flight: dict[str, int] | None = None,
         delays: dict[str, int] | None = None,
         markers: dict[str, str] | None = None,
+        optimize_square_waveforms: bool = False,
     ) -> QbloxCompilationOutput:
         """Compile QProgram to qpysequence.Sequence
 
@@ -216,6 +219,7 @@ class QbloxCompiler:
                 "Cannot compile to hardware-native instructions because QProgram contains named operations that are not mapped. Provide a calibration instance containing all necessary mappings."
             )
 
+        self.optimize_square_waveforms = optimize_square_waveforms
         self._sync_counter = 0
         self._buses = self._populate_buses()
 
@@ -591,19 +595,59 @@ class QbloxCompiler:
     def _handle_play(self, element: Play):
         waveform_I, waveform_Q = element.get_waveforms()
         waveform_variables = element.get_waveform_variables()
-        if not waveform_variables:
-            index_I, index_Q, duration = self._append_to_waveforms_of_bus(
+        if waveform_variables:
+            logger.error("Variables in waveforms are not supported in Qblox.")
+            return
+        if element.wait_time:
+            # The qp.qblox.play() was used. Don't apply optimizations
+            index_I, index_Q, _ = self._append_to_waveforms_of_bus(
                 bus=element.bus, waveform_I=waveform_I, waveform_Q=waveform_Q
             )
-            if element.wait_time is not None:  # TODO: Change this in clean fix
-                duration = element.wait_time
             convert = QbloxCompiler._convert_value(element)
-            duration = convert(duration)
-            self._buses[element.bus].static_duration += duration
+            duration = convert(element.wait_time)
             self._buses[element.bus].qpy_block_stack[-1].append_component(
                 component=QPyInstructions.Play(index_I, index_Q, wait_time=duration)
             )
-            self._buses[element.bus].marked_for_sync = True
+        elif (
+            self.optimize_square_waveforms
+            and isinstance(waveform_I, Square)
+            and (waveform_Q is None or isinstance(waveform_Q, Square))
+        ):
+            duration = waveform_I.duration
+            chunk_duration, iterations, remainder = QbloxCompiler.calculate_square_waveform_optimization_values(
+                duration
+            )
+            waveform_I.duration = chunk_duration
+            if isinstance(waveform_Q, Square):
+                waveform_Q.duration = chunk_duration
+            index_I, index_Q, _ = self._append_to_waveforms_of_bus(
+                bus=element.bus, waveform_I=waveform_I, waveform_Q=waveform_Q
+            )
+            loop = QPyProgram.IterativeLoop(
+                name=f"square_{self._buses[element.bus].square_optimization_counter}", iterations=iterations
+            )
+            loop.append_component(component=QPyInstructions.Play(index_I, index_Q, wait_time=chunk_duration))
+            self._buses[element.bus].qpy_block_stack[-1].append_component(component=loop)
+            if remainder != 0:
+                waveform_I.duration = remainder
+                if isinstance(waveform_Q, Square):
+                    waveform_Q.duration = remainder
+                index_I, index_Q, _ = self._append_to_waveforms_of_bus(
+                    bus=element.bus, waveform_I=waveform_I, waveform_Q=waveform_Q
+                )
+                self._buses[element.bus].qpy_block_stack[-1].append_component(
+                    component=QPyInstructions.Play(index_I, index_Q, wait_time=remainder)
+                )
+            self._buses[element.bus].square_optimization_counter += 1
+        else:
+            index_I, index_Q, duration = self._append_to_waveforms_of_bus(
+                bus=element.bus, waveform_I=waveform_I, waveform_Q=waveform_Q
+            )
+            self._buses[element.bus].qpy_block_stack[-1].append_component(
+                component=QPyInstructions.Play(index_I, index_Q, wait_time=duration)
+            )
+        self._buses[element.bus].static_duration += duration
+        self._buses[element.bus].marked_for_sync = True
 
     def _handle_block(self, element: Block):
         pass
@@ -669,3 +713,40 @@ class QbloxCompiler:
             key: (value.__dict__ if isinstance(value, Waveform) else value) for key, value in waveform.__dict__.items()
         }
         return f"{waveform.__class__.__name__} {hashes}"
+
+    @staticmethod
+    def calculate_ideal_coeff(duration):
+        if duration <= 1e3:
+            return 10
+        if duration <= 1e5:
+            return 100
+        if duration <= 1e7:
+            return 1000
+        return 10000
+
+    @staticmethod
+    def calculate_square_waveform_optimization_values(duration):
+        def remainder_conditions(pd):
+            rem = duration % pd
+            return rem, (pd >= 4 and (rem == 0 or rem >= 4))
+
+        def find_piece_duration(condition_func):
+            for pd in range(100, 1101):
+                if pd <= duration:
+                    rem, valid = remainder_conditions(pd)
+                    if valid and condition_func(rem):
+                        return pd
+            return None
+
+        # First try for remainder == 0
+        final_pd = find_piece_duration(lambda rem: rem == 0)
+        if final_pd is not None:
+            return final_pd, duration // final_pd, duration % final_pd
+
+        # If not found, try for remainder ≥ 4
+        final_pd = find_piece_duration(lambda rem: rem >= 4)
+        if final_pd is not None:
+            return final_pd, duration // final_pd, duration % final_pd
+
+        # If no suitable piece_duration found, fallback to entire duration
+        return duration, 1, 0

--- a/tests/qprogram/test_qblox_compiler.py
+++ b/tests/qprogram/test_qblox_compiler.py
@@ -7,6 +7,8 @@ import qpysequence as QPy
 from qililab import Calibration, Domain, Gaussian, IQPair, QbloxCompiler, QProgram, Square
 from qililab.qprogram.blocks import ForLoop
 from tests.test_utils import is_q1asm_equal
+from qililab.config import logger
+import logging
 
 
 def setup_q1asm(marker: str):
@@ -363,7 +365,15 @@ def fixture_lay_square_waveforms_with_optimization() -> QProgram:
     qp.play(bus="drive", waveform=IQPair(I=Square(1.0, duration=500), Q=Square(0.0, duration=500)))
     qp.play(bus="drive", waveform=Square(1.0, duration=50_000))
     qp.play(bus="drive", waveform=Square(1.0, duration=9790223))
+    qp.play(bus="drive", waveform=IQPair(I=Square(1.0, duration=9790223), Q=Square(1.0, duration=9790223)))
     qp.play(bus="drive", waveform=Square(0.5, duration=1234567))
+    return qp
+
+@pytest.fixture(name="play_operation_with_variable_in_waveform")
+def fixture_play_operation_with_variable_in_waveform() -> QProgram:
+    qp = QProgram()
+    amplitude = qp.variable(label="amplitude", domain=Domain.Voltage)
+    qp.play(bus="drive", waveform=Square(amplitude=amplitude, duration=100))
     return qp
 
 
@@ -1290,15 +1300,28 @@ class TestQBloxCompiler:
                             play             2, 3, 100
                             loop             R3, @square_3
                             play             5, 6, 23
-                            move             9721, R4
+                            move             97902, R4
             square_4:
-                            play             7, 8, 127
+                            play             2, 2, 100
                             loop             R4, @square_4
+                            play             5, 5, 23
+                            move             9721, R5
+            square_5:
+                            play             7, 8, 127
+                            loop             R5, @square_5
                             set_mrk          0
                             upd_param        4
                             stop
         """
         assert is_q1asm_equal(sequences["drive"], drive_str)
+
+    def test_play_operation_with_variable_in_waveform(self, caplog, play_operation_with_variable_in_waveform: QProgram):
+        compiler = QbloxCompiler()
+        with caplog.at_level(logging.ERROR):
+            _ = compiler.compile(qprogram=play_operation_with_variable_in_waveform)
+
+        assert "Variables in waveforms are not supported in Qblox." in caplog.text
+
 
     def test_delay(self, average_with_for_loop_nshots: QProgram):
         compiler = QbloxCompiler()

--- a/tests/qprogram/test_qblox_compiler.py
+++ b/tests/qprogram/test_qblox_compiler.py
@@ -360,6 +360,7 @@ def fixture_multiple_play_operations_with_no_Q_waveform() -> QProgram:
 @pytest.fixture(name="play_square_waveforms_with_optimization")
 def fixture_lay_square_waveforms_with_optimization() -> QProgram:
     qp = QProgram()
+    qp.play(bus="drive", waveform=IQPair(I=Square(1.0, duration=25), Q=Square(0.5, duration=25)))
     qp.play(bus="drive", waveform=Square(1.0, duration=50))
     qp.play(bus="drive", waveform=Square(1.0, duration=500))
     qp.play(bus="drive", waveform=IQPair(I=Square(1.0, duration=500), Q=Square(0.0, duration=500)))
@@ -1272,7 +1273,7 @@ class TestQBloxCompiler:
         compiler = QbloxCompiler()
         sequences, _ = compiler.compile(qprogram=play_square_waveforms_with_optimization, optimize_square_waveforms=True)
 
-        assert len(sequences["drive"]._waveforms._waveforms) == 9
+        assert len(sequences["drive"]._waveforms._waveforms) == 11
         assert sequences["drive"]._program._compiled
 
         drive_str = """
@@ -1282,32 +1283,33 @@ class TestQBloxCompiler:
                             upd_param        4
 
             main:
-                            play             0, 1, 50
+                            play             0, 1, 25
+                            play             2, 3, 50
                             move             5, R0
             square_0:
-                            play             2, 3, 100
+                            play             4, 5, 100
                             loop             R0, @square_0
                             move             5, R1
             square_1:
-                            play             2, 4, 100
+                            play             4, 6, 100
                             loop             R1, @square_1
                             move             500, R2
             square_2:
-                            play             2, 3, 100
+                            play             4, 5, 100
                             loop             R2, @square_2
                             move             97902, R3
             square_3:
-                            play             2, 3, 100
+                            play             4, 5, 100
                             loop             R3, @square_3
-                            play             5, 6, 23
+                            play             7, 8, 23
                             move             97902, R4
             square_4:
-                            play             2, 2, 100
+                            play             4, 4, 100
                             loop             R4, @square_4
-                            play             5, 5, 23
+                            play             7, 7, 23
                             move             9721, R5
             square_5:
-                            play             7, 8, 127
+                            play             9, 10, 127
                             loop             R5, @square_5
                             set_mrk          0
                             upd_param        4


### PR DESCRIPTION
We have introduced an optimization in the QbloxCompiler that significantly reduces memory usage when compiling square waveforms. The compiler now uses a heuristic algorithm that segments long waveforms into smaller chunks and loops over them. This optimization follows a two-pass search:

  1. **First Pass**: The compiler tries to find a chunk duration that divides the total waveform length evenly (i.e., remainder = 0).
  1. **Second Pass**: If no exact divisor is found, it looks for a chunk duration that leaves a remainder of at least 4 ns. This leftover chunk is large enough to be stored or handled separately.

  Each chunk duration is restricted to the range (\[100, 500\]) ns, ensuring that chunks are neither too small (leading to excessive repetitions) nor too large (risking out-of-memory issues). If no duration within (\[100, 500\]) ns meets these remainder constraints, the compiler defaults to using the original waveform in its entirety.