### PR TITLE
Remove duplication of `(... | None, optional)` across `qililab`

### DIFF
--- a/src/qililab/calibration/calibration_node.py
+++ b/src/qililab/calibration/calibration_node.py
@@ -59,11 +59,11 @@ class CalibrationNode:
 
     Args:
         nb_path (str): Full notebook path with the folder, nb_name, and ``.ipynb`` extension, written in unix format: `folder/subfolder/.../file.ipynb`.
-        qubit_index (int | list[int] | None, optional): Qubit on which this notebook will be executed. Defaults to None.
-        node_distinguishier (int | str | None, optional): Distinguisher for when the same notebook its used multiple times in the same qubit. Mandatory to use in such case, or
+        qubit_index (int | list[int], optional): Qubit on which this notebook will be executed. Defaults to None.
+        node_distinguishier (int | str, optional): Distinguisher for when the same notebook its used multiple times in the same qubit. Mandatory to use in such case, or
             the :class:`.CalibrationController` won't do the graph mapping properly, and the calibration will fail. Defaults to None.
-        input_parameters (dict | None, optional): Kwargs for input parameters to pass and be interpreted by the notebook. Defaults to None.
-        sweep_interval (np.ndarray | None, optional): Array describing the sweep values of the experiment. Defaults to None, which means the one specified in the notebook will be used.
+        input_parameters (dict, optional): Kwargs for input parameters to pass and be interpreted by the notebook. Defaults to None.
+        sweep_interval (np.ndarray, optional): Array describing the sweep values of the experiment. Defaults to None, which means the one specified in the notebook will be used.
 
     Examples:
 
@@ -409,7 +409,7 @@ class CalibrationNode:
         Args:
             input_path (str): The input path of the notebook to be executed.
             output_path (str): The output path where the executed noteboo will be saved. If None, no file will be saved.
-            parameters (dict | None, optional): Input parameters kwargs, to overwrite the notebook `parameters` cell with. Defaults to None.
+            parameters (dict, optional): Input parameters kwargs, to overwrite the notebook `parameters` cell with. Defaults to None.
 
         Returns:
             dict | None: A dictionary containing the output parameters of the execution.
@@ -442,7 +442,7 @@ class CalibrationNode:
         Args:
             original_path (str): The original path of the notebook, to add the datetime to. The path directory doesn't need to exist. Can have the ``.ipynb`` extension or not.
                 The part of the string after the last "/" will be considered the file name, and the part before it's directory.
-            timestamp (float | None, optional): Timestamp to add to the name. If None, the current time will be used. Defaults to None.
+            timestamp (float, optional): Timestamp to add to the name. If None, the current time will be used. Defaults to None.
             dirty (bool, optional): Flag indicating if the notebook is in a "dirty" state. Defaults to False.
             error (bool, optional): Flag indicating if the notebook comes from an execution error. Defaults to False.
 

--- a/src/qililab/data_management.py
+++ b/src/qililab/data_management.py
@@ -35,7 +35,7 @@ def save_results(results: np.ndarray, loops: dict[str, np.ndarray], data_path: s
         loops (dict): A dictionary containing all the loops used in an experiment. The keys are used to identify the
             loop and the values of the dictionary correspond to the values of the loop.
         data_path (str): Path to the main data directory.
-        name (str | None, optional): Name of the experiment. If given, the name is added to the name of the folder.
+        name (str, optional): Name of the experiment. If given, the name is added to the name of the folder.
             Defaults to None.
 
     Returns:

--- a/src/qililab/instruments/instrument.py
+++ b/src/qililab/instruments/instrument.py
@@ -109,7 +109,7 @@ class Instrument(BusElement, ABC):
 
         Args:
             parameter (Parameter): Name of the parameter to get.
-            channel_id (int | None, optional): Instrument channel, if multiple. Defaults to None.
+            channel_id (int, optional): Instrument channel, if multiple. Defaults to None.
 
         Returns:
             str | int | float | bool: Parameter value.
@@ -123,7 +123,7 @@ class Instrument(BusElement, ABC):
         Args:
             parameter (Parameter): parameter settings of the instrument to update
             value (float | str | bool): value to update
-            channel_id (int | None, optional): instrument channel to update, if multiple. Defaults to None.
+            channel_id (int, optional): instrument channel to update, if multiple. Defaults to None.
 
         Returns:
             bool: True if the parameter is set correctly, False otherwise

--- a/src/qililab/instruments/qblox/qblox_qcm_rf.py
+++ b/src/qililab/instruments/qblox/qblox_qcm_rf.py
@@ -91,7 +91,7 @@ class QbloxQCMRF(QbloxQCM):
         Args:
             parameter (Parameter): Parameter name.
             value (float | str | bool): Value to set.
-            channel_id (int | None, optional): ID of the sequencer. Defaults to None.
+            channel_id (int, optional): ID of the sequencer. Defaults to None.
         """
         if parameter == Parameter.LO_FREQUENCY:
             if channel_id is not None:
@@ -133,7 +133,7 @@ class QbloxQCMRF(QbloxQCM):
         Args:
             parameter (Parameter): Parameter name.
             value (float | str | bool): Value to set.
-            channel_id (int | None, optional): ID of the sequencer. Defaults to None.
+            channel_id (int, optional): ID of the sequencer. Defaults to None.
         """
         if parameter == Parameter.LO_FREQUENCY:
             if channel_id is not None:

--- a/src/qililab/instruments/qblox/qblox_qrm_rf.py
+++ b/src/qililab/instruments/qblox/qblox_qrm_rf.py
@@ -82,7 +82,7 @@ class QbloxQRMRF(QbloxQRM):
         Args:
             parameter (Parameter): Parameter name.
             value (float | str | bool): Value to set.
-            channel_id (int | None, optional): ID of the sequencer. Defaults to None.
+            channel_id (int, optional): ID of the sequencer. Defaults to None.
         """
         if parameter == Parameter.LO_FREQUENCY:
             parameter = Parameter.OUT0_IN0_LO_FREQ
@@ -108,7 +108,7 @@ class QbloxQRMRF(QbloxQRM):
         Args:
             parameter (Parameter): Parameter name.
             value (float | str | bool): Value to set.
-            channel_id (int | None, optional): ID of the sequencer. Defaults to None.
+            channel_id (int, optional): ID of the sequencer. Defaults to None.
         """
         if parameter == Parameter.LO_FREQUENCY:
             parameter = Parameter.OUT0_IN0_LO_FREQ

--- a/src/qililab/instruments/qdevil/qdevil_qdac2.py
+++ b/src/qililab/instruments/qdevil/qdevil_qdac2.py
@@ -90,8 +90,13 @@ class QDevilQDac2(VoltageSource):
             self.settings.ramping_enabled[index] = ramping_enabled
             if self.is_device_active():
                 if ramping_enabled:
-                    if self.ramp_rate[index] < QDevilQDac2._MIN_RAMPING_RATE or self.ramp_rate[index] > QDevilQDac2._MAX_RAMPING_RATE:
-                        raise ValueError(f"The ramp rate is out of range on channel {channel_id}. It should be between 0.01 V/s and 2e7 V/s.")
+                    if (
+                        self.ramp_rate[index] < QDevilQDac2._MIN_RAMPING_RATE
+                        or self.ramp_rate[index] > QDevilQDac2._MAX_RAMPING_RATE
+                    ):
+                        raise ValueError(
+                            f"The ramp rate is out of range on channel {channel_id}. It should be between 0.01 V/s and 2e7 V/s."
+                        )
                     channel.dc_slew_rate_V_per_s(self.ramp_rate[index])
                 else:
                     channel.dc_slew_rate_V_per_s(2e7)
@@ -102,7 +107,9 @@ class QDevilQDac2(VoltageSource):
             ramping_enabled = self.ramping_enabled[index]
             if ramping_enabled and self.is_device_active():
                 if ramping_rate < QDevilQDac2._MIN_RAMPING_RATE or ramping_rate > QDevilQDac2._MAX_RAMPING_RATE:
-                    raise ValueError(f"The ramp rate is out of range on channel {channel_id}. It should be between 0.01 V/s and 2e7 V/s.")
+                    raise ValueError(
+                        f"The ramp rate is out of range on channel {channel_id}. It should be between 0.01 V/s and 2e7 V/s."
+                    )
                 channel.dc_slew_rate_V_per_s(ramping_rate)
             return
         if parameter == Parameter.LOW_PASS_FILTER:
@@ -151,7 +158,7 @@ class QDevilQDac2(VoltageSource):
         """Plays a waveform for a given channel id. If no channel id is given, plays all waveforms stored in the cache.
 
         Args:
-            channel_id (ChannelID | None, optional): Channel id to play a waveform through. Defaults to None.
+            channel_id (ChannelID, optional): Channel id to play a waveform through. Defaults to None.
             clear_after (bool): If True, clears cache. Defaults to True.
         """
         if channel_id is None:
@@ -190,7 +197,6 @@ class QDevilQDac2(VoltageSource):
         """Perform an initial setup."""
 
         for channel_id in self.dacs:
-
             self._validate_channel(channel_id=channel_id)
 
             index = self.dacs.index(channel_id)
@@ -200,8 +206,13 @@ class QDevilQDac2(VoltageSource):
             channel.output_filter(self.low_pass_filter[index])
 
             if self.ramping_enabled[index]:
-                if self.ramp_rate[index] < QDevilQDac2._MIN_RAMPING_RATE or self.ramp_rate[index] > QDevilQDac2._MAX_RAMPING_RATE:
-                    raise ValueError(f"The ramp rate is out of range on channel {channel_id}. It should be between 0.01 V/s and 2e7 V/s.")
+                if (
+                    self.ramp_rate[index] < QDevilQDac2._MIN_RAMPING_RATE
+                    or self.ramp_rate[index] > QDevilQDac2._MAX_RAMPING_RATE
+                ):
+                    raise ValueError(
+                        f"The ramp rate is out of range on channel {channel_id}. It should be between 0.01 V/s and 2e7 V/s."
+                    )
                 channel.dc_slew_rate_V_per_s(self.ramp_rate[index])
             else:
                 channel.dc_slew_rate_V_per_s(2e7)

--- a/src/qililab/platform/components/bus.py
+++ b/src/qililab/platform/components/bus.py
@@ -159,7 +159,7 @@ class Bus:
         Args:
             parameter (Parameter): parameter settings of the instrument to update
             value (int | float | str | bool): value to update
-            channel_id (int | None, optional): instrument channel to update, if multiple. Defaults to None.
+            channel_id (int, optional): instrument channel to update, if multiple. Defaults to None.
         """
         for instrument, instrument_channel in zip(self.instruments, self.channels):
             with contextlib.suppress(ParameterNotFound):
@@ -176,7 +176,7 @@ class Bus:
         Args:
             parameter (Parameter): parameter settings of the instrument to update
             value (int | float | str | bool): value to update
-            channel_id (int | None, optional): instrument channel to update, if multiple. Defaults to None.
+            channel_id (int, optional): instrument channel to update, if multiple. Defaults to None.
         """
         if parameter == Parameter.DELAY:
             return self.settings.delay
@@ -243,7 +243,7 @@ class Bus:
 
         Returns:
             list[Result]: Acquired results in chronological order
-            channel_id (int | None, optional): instrument channel of QRM. Defaults to None.
+            channel_id (int, optional): instrument channel of QRM. Defaults to None.
         """
         # TODO: Support acquisition from multiple instruments
         total_results: list[list[MeasurementResult]] = []

--- a/src/qililab/qprogram/qblox_compiler.py
+++ b/src/qililab/qprogram/qblox_compiler.py
@@ -169,8 +169,8 @@ class QbloxCompiler:
 
         Args:
             qprogram (QProgram): The QProgram to be compiled
-            bus_mapping (dict[str, str] | None, optional): Optional mapping of bus names. Defaults to None.
-            times_of_flight (dict[str, int] | None, optional): Optional time of flight of bus. Defaults to None.
+            bus_mapping (dict[str, str], optional): Optional mapping of bus names. Defaults to None.
+            times_of_flight (dict[str, int], optional): Optional time of flight of bus. Defaults to None.
 
         Returns:
             QbloxCompilationOutput:

--- a/src/qililab/qprogram/qprogram.py
+++ b/src/qililab/qprogram/qprogram.py
@@ -410,7 +410,7 @@ class QProgram(StructuredProgram):
         If no buses are given, then the synchronization will involve all buses present in the QProgram.
 
         Args:
-            buses (list[str] | None, optional): List of unique identifiers of the buses. Defaults to None.
+            buses (list[str], optional): List of unique identifiers of the buses. Defaults to None.
         """
         operation = Sync(buses=buses)
         self._active_block.append(operation)

--- a/src/qililab/qprogram/quantum_machines_compiler.py
+++ b/src/qililab/qprogram/quantum_machines_compiler.py
@@ -168,7 +168,7 @@ class QuantumMachinesCompiler:
 
         Args:
             qprogram (QProgram): The QProgram to be compiled
-            bus_mapping (dict[str, str] | None, optional): Optional mapping of bus names. Defaults to None.
+            bus_mapping (dict[str, str], optional): Optional mapping of bus names. Defaults to None.
 
         Returns:
             tuple[qua.Program, dict, list[MeasurementInfo]]: A tuple consisting of the generated QUA program, the generated configuration and a list of measurements' information.

--- a/src/qililab/result/qprogram/quantum_machines_measurement_result.py
+++ b/src/qililab/result/qprogram/quantum_machines_measurement_result.py
@@ -30,8 +30,8 @@ class QuantumMachinesMeasurementResult(MeasurementResult):
     Args:
         I (np.ndarray): Data obtained from I stream.
         Q (np.ndarray): Data obtained from Q stream.
-        adc1 (np.ndarray, Optional): Data obtained from adc1 stream. Defaults to None.
-        adc2 (np.ndarray, Optional): Data obtained from adc2 stream. Defaults to None.
+        adc1 (np.ndarray, optional): Data obtained from adc1 stream. Defaults to None.
+        adc2 (np.ndarray, optional): Data obtained from adc2 stream. Defaults to None.
     """
 
     name = ResultName.QUANTUM_MACHINES_MEASUREMENT

--- a/src/qililab/settings/digital/digital_compilation_settings.py
+++ b/src/qililab/settings/digital/digital_compilation_settings.py
@@ -94,7 +94,7 @@ class DigitalCompilationSettings:
         Args:
             parameter (Parameter): Name of the parameter to get.
             value (float | str | bool): New value to set in the parameter.
-            channel_id (int | None, optional): Channel id. Defaults to None.
+            channel_id (int, optional): Channel id. Defaults to None.
             alias (str): String which specifies where the parameter can be found.
         """
         if parameter == Parameter.DELAY_BEFORE_READOUT:
@@ -120,7 +120,7 @@ class DigitalCompilationSettings:
 
         Args:
             parameter (Parameter): Name of the parameter to get.
-            channel_id (int | None, optional): Channel id. Defaults to None.
+            channel_id (int, optional): Channel id. Defaults to None.
             alias (str): String which specifies where the parameter can be found.
         """
         # if alias is None or alias == "platform":

--- a/src/qililab/settings/digital/gate_event_settings.py
+++ b/src/qililab/settings/digital/gate_event_settings.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from dataclasses import dataclass
-from typing import Optional
 
 from qililab.typings.enums import Parameter
 
@@ -48,7 +47,7 @@ class GateEventSettings:
         phase: float
         duration: int
         shape: dict
-        options: Optional[dict] = None
+        options: dict | None = None
 
     bus: str
     pulse: GatePulseSettings

--- a/src/qililab/utils/serialization.py
+++ b/src/qililab/utils/serialization.py
@@ -78,7 +78,7 @@ def deserialize(string: str, cls: type[T] | None = None) -> Any | T:
 
     Args:
         string (str): The YAML string to deserialize.
-        cls (type[T] | None, optional): The class type to cast the deserialized object to. Defaults to None.
+        cls (type[T], optional): The class type to cast the deserialized object to. Defaults to None.
 
     Raises:
         DeserializationError: If deserialization fails or the resulting object is not of the specified type.
@@ -109,7 +109,7 @@ def deserialize_from(file: str, cls: type[T] | None = None) -> Any | T:
 
     Args:
         file (str): The file path of the YAML file to deserialize.
-        cls (type[T] | None, optional): The class type to cast the deserialized object to. Defaults to None.
+        cls (type[T], optional): The class type to cast the deserialized object to. Defaults to None.
 
     Raises:
         DeserializationError: If deserialization fails or the resulting object is not of the specified type.


### PR DESCRIPTION
## Summary:
With `cmd + F`, I found a lot of duplicated info in `qililab` regarding `| None` and `optional`, in docstrings mostly.

## Changes from this PR:
- Change docstring from `(... | None, optional)` to `(..., optional)`
- Removed Optional in `gate_event_setitngs`
- And some automatic autoformater changes from pre-commit in `qdevil-qdac2.py`