### PR TITLE
[QHC-878] Fix Bug in Square Waveform Optimization

### DIFF
--- a/src/qililab/qprogram/qblox_compiler.py
+++ b/src/qililab/qprogram/qblox_compiler.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
+from copy import deepcopy
 import math
 from collections import deque
 from dataclasses import dataclass
@@ -613,15 +613,17 @@ class QbloxCompiler:
             and (waveform_Q is None or isinstance(waveform_Q, Square))
             and (waveform_I.duration >= 100)
         ):
-            duration = waveform_I.duration
+            copied_waveform_I: Square = deepcopy(waveform_I)
+            copied_waveform_Q: Square | None = deepcopy(waveform_Q)
+            duration = copied_waveform_I.duration
             chunk_duration, iterations, remainder = QbloxCompiler.calculate_square_waveform_optimization_values(
                 duration
             )
-            waveform_I.duration = chunk_duration
-            if isinstance(waveform_Q, Square):
-                waveform_Q.duration = chunk_duration
+            copied_waveform_I.duration = chunk_duration
+            if isinstance(copied_waveform_Q, Square):
+                copied_waveform_Q.duration = chunk_duration
             index_I, index_Q, _ = self._append_to_waveforms_of_bus(
-                bus=element.bus, waveform_I=waveform_I, waveform_Q=waveform_Q
+                bus=element.bus, waveform_I=copied_waveform_I, waveform_Q=copied_waveform_Q
             )
             loop = QPyProgram.IterativeLoop(
                 name=f"square_{self._buses[element.bus].square_optimization_counter}", iterations=iterations
@@ -629,11 +631,11 @@ class QbloxCompiler:
             loop.append_component(component=QPyInstructions.Play(index_I, index_Q, wait_time=chunk_duration))
             self._buses[element.bus].qpy_block_stack[-1].append_component(component=loop)
             if remainder != 0:
-                waveform_I.duration = remainder
-                if isinstance(waveform_Q, Square):
-                    waveform_Q.duration = remainder
+                copied_waveform_I.duration = remainder
+                if isinstance(copied_waveform_Q, Square):
+                    copied_waveform_Q.duration = remainder
                 index_I, index_Q, _ = self._append_to_waveforms_of_bus(
-                    bus=element.bus, waveform_I=waveform_I, waveform_Q=waveform_Q
+                    bus=element.bus, waveform_I=copied_waveform_I, waveform_Q=copied_waveform_Q
                 )
                 self._buses[element.bus].qpy_block_stack[-1].append_component(
                     component=QPyInstructions.Play(index_I, index_Q, wait_time=remainder)

--- a/tests/qprogram/test_qblox_compiler.py
+++ b/tests/qprogram/test_qblox_compiler.py
@@ -465,7 +465,7 @@ class TestQBloxCompiler:
         """
         assert is_q1asm_equal(sequences["drive"], drive_str)
 
-        assert len(sequences["readout"]._waveforms._waveforms) == 2
+        assert len(sequences["readout"]._waveforms._waveforms) == 4
         assert len(sequences["readout"]._acquisitions._acquisitions) == 1
         assert sequences["readout"]._acquisitions._acquisitions[0].num_bins == 1
         assert len(sequences["readout"]._weights._weights) == 2
@@ -485,7 +485,7 @@ class TestQBloxCompiler:
                             play             0, 1, 100      
                             loop             R0, @square_0  
                             set_mrk          7              
-                            play             0, 1, 4        
+                            play             2, 3, 4        
                             acquire_weighed  0, 0, 0, 1, 2000
                             set_mrk          0              
                             upd_param        4              
@@ -1053,7 +1053,7 @@ class TestQBloxCompiler:
                             nop                             
             loop_1:
                             set_awg_gain     R11, R11       
-                            move             1, R12         
+                            move             10, R12         
             square_1:
                             play             0, 1, 100      
                             loop             R12, @square_1 


### PR DESCRIPTION
Fixed an issue in Qblox’s Square Waveform Optimization that produced incorrect Q1ASM when reusing the same waveform in multiple Play operations.