### PR TITLE
Update pyproject.toml for right qblox instruments version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "pandas==1.5.3",
     "papermill>=2.6.0",
     "pyvisa-py>=0.7.2",
-    "qblox-instruments>=0.14.2",
+    "qblox-instruments==0.14.2",
     "qcodes>=0.51.0",
     "qcodes-contrib-drivers>=0.23.0",
     "qibo==0.2.15",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "pandas==1.5.3",
     "papermill>=2.6.0",
     "pyvisa-py>=0.7.2",
-    "qblox-instruments>=0.16.0",
+    "qblox-instruments>=0.14.2",
     "qcodes>=0.51.0",
     "qcodes-contrib-drivers>=0.23.0",
     "qibo==0.2.15",

--- a/uv.lock
+++ b/uv.lock
@@ -2846,7 +2846,7 @@ wheels = [
 
 [[package]]
 name = "qblox-instruments"
-version = "0.16.0"
+version = "0.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastjsonschema" },
@@ -2855,7 +2855,7 @@ dependencies = [
     { name = "qcodes" },
     { name = "spirack" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3f/48/7974ef40f055866a48091477d691b8f85ea5312a60a8f3ced5af6a1edede/qblox_instruments-0.16.0.tar.gz", hash = "sha256:8a9785d916af27a35c0c51a6a870de5ed879cadb56fff1ee47f4a79a2cf0ad62", size = 2289124 }
+sdist = { url = "https://files.pythonhosted.org/packages/9e/3b/b6371da7190c080530e731979f755d58310f6649e73dd0472b1810193aaa/qblox_instruments-0.14.2.tar.gz", hash = "sha256:92a3a6c5530cbaf912a525147314c7de4fe23897d5824ad798fd02e7f179c03f", size = 1349262 }
 
 [[package]]
 name = "qcodes"
@@ -2988,7 +2988,7 @@ requires-dist = [
     { name = "pandas", specifier = "==1.5.3" },
     { name = "papermill", specifier = ">=2.6.0" },
     { name = "pyvisa-py", specifier = ">=0.7.2" },
-    { name = "qblox-instruments", specifier = ">=0.16.0" },
+    { name = "qblox-instruments", specifier = "==0.14.2" },
     { name = "qcodes", specifier = ">=0.51.0" },
     { name = "qcodes-contrib-drivers", specifier = ">=0.23.0" },
     { name = "qibo", specifier = "==0.2.15" },


### PR DESCRIPTION
This PR reverts to the right version for qblox-instruments, which we lost somehow when we introduced uv.