### PR TITLE
[QHC-949] Parallelize Tests

### DIFF
--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -32,7 +32,7 @@ jobs:
         run: uv python install 3.10
 
       - name: Install the project
-        run: uv sync --all-extras --all-groups --dev
+        run: uv sync --all-extras
 
       - name: Ruff
         run: uv run ruff check --output-format=github .

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,7 +25,7 @@ jobs:
           run: uv python install 3.10
 
         - name: Install the project
-          run: uv sync --all-extras --all-groups --dev
+          run: uv sync --all-extras --group docs
 
         - name: Build docs
           run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,11 +32,11 @@ jobs:
         run: uv python install 3.10
 
       - name: Install the project
-        run: uv sync --all-extras --dev
+        run: uv sync --all-extras
 
       - name: Run tests
         run: |
-          uv run pytest --cov=qililab --cov-report=xml tests
+          uv run pytest -n logical --dist loadscope --cov=qililab --cov-report=xml tests
 
       - name: Upload Coverage
         uses: codecov/codecov-action@v5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Run tests
         run: |
-          uv run pytest -n logical --dist loadscope --cov=qililab --cov-report=xml tests
+          uv run pytest -n logical --dist loadfile --cov=qililab --cov-report=xml tests
 
       - name: Upload Coverage
         uses: codecov/codecov-action@v5

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Run tests
         run: |
-          uv run pytest -n logical --dist loadfile --cov=qililab --cov-report=xml tests
+          uv run pytest -n auto --dist loadfile --cov=qililab --cov-report=xml tests
 
       - name: Upload Coverage
         uses: codecov/codecov-action@v5

--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -3,8 +3,11 @@
 ### New features since last release
 
 ### Improvements
-- The tests of qbloxdraw have been modified such that the plots don't open on the user's browser when running pytests via vs code, 
-[#924](https://github.com/qilimanjaro-tech/qililab/pull/924)
+
+- The tests for `QbloxDraw` have been modified such that the plots don't open on the user's browser when running pytests via VSCode.
+  [#924](https://github.com/qilimanjaro-tech/qililab/pull/924)
+
+- Github Actions now use `pytest-xdist` plugin to run tests in parallel. To run tests in parallel locally use `uv run pytest -n auto --dist loadfile`. The `--dist loadfile` flag is mandatory to avoid conflicts between tests that edit shared data, and should be planned for removal in the future.
 
 ### Breaking changes
 

--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -8,6 +8,7 @@
   [#924](https://github.com/qilimanjaro-tech/qililab/pull/924)
 
 - Github Actions now use `pytest-xdist` plugin to run tests in parallel. To run tests in parallel locally use `uv run pytest -n auto --dist loadfile`. The `--dist loadfile` flag is mandatory to avoid conflicts between tests that edit shared data, and should be planned for removal in the future.
+  [#925](https://github.com/qilimanjaro-tech/qililab/pull/925)
 
 ### Breaking changes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dev = [
     "pre-commit>=4.2.0",
     "pytest>=8.3.5",
     "pytest-cov>=6.0.0",
-    "pytest-xdist[psutil]>=3.6.1",
+    "pytest-xdist>=3.6.1",
     "ruff>=0.11.2",
 ]
 docs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dev = [
     "pre-commit>=4.2.0",
     "pytest>=8.3.5",
     "pytest-cov>=6.0.0",
+    "pytest-xdist[psutil]>=3.6.1",
     "ruff>=0.11.2",
 ]
 docs = [

--- a/uv.lock
+++ b/uv.lock
@@ -871,6 +871,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/ff/b4c0dc78fbe20c3e59c0c7334de0c27eb4001a2b2017999af398bf730817/execnet-2.1.1.tar.gz", hash = "sha256:5189b52c6121c24feae288166ab41b32549c7e2348652736540b9e6e7d4e72e3", size = 166524 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/09/2aea36ff60d16dd8879bdb2f5b3ee0ba8d08cbbdcdfe870e695ce3784385/execnet-2.1.1-py3-none-any.whl", hash = "sha256:26dee51f1b80cebd6d0ca8e74dd8745419761d3bef34163928cbebbdc4749fdc", size = 40612 },
+]
+
+[[package]]
 name = "executing"
 version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2632,6 +2641,24 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-xdist"
+version = "3.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/41/c4/3c310a19bc1f1e9ef50075582652673ef2bfc8cd62afef9585683821902f/pytest_xdist-3.6.1.tar.gz", hash = "sha256:ead156a4db231eec769737f57668ef58a2084a34b2e55c4a8fa20d861107300d", size = 84060 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/82/1d96bf03ee4c0fdc3c0cbe61470070e659ca78dc0086fb88b66c185e2449/pytest_xdist-3.6.1-py3-none-any.whl", hash = "sha256:9ed4adfb68a016610848639bb7e02c9352d5d9f03d04809919e2dafc3be4cca7", size = 46108 },
+]
+
+[package.optional-dependencies]
+psutil = [
+    { name = "psutil" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -2946,6 +2973,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist", extra = ["psutil"] },
     { name = "ruff" },
 ]
 docs = [
@@ -2988,6 +3016,7 @@ dev = [
     { name = "pre-commit", specifier = ">=4.2.0" },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
+    { name = "pytest-xdist", extras = ["psutil"], specifier = ">=3.6.1" },
     { name = "ruff", specifier = ">=0.11.2" },
 ]
 docs = [

--- a/uv.lock
+++ b/uv.lock
@@ -2653,11 +2653,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6d/82/1d96bf03ee4c0fdc3c0cbe61470070e659ca78dc0086fb88b66c185e2449/pytest_xdist-3.6.1-py3-none-any.whl", hash = "sha256:9ed4adfb68a016610848639bb7e02c9352d5d9f03d04809919e2dafc3be4cca7", size = 46108 },
 ]
 
-[package.optional-dependencies]
-psutil = [
-    { name = "psutil" },
-]
-
 [[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
@@ -2973,7 +2968,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
-    { name = "pytest-xdist", extra = ["psutil"] },
+    { name = "pytest-xdist" },
     { name = "ruff" },
 ]
 docs = [
@@ -3016,7 +3011,7 @@ dev = [
     { name = "pre-commit", specifier = ">=4.2.0" },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
-    { name = "pytest-xdist", extras = ["psutil"], specifier = ">=3.6.1" },
+    { name = "pytest-xdist", specifier = ">=3.6.1" },
     { name = "ruff", specifier = ">=0.11.2" },
 ]
 docs = [


### PR DESCRIPTION
Github Actions now use `pytest-xdist` plugin to run tests in parallel. To run tests in parallel locally use `uv run pytest -n auto --dist loadfile`. The `--dist loadfile` flag is mandatory to avoid conflicts between tests that edit shared data, and should be planned for removal in the future.