### PR TITLE
Qhc 1014 implement hardware loop over time for qblox

### DIFF
--- a/src/qililab/platform/platform.py
+++ b/src/qililab/platform/platform.py
@@ -1610,6 +1610,9 @@ class Platform:
         qblox_draw = QbloxDraw()
         compiler = QbloxCompiler()
         sequencer = compiler.compile(qprogram)
+        for variable in sequencer.qprogram._variables:
+            if variable.domain == Domain.Time:
+                raise NotImplementedError("QbloxDraw does not support hardware time-domain loops at the moment.")
         result = qblox_draw.draw(sequencer, runcard_data, time_window, averages_displayed)
 
         return result

--- a/src/qililab/qprogram/qblox_compiler.py
+++ b/src/qililab/qprogram/qblox_compiler.py
@@ -42,7 +42,7 @@ from qililab.qprogram.operations import (
     Wait,
 )
 from qililab.qprogram.qprogram import QProgram
-from qililab.qprogram.variable import Variable
+from qililab.qprogram.variable import Variable, VariableExpression
 from qililab.waveforms import IQPair, Square, Waveform
 
 
@@ -132,8 +132,12 @@ class BusCompilationInfo:
         self.upd_param_instruction_pending: bool = False
 
         # Registers values used for the hardware loop over time
-        self.store_bus_difference: QPyProgram.Register = None
+        self.bus_difference_register: QPyProgram.Register = None
 
+        self.max_other_register: QPyProgram.Register = None
+        self.max_other_static_register: QPyProgram.Register = None
+        self.dynamic_sync_counter: int = 0
+        self.add_dynamic_static_register: QPyProgram.Register = None
         # # Track the number of hardware loop over time
         # self.time_loop_counter: int = 0
 
@@ -263,15 +267,21 @@ class QbloxCompiler:
 
             # TODO: works but add a cleaner check
             # Check if variable waits are used
-            if self._time_loop_counter > 0:
-                dynamic_sync_block = QPyProgram.Block(name="dynamic_sync")
-                self._buses[bus].qpy_block_stack[0]._append_block(dynamic_sync_block)
+            if self._buses[bus].dynamic_sync_counter > 0:
 
-                #TODO: very wrong - should be a variable
-                # TODO: Give an error if time variable created but no dynamic sync
-                self._buses[bus].qpy_block_stack[0].append_component(component=QPyInstructions.Wait(self._buses[bus].store_bus_difference))
-                self._buses[bus].qpy_block_stack[0].append_component(component=QPyInstructions.Jmp("@after_dynamic_sync"))
+                for idx in range(self._buses[bus].dynamic_sync_counter):
+                # Block to add the wait if needed following the Jlt instruction
+                    self._buses[bus].qpy_block_stack[0]._append_block(QPyProgram.Block(name=f"dynamic_sync_{idx}"))
+                    self._buses[bus].qpy_block_stack[0].append_component(component=QPyInstructions.Wait(self._buses[bus].bus_difference_register))
+                    self._buses[bus].qpy_block_stack[0].append_component(component=QPyInstructions.Jmp(f"@after_dynamic_sync_{idx}"))
 
+
+                    if self._buses[bus].max_other_register is not None: # the bus is static, hence  an extra check needs to be added
+                        self._buses[bus].qpy_block_stack[0]._append_block(QPyProgram.Block(name=f"other_max_duration_{idx}"))
+                        self._buses[bus].qpy_block_stack[0].append_component(component=QPyInstructions.Move(self._buses[bus].max_other_static_register, self._buses[bus].max_other_register))
+                        self._buses[bus].qpy_block_stack[0].append_component(component=QPyInstructions.Jmp(F"@after_other_max_duration_{idx}"))
+                    
+            
                 #TODO: add the other cases. that are messed up because we cant have wait<
 
             #TODO: what is the use of this variable below? i should probably update it
@@ -486,13 +496,40 @@ class QbloxCompiler:
     def _handle_wait(self, element: Wait, delay: bool = False):
         duration: QPyProgram.Register | int
         if isinstance(element.duration, Variable):
-            duration = self._buses[element.bus].variable_to_register[element.duration]
-            self._buses[element.bus].dynamic_durations.append(element.duration)
-            self._buses[element.bus].qpy_block_stack[-1].append_component(
-                component=QPyInstructions.Wait(wait_time=duration)
-            )
+            if not isinstance(element.duration, VariableExpression):
+                duration = self._buses[element.bus].variable_to_register[element.duration]
+                self._buses[element.bus].dynamic_durations.append(element.duration)
+                self._buses[element.bus].qpy_block_stack[-1].append_component(
+                    component=QPyInstructions.Wait(wait_time=duration)
+                )
+                self._buses[element.bus].dynamic_durations.append(element.duration)
+            else:
+                #TODO: now this only supports CST + VARIABLE OR CST - VARIABLE
+                #TODO: what happens if called more than once in such a way !!!!!!!!!!! NEEDED FOR CRYOSCOPE
+
+                wait_register = QPyProgram.Register()
+
+                # Retrieve the uuid of the variable instead of the whole expression
+                variable_duration = self._buses[element.bus].variable_to_register[element.duration.extract_variables()]
+                constant_duration = element.duration.extract_constants()
+
+                if element.duration.operator == "+":
+                    self._buses[element.bus].qpy_block_stack[-1].append_component(component=QPyInstructions.Add(variable_duration, constant_duration,wait_register))
+
+                elif element.duration.operator == "-":
+                    constant_duration_register = QPyProgram.Register()
+                    self._buses[element.bus].qpy_block_stack[-1].append_component(component=QPyInstructions.Move(constant_duration, constant_duration_register))
+                    self._buses[element.bus].qpy_block_stack[-1].append_component(component=QPyInstructions.Nop())
+                    self._buses[element.bus].qpy_block_stack[-1].append_component(component=QPyInstructions.Sub(constant_duration_register, variable_duration, wait_register))
+                
+                self._buses[element.bus].qpy_block_stack[-1].append_component(component=QPyInstructions.Nop())
+                self._buses[element.bus].qpy_block_stack[-1].append_component(component=QPyInstructions.Wait(wait_register))
+                
+                #TODO: not sure of that one
+                self._buses[element.bus].dynamic_durations.append(wait_register)
+
+
             self._buses[element.bus].marked_for_dynamic_sync = True
-            # self._buses[element.bus].time_loop_counter += 1
             self._time_loop_counter+= 1
         else:
             convert = QbloxCompiler._convert_value(element)
@@ -549,7 +586,7 @@ class QbloxCompiler:
             return
 
         # If there is no bus marked for sync, return.
-        if all(not self._buses[bus].marked_for_sync for bus in buses):
+        if all(not self._buses[bus].marked_for_sync and not self._buses[bus].marked_for_dynamic_sync for bus in buses):
             return
 
         # Is there any bus that has dynamic durations?
@@ -617,9 +654,9 @@ class QbloxCompiler:
         #  need smthg to track that a bus has dyanmic status (for now i am only thinkign abt teh case where one bus has a dynamic time)
         # will need to increment the name using the counter time_loop_counter
 
+        # Find the dynamic duration
         
 
-        # Find the dynamic duration
         count_dynamic_bus = 0
         for bus in buses:
             if self._buses[bus].dynamic_durations:
@@ -627,64 +664,306 @@ class QbloxCompiler:
                 count_dynamic_bus += 1
                 if count_dynamic_bus >= 2:
                     raise NotImplementedError("More than 2 buses have a dynamic duration, which is not allowed.")
-                
-            else:  # non dynamic bus
-                static_bus = bus
+
 
         for bus in buses:
-            dynamic_duration_register = self._buses[bus].variable_to_register[self._buses[dynamic_bus].dynamic_durations[0]]
+            if self._buses[bus].dynamic_sync_counter == 0:
+                self._buses[bus].max_other_static_register = QPyProgram.Register()
+                self._buses[bus].add_dynamic_static_register = QPyProgram.Register()
+                self._buses[bus].bus_difference_register = QPyProgram.Register()
+                if not self._buses[bus].dynamic_durations:
+                    self._buses[bus].max_other_register = QPyProgram.Register()
+                
+            
+
+            #  Get the max static duration of the other buses
+            max_bus = max(
+                        (bus_other for bus_other in buses if bus_other != bus),
+                        key=lambda bus_other: self._buses[bus_other].static_duration
+                        )
+            max_static = self._buses[max_bus].static_duration
+            self._buses[bus].qpy_block_stack[-1].append_component(QPyInstructions.Move(max_static, self._buses[bus].max_other_static_register))
+
+            # Compute the duration of the dynamic bus
+            dynamic_duration_register = self._buses[bus].variable_to_register[self._buses[dynamic_bus].dynamic_durations[0]] # retrieves the register of the time variable
             static_duration_dynamic_bus = self._buses[dynamic_bus].static_duration
-            add_dynamic_static_register = QPyProgram.Register()
-            add_dynamic_static = QPyInstructions.Add(dynamic_duration_register, static_duration_dynamic_bus, add_dynamic_static_register)
-            self._buses[bus].qpy_block_stack[-1].append_component(component=add_dynamic_static)
-            store_bus_difference = QPyProgram.Register()
-        
+            self._buses[bus].qpy_block_stack[-1].append_component(QPyInstructions.Add(dynamic_duration_register, static_duration_dynamic_bus, self._buses[bus].add_dynamic_static_register))
+            self._buses[bus].qpy_block_stack[-1].append_component(QPyInstructions.Nop())
+
+
+
             if self._buses[bus].dynamic_durations:
-                to_substract = add_dynamic_static_register
-                static_dur_non_dynamic_bus = self._buses[static_bus].static_duration
-                to_add = static_dur_non_dynamic_bus
+
+                #TODO if the dynamic bus has the longest static duration, Q1ASM can be further simplified, no need for any comparison
+                #TODO consider the case where there is no static duration in this bus
+
+                # Maximum duration of the other buses - Duration of this bus
+                self._buses[bus].qpy_block_stack[-1].append_component(QPyInstructions.Sub(self._buses[bus].max_other_static_register, self._buses[bus].add_dynamic_static_register,self._buses[bus].bus_difference_register))
+                self._buses[bus].qpy_block_stack[-1].append_component(QPyInstructions.Nop())
+
+                # Check the sign of the bus difference
+                self._buses[bus].qpy_block_stack[-1].append_component(QPyInstructions.Jlt(self._buses[bus].bus_difference_register, 2147483648, f"@dynamic_sync_{self._buses[bus].dynamic_sync_counter}"))
+
+                #Add the block to label to continue after the comparison
+                self._buses[bus].qpy_block_stack[-1]._append_block(QPyProgram.Block(name=f"after_dynamic_sync_{self._buses[bus].dynamic_sync_counter}"))
+
+                
 
             else:
-                to_substract = self._buses[bus].static_duration
-                to_add = add_dynamic_static_register
+                
+                current_bus_duration_register = QPyProgram.Register()
 
-            to_add_register = QPyProgram.Register()
+                # Check which of the other buses has the longest duration (this check is needed in the Q1ASM as at least one bus will have dynamic duration)
+                self._buses[bus].qpy_block_stack[-1].append_component(QPyInstructions.Sub(self._buses[bus].max_other_static_register, self._buses[bus].add_dynamic_static_register, self._buses[bus].max_other_register))
+                self._buses[bus].qpy_block_stack[-1].append_component(QPyInstructions.Nop())
+                self._buses[bus].qpy_block_stack[-1].append_component(QPyInstructions.Jlt(self._buses[bus].max_other_register, 2147483648, f"@other_max_duration_{self._buses[bus].dynamic_sync_counter}"))
 
-            #TODO: this move isnt always useful - it shouldnt move a register - but if removed then the register operations following need to be modified
-            move_to_add = QPyInstructions.Move(to_add, to_add_register)
-            self._buses[bus].qpy_block_stack[-1].append_component(component=move_to_add)
+                # If the Jlt condition is not met, the dynamic bus has the longest duration of the other bus
+                self._buses[bus].qpy_block_stack[-1].append_component(QPyInstructions.Move(self._buses[bus].add_dynamic_static_register, self._buses[bus].max_other_register))
+
+                #  Add the block to label to continue after the comparison
+                self._buses[bus].qpy_block_stack[-1]._append_block(QPyProgram.Block(name=f"after_other_max_duration_{self._buses[bus].dynamic_sync_counter}"))
+
+                #  Move the static duration of the current bus to a register
+                static_duration_current_bus = self._buses[bus].static_duration
+                self._buses[bus].qpy_block_stack[-1].append_component(QPyInstructions.Move(static_duration_current_bus, current_bus_duration_register))
+
+                # This part is the same for the dynamic bus
+                # Maximum duration of the other buses - Duration of this bus
+                self._buses[bus].qpy_block_stack[-1].append_component(QPyInstructions.Sub(self._buses[bus].max_other_register, current_bus_duration_register, self._buses[bus].bus_difference_register))
+                self._buses[bus].qpy_block_stack[-1].append_component(QPyInstructions.Nop())
+
+                # Check the sign of the bus difference
+                self._buses[bus].qpy_block_stack[-1].append_component(QPyInstructions.Jlt(self._buses[bus].bus_difference_register, 2147483648, f"@dynamic_sync_{self._buses[bus].dynamic_sync_counter}"))
+
+                # Add the block to label to continue after the comparison
+                self._buses[bus].qpy_block_stack[-1]._append_block(QPyProgram.Block(name=f"after_dynamic_sync_{self._buses[bus].dynamic_sync_counter}"))
+
+
+                # self._buses[bus].max_other_register = max_other_register
+                # self._buses[bus].max_other_static_register = max_other_static_register
+                # self._buses[bus].add_dynamic_static_register = add_dynamic_static_register
+                
+
+            self._buses[bus].dynamic_sync_counter += 1
+            # self._buses[bus].bus_difference_register = bus_difference_register
+
+
+
             
-            nop = QPyInstructions.Nop()
-            self._buses[bus].qpy_block_stack[-1].append_component(component=nop)
+            
+            
+            
+            # add_dynamic_static = QPyInstructions.Add(dynamic_duration_register, static_duration_dynamic_bus, add_dynamic_static_register)
+            # self._buses[bus].qpy_block_stack[-1].append_component(component=add_dynamic_static)
+            # store_bus_difference = QPyProgram.Register()
+        
+            # if self._buses[bus].dynamic_durations:
+            #     to_substract = add_dynamic_static_register
+            #     # static_dur_non_dynamic_bus = self._buses[static_bus].static_duration
+            #     # to_add = static_dur_non_dynamic_bus
 
-            not_operation = QPyInstructions.Not(to_substract, store_bus_difference)
-            self._buses[bus].qpy_block_stack[-1].append_component(component=not_operation)
+            # else:
+            #     to_substract = self._buses[bus].static_duration
+            #     # to_add = add_dynamic_static_register
 
-            self._buses[bus].qpy_block_stack[-1].append_component(component=nop)
+            # # to_add_register = QPyProgram.Register()
 
-            add1 = QPyInstructions.Add(store_bus_difference, 1, store_bus_difference)
-            self._buses[bus].qpy_block_stack[-1].append_component(component=add1)
+            # #TODO: this move isnt always useful - it shouldnt move a register - but if removed then the register operations following need to be modified
 
-            self._buses[bus].qpy_block_stack[-1].append_component(component=nop)
+            # #TODO: What happens if this max bus is also the dynamic one?
+            # # Retrieve the greatest static duration of the other buses
+            # # max_static = max(self._buses[bus_other].static_duration for bus_other in buses if bus != bus)
+            # max_bus = max(
+            #     (bus_other for bus_other in buses if bus_other != bus),
+            #     key=lambda bus_other: self._buses[bus_other].static_duration
+            # )
+            # max_static = self._buses[max_bus].static_duration
 
-            bus_difference = QPyInstructions.Add(store_bus_difference, to_add_register, store_bus_difference)
-            self._buses[bus].qpy_block_stack[-1].append_component(component=bus_difference)
+            # max_other_bus_register = QPyProgram.Register() 
+            # if max_bus != dynamic_bus: #  if it is the same bus, the element for comparison is already added by the add_dynamic_static component
 
-            comparison = QPyInstructions.Jlt(store_bus_difference, 2147483648, "@dynamic_sync")
-            self._buses[bus].qpy_block_stack[-1].append_component(component=comparison)
+            #     max_static_register = QPyProgram.Register()
+            #     max_static_component = QPyInstructions.Move(max_static, max_static_register)
+            #     self._buses[bus].qpy_block_stack[-1].append_component(component=max_static_component)
 
-            dynamic_block = QPyProgram.Block(name="after_dynamic_sync")
-            self._buses[bus].qpy_block_stack[-1]._append_block(dynamic_block)
+                
+            #     max_other_bus_comparison_component = QPyInstructions.Sub(add_dynamic_static_register, max_static_register, max_other_bus_register)
+            #     self._buses[bus].qpy_block_stack[-1].append_component(component=max_other_bus_comparison_component)
+
+            #     if bus is not dynamic_bus:
+            #         self._buses[bus].max_other_bus_register = max_other_bus_register
+            #         self._buses[bus].add_dynamic_static_register = add_dynamic_static_register
+            #         comparison = QPyInstructions.Jlt(max_other_bus_register, 2147483648, "@max_other_bus")
+            #         self._buses[bus].qpy_block_stack[-1].append_component(component=comparison)
+
+            #         max_other_bus = QPyInstructions.Move(max_static_register, max_other_bus_register) # if the jlt is not met, the static is the biggest one
+            #         self._buses[bus].qpy_block_stack[-1].append_component(component=max_other_bus)
+
+            #         after_max_other_bus_block = QPyProgram.Block(name="after_max_other_bus")
+            #         self._buses[bus].qpy_block_stack[-1]._append_block(after_max_other_bus_block)
+
+                
+            # elif max_bus == dynamic_bus and bus ==dynamic_bus:
+            #     max_other_bus = QPyInstructions.Move(max_static, max_other_bus_register) # if the jlt is not met, the static is the biggest one
+            #     self._buses[bus].qpy_block_stack[-1].append_component(component=max_other_bus)
+            
+            # else:
+            #     max_other_bus_register = add_dynamic_static_register
+
+            #             #TODO: below block to be replaced with a sub i think - to test in hw
+            # nop = QPyInstructions.Nop()
+            # # self._buses[bus].qpy_block_stack[-1].append_component(component=nop)
+            # # not_operation = QPyInstructions.Not(to_substract, store_bus_difference)
+            # # self._buses[bus].qpy_block_stack[-1].append_component(component=not_operation)
+
+            # # add1 = QPyInstructions.Add(store_bus_difference, 1, store_bus_difference)
+
+            # self._buses[bus].qpy_block_stack[-1].append_component(component=nop)
+            # # nop = QPyInstructions.Nop()
+            # # self._buses[bus].qpy_block_stack[-1].append_component(component=nop)
+            # # not_operation = QPyInstructions.Not(to_substract, store_bus_difference)
+            # # self._buses[bus].qpy_block_stack[-1].append_component(component=not_operation)
+            # # self._buses[bus].qpy_block_stack[-1].append_component(component=nop)
+            # # add1 = QPyInstructions.Add(store_bus_difference, 1, store_bus_difference)
+            # # self._buses[bus].qpy_block_stack[-1].append_component(component=add1)
+            # # self._buses[bus].qpy_block_stack[-1].append_component(component=nop)
+
+            # bus_difference = QPyInstructions.Sub(max_other_bus_register, to_substract, store_bus_difference)
+            # self._buses[bus].qpy_block_stack[-1].append_component(component=bus_difference)
+            # self._buses[bus].qpy_block_stack[-1].append_component(component=nop)
+
+            # # bus_difference = QPyInstructions.Add(store_bus_difference, max_other_bus_register, store_bus_difference)
+            # # self._buses[bus].qpy_block_stack[-1].append_component(component=bus_difference)
+
+            # comparison = QPyInstructions.Jlt(store_bus_difference, 2147483648, "@dynamic_sync")
+            # self._buses[bus].qpy_block_stack[-1].append_component(component=comparison)
+
+            # dynamic_block = QPyProgram.Block(name="after_dynamic_sync")
+            # self._buses[bus].qpy_block_stack[-1]._append_block(dynamic_block)
 
 
-            self._buses[bus].store_bus_difference = store_bus_difference
+            # self._buses[bus].store_bus_difference = store_bus_difference
 
 
-            # static_duration = self._buses[bus].static_duration
-            # static_duration__max_other_bus = max(
-            #                                     self._buses[other_bus].static_duration
-            #                                     for other_bus in buses
-            #                                     if other_bus != bus
+            
+
+
+
+
+            # dynamic_duration_register = self._buses[bus].variable_to_register[self._buses[dynamic_bus].dynamic_durations[0]]
+            # static_duration_dynamic_bus = self._buses[dynamic_bus].static_duration
+            # add_dynamic_static_register = QPyProgram.Register()
+            # add_dynamic_static = QPyInstructions.Add(dynamic_duration_register, static_duration_dynamic_bus, add_dynamic_static_register)
+            # self._buses[bus].qpy_block_stack[-1].append_component(component=add_dynamic_static)
+            # store_bus_difference = QPyProgram.Register()
+        
+            # if self._buses[bus].dynamic_durations:
+            #     to_substract = add_dynamic_static_register
+            #     # static_dur_non_dynamic_bus = self._buses[static_bus].static_duration
+            #     # to_add = static_dur_non_dynamic_bus
+
+            # else:
+            #     to_substract = self._buses[bus].static_duration
+            #     # to_add = add_dynamic_static_register
+
+            # # to_add_register = QPyProgram.Register()
+
+            # #TODO: this move isnt always useful - it shouldnt move a register - but if removed then the register operations following need to be modified
+
+            # #TODO: What happens if this max bus is also the dynamic one?
+            # # Retrieve the greatest static duration of the other buses
+            # # max_static = max(self._buses[bus_other].static_duration for bus_other in buses if bus != bus)
+            # max_bus = max(
+            #     (bus_other for bus_other in buses if bus_other != bus),
+            #     key=lambda bus_other: self._buses[bus_other].static_duration
+            # )
+            # max_static = self._buses[max_bus].static_duration
+
+            # max_other_bus_register = QPyProgram.Register() 
+            # if max_bus != dynamic_bus: #  if it is the same bus, the element for comparison is already added by the add_dynamic_static component
+
+            #     max_static_register = QPyProgram.Register()
+            #     max_static_component = QPyInstructions.Move(max_static, max_static_register)
+            #     self._buses[bus].qpy_block_stack[-1].append_component(component=max_static_component)
+
+                
+            #     max_other_bus_comparison_component = QPyInstructions.Sub(add_dynamic_static_register, max_static_register, max_other_bus_register)
+            #     self._buses[bus].qpy_block_stack[-1].append_component(component=max_other_bus_comparison_component)
+
+            #     if bus is not dynamic_bus:
+            #         self._buses[bus].max_other_bus_register = max_other_bus_register
+            #         self._buses[bus].add_dynamic_static_register = add_dynamic_static_register
+            #         comparison = QPyInstructions.Jlt(max_other_bus_register, 2147483648, "@max_other_bus")
+            #         self._buses[bus].qpy_block_stack[-1].append_component(component=comparison)
+
+            #         max_other_bus = QPyInstructions.Move(max_static_register, max_other_bus_register) # if the jlt is not met, the static is the biggest one
+            #         self._buses[bus].qpy_block_stack[-1].append_component(component=max_other_bus)
+
+            #         after_max_other_bus_block = QPyProgram.Block(name="after_max_other_bus")
+            #         self._buses[bus].qpy_block_stack[-1]._append_block(after_max_other_bus_block)
+
+                
+            # elif max_bus == dynamic_bus and bus ==dynamic_bus:
+            #     max_other_bus = QPyInstructions.Move(max_static, max_other_bus_register) # if the jlt is not met, the static is the biggest one
+            #     self._buses[bus].qpy_block_stack[-1].append_component(component=max_other_bus)
+            
+            # else:
+            #     max_other_bus_register = add_dynamic_static_register
+
+            #     # is bus != dynamic_bus:
+            #     #     max_dynamic_register = QPyProgram.Register()
+            #     #     max_static_component = QPyInstructions.Move(max_static, max_static_register)
+            #     #     self._buses[bus].qpy_block_stack[-1].append_component(component=max_static_component)
+
+
+
+            # # move_to_add = QPyInstructions.Move(to_add, to_add_register)
+            # # self._buses[bus].qpy_block_stack[-1].append_component(component=move_to_add)
+            
+
+
+
+            # #TODO: below block to be replaced with a sub i think - to test in hw
+            # nop = QPyInstructions.Nop()
+            # # self._buses[bus].qpy_block_stack[-1].append_component(component=nop)
+            # # not_operation = QPyInstructions.Not(to_substract, store_bus_difference)
+            # # self._buses[bus].qpy_block_stack[-1].append_component(component=not_operation)
+
+            # # add1 = QPyInstructions.Add(store_bus_difference, 1, store_bus_difference)
+
+            # self._buses[bus].qpy_block_stack[-1].append_component(component=nop)
+            # # nop = QPyInstructions.Nop()
+            # # self._buses[bus].qpy_block_stack[-1].append_component(component=nop)
+            # # not_operation = QPyInstructions.Not(to_substract, store_bus_difference)
+            # # self._buses[bus].qpy_block_stack[-1].append_component(component=not_operation)
+            # # self._buses[bus].qpy_block_stack[-1].append_component(component=nop)
+            # # add1 = QPyInstructions.Add(store_bus_difference, 1, store_bus_difference)
+            # # self._buses[bus].qpy_block_stack[-1].append_component(component=add1)
+            # # self._buses[bus].qpy_block_stack[-1].append_component(component=nop)
+
+            # bus_difference = QPyInstructions.Sub(max_other_bus_register, to_substract, store_bus_difference)
+            # self._buses[bus].qpy_block_stack[-1].append_component(component=bus_difference)
+            # self._buses[bus].qpy_block_stack[-1].append_component(component=nop)
+
+            # # bus_difference = QPyInstructions.Add(store_bus_difference, max_other_bus_register, store_bus_difference)
+            # # self._buses[bus].qpy_block_stack[-1].append_component(component=bus_difference)
+
+            # comparison = QPyInstructions.Jlt(store_bus_difference, 2147483648, "@dynamic_sync")
+            # self._buses[bus].qpy_block_stack[-1].append_component(component=comparison)
+
+            # dynamic_block = QPyProgram.Block(name="after_dynamic_sync")
+            # self._buses[bus].qpy_block_stack[-1]._append_block(dynamic_block)
+
+
+            # self._buses[bus].store_bus_difference = store_bus_difference
+
+
+            # # static_duration = self._buses[bus].static_duration
+            # # static_duration__max_other_bus = max(
+            # #                                     self._buses[other_bus].static_duration
+            # #                                     for other_bus in buses
+            # #                                     if other_bus != bus
             #                                 )
 
             # if self._buses[bus].dynamic_durations:

--- a/src/qililab/qprogram/qprogram.py
+++ b/src/qililab/qprogram/qprogram.py
@@ -732,6 +732,9 @@ class QProgram(StructuredProgram):
         qblox_draw = QbloxDraw()
         compiler = QbloxCompiler()
         sequencer = compiler.compile(self)
+        for variable in sequencer.qprogram._variables:
+            if variable.domain == Domain.Time:
+                raise NotImplementedError("QbloxDraw does not support hardware time-domain loops at the moment.")
         result_draw = qblox_draw.draw(sequencer=sequencer, time_window=time_window, averages_displayed=averages_displayed)
         logger.warning("The drawing feature is currently only supported for QBlox.")
         return result_draw


### PR DESCRIPTION
Implement hardware loop over time in qblox.
Also introduces VariableExpression to qprogram, this is the building block required to set a variable expression such as qp.wait(bus, time+constant). For now, the operations are limited to time+constant, constant+time, time-constant, constant-time; and they are only implement for a loop over the Time domain