### PR TITLE
[QHC-924] Remove GRES check in `slurm.py`

### DIFF
--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -11,13 +11,17 @@
 
   ```python
   with platform.session():
-    results = platform.execute_qprograms_parallel([qprogram1, qprogram2, qprogram3])
+      results = platform.execute_qprograms_parallel([qprogram1, qprogram2, qprogram3])
   ```
+
   [#906](https://github.com/qilimanjaro-tech/qililab/pull/906)
 
 ### Breaking changes
 
 ### Deprecations / Removals
+
+- Remove the check of forcing GRES in slurm.
+  [#907](https://github.com/qilimanjaro-tech/qililab/pull/907)
 
 ### Documentation
 

--- a/src/qililab/config/version.py
+++ b/src/qililab/config/version.py
@@ -14,4 +14,4 @@
 
 """Version number (major.minor.patch[-label])"""
 
-__version__ = "0.29.1"
+__version__ = "0.29.0"

--- a/src/qililab/config/version.py
+++ b/src/qililab/config/version.py
@@ -13,4 +13,5 @@
 # limitations under the License.
 
 """Version number (major.minor.patch[-label])"""
-__version__ = "0.29.0"
+
+__version__ = "0.29.1"

--- a/src/qililab/slurm.py
+++ b/src/qililab/slurm.py
@@ -105,12 +105,15 @@ def submit_job(line: str, cell: str, local_ns: dict) -> None:
     executable_code = "\n".join([*import_lines, cell])
 
     # Create the executor that will be used to queue the SLURM job
+    slurm_additional_parameters = {"begin": begin_time, "nice": nice_factor}
+    if gres:
+        slurm_additional_parameters |= {"gres": f"{gres}:1"}
     executor = AutoExecutor(folder=folder_path, cluster=execution_env)
     executor.update_parameters(
         slurm_partition=partition,
         name=job_name,
         timeout_min=time_limit,
-        slurm_additional_parameters={"begin": begin_time, "nice": nice_factor, "gres": f"{gres}:1"},
+        slurm_additional_parameters=slurm_additional_parameters,
     )
 
     # Compile the code defined above

--- a/src/qililab/slurm.py
+++ b/src/qililab/slurm.py
@@ -94,8 +94,6 @@ def submit_job(line: str, cell: str, local_ns: dict) -> None:
     begin_time = args.begin
     low_priority = args.low_priority
 
-    if gres is None:
-        raise ValueError("GRES needs to be provided! See the available ones typing 'sinfo -o '%G'' in the terminal")
     nice_factor = 0
     if low_priority in ["True", "true"]:
         nice_factor = 1000000  # this ensures Lab jobs have 0 priority, same as QaaS jobs

--- a/tests/test_slurm.py
+++ b/tests/test_slurm.py
@@ -52,16 +52,16 @@ class TestSubmitJob:
             )
 
     def test_submit_job_no_gres_provided(self, ip):
-        """Check ValueError is raised in case GRES is not provided."""
+        """Check no Error is raised in case GRES is not provided."""
         ip.run_cell(raw_cell="a=1\nb=1")
-        with pytest.raises(
-            ValueError, match="GRES needs to be provided! See the available ones typing 'sinfo -o '%G'' in the terminal"
-        ):
-            ip.run_cell_magic(
-                magic_name="submit_job",
-                line=f"-o results -l {slurm_job_data_test} -n unit_test -e local",
-                cell="a+b",
-            )
+
+        ip.run_cell_magic(
+            magic_name="submit_job",
+            line=f"-o results -l {slurm_job_data_test} -n unit_test -e local",
+            cell="results = a+b ",
+        )
+        time.sleep(4)
+        assert ip.user_global_ns["results"].result() == 2
 
     def test_submit_job_with_random_file_in_logs_folder(self, ip):
         """Check non-submitit files are deleted if found in logs folder"""

--- a/tests/test_slurm.py
+++ b/tests/test_slurm.py
@@ -60,8 +60,6 @@ class TestSubmitJob:
             line=f"-o results -l {slurm_job_data_test} -n unit_test -e local",
             cell="results = a+b ",
         )
-        time.sleep(4)
-        assert ip.user_global_ns["results"].result() == 2
 
     def test_submit_job_with_random_file_in_logs_folder(self, ip):
         """Check non-submitit files are deleted if found in logs folder"""


### PR DESCRIPTION
@JavierSab and @islegmar pointed out that not everyone using `slurm` will have GRES, concretely BSC won't, so this would error...

With this change we will need to release version `0.29.1`, to send BSC, correcting this bug