### PR TITLE
Modify the SGS100a to include operation mode setting

### DIFF
--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -8,10 +8,6 @@
 in the settings are `normal` and `bypass`. If the instrument is reset the native instrument configuration defaults to normal.
 [#957](https://github.com/qilimanjaro-tech/qililab/pull/957)
 
-- For the plots outputted by Qblox Draw, the name legend will now be a concatenation of the bus name and "Flux", similar to I and Q when hardware modulation is enabled.
-- An additional argument has been added, to Qblox Draw, time_window. It allows the user to stop the plotting after the specified number of ns have been plotted. The plotting might not be the exact number of ns inputted. For example, if the time_window is 100 ns but there is a play operation of 150 ns, the plots will display the data until 150 ns.
-[#933](https://github.com/qilimanjaro-tech/qililab/pull/933)
-
 - Implementation of the Sudden Net Zero (SNZ) waveform to be able to realise better fidelity two qubit gates.
 [#952](https://github.com/qilimanjaro-tech/qililab/pull/952)
 

--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -4,6 +4,14 @@
 
 ### Improvements
 
+- The R&S SGS100a driver has now the capability to change the operation mode between normal mode and bypass mode. The default mode is the normal mode. The allowed strings for each mode
+in the settings are `normal` and `bypass`. If the instrument is reset the native instrument configuration defaults to normal.
+[#957](https://github.com/qilimanjaro-tech/qililab/pull/957)
+
+- For the plots outputted by Qblox Draw, the name legend will now be a concatenation of the bus name and "Flux", similar to I and Q when hardware modulation is enabled.
+- An additional argument has been added, to Qblox Draw, time_window. It allows the user to stop the plotting after the specified number of ns have been plotted. The plotting might not be the exact number of ns inputted. For example, if the time_window is 100 ns but there is a play operation of 150 ns, the plots will display the data until 150 ns.
+[#933](https://github.com/qilimanjaro-tech/qililab/pull/933)
+
 - Implementation of the Sudden Net Zero (SNZ) waveform to be able to realise better fidelity two qubit gates.
 [#952](https://github.com/qilimanjaro-tech/qililab/pull/952)
 

--- a/src/qililab/instruments/rohde_schwarz/sgs100a.py
+++ b/src/qililab/instruments/rohde_schwarz/sgs100a.py
@@ -265,6 +265,7 @@ class SGS100A(Instrument):
                 f"Operation mode '{self.operation_mode}' not allowed, defaulting to normal operation mode",
                 ResourceWarning
             )
+            self.settings.operation_mode = "normal"
             self.device.write(":SOUR:OPMode NORMal")
 
     @check_device_initialized

--- a/src/qililab/instruments/rohde_schwarz/sgs100a.py
+++ b/src/qililab/instruments/rohde_schwarz/sgs100a.py
@@ -185,7 +185,7 @@ class SGS100A(Instrument):
             if self.is_device_active():
                 operation_mode = "NORMal" if value == "normal" else "BBBYpass"
                 self.device.write(f":SOUR:OPMode {operation_mode}")
-
+            return
         raise ParameterNotFound(self, parameter)
 
     def get_parameter(self, parameter: Parameter, channel_id: ChannelID | None = None) -> ParameterValue:

--- a/src/qililab/instruments/rohde_schwarz/sgs100a.py
+++ b/src/qililab/instruments/rohde_schwarz/sgs100a.py
@@ -52,7 +52,7 @@ class SGS100A(Instrument):
         alc: bool = True
         iq_modulation: bool = False
         iq_wideband: bool = True
-        operation_mode: str = "normal"
+        operation_mode: str = str("normal")
 
     settings: SGS100ASettings
     device: RohdeSchwarzSGS100A
@@ -178,6 +178,7 @@ class SGS100A(Instrument):
                 self.device.IQ_state(self.iq_modulation)
             return
         if parameter == Parameter.OPERATION_MODE:
+            value = str(value).lower()
             if value not in ("normal", "bypass"):
                 raise ParameterNotFound(self, parameter)
             self.settings.operation_mode = value

--- a/src/qililab/instruments/rohde_schwarz/sgs100a.py
+++ b/src/qililab/instruments/rohde_schwarz/sgs100a.py
@@ -119,7 +119,7 @@ class SGS100A(Instrument):
             bool: settings.iq_wideband.
         """
         return self.settings.iq_wideband
-    
+
     @property
     def operation_mode(self):
         """SignalGenerator "Operation Mode" property.
@@ -265,7 +265,6 @@ class SGS100A(Instrument):
                 ResourceWarning
             )
             self.device.write(":SOUR:OPMode NORMal")
-
 
     @check_device_initialized
     def turn_on(self):

--- a/src/qililab/instruments/rohde_schwarz/sgs100a.py
+++ b/src/qililab/instruments/rohde_schwarz/sgs100a.py
@@ -52,6 +52,7 @@ class SGS100A(Instrument):
         alc: bool = True
         iq_modulation: bool = False
         iq_wideband: bool = True
+        operation_mode: str = "normal"
 
     settings: SGS100ASettings
     device: RohdeSchwarzSGS100A
@@ -118,6 +119,14 @@ class SGS100A(Instrument):
             bool: settings.iq_wideband.
         """
         return self.settings.iq_wideband
+    
+    @property
+    def operation_mode(self):
+        """SignalGenerator "Operation Mode" property.
+        Returns:
+            str: settings.operation_mode.
+        """
+        return self.settings.operation_mode
 
     def to_dict(self):
         """Return a dict representation of the SignalGenerator class."""
@@ -168,6 +177,14 @@ class SGS100A(Instrument):
             if self.is_device_active():
                 self.device.IQ_state(self.iq_modulation)
             return
+        if parameter == Parameter.OPERATION_MODE:
+            if value not in ("normal", "bypass"):
+                raise ParameterNotFound(self, parameter)
+            self.settings.operation_mode = value
+            if self.is_device_active():
+                operation_mode = "NORMal" if value == "normal" else "BBBYpass"
+                self.device.write(f":SOUR:OPMode {operation_mode}")
+
         raise ParameterNotFound(self, parameter)
 
     def get_parameter(self, parameter: Parameter, channel_id: ChannelID | None = None) -> ParameterValue:
@@ -183,6 +200,8 @@ class SGS100A(Instrument):
             return self.settings.iq_wideband
         if parameter == Parameter.IQ_MODULATION:
             return self.settings.iq_modulation
+        if parameter == Parameter.OPERATION_MODE:
+            return self.settings.operation_mode
         raise ParameterNotFound(self, parameter)
 
     @check_device_initialized
@@ -237,6 +256,16 @@ class SGS100A(Instrument):
             self.device.on()
         else:
             self.device.off()
+        if self.operation_mode in ("normal", "bypass"):
+            operation_mode = "NORMal" if self.operation_mode == "normal" else "BBBYpass"
+            self.device.write(f":SOUR:OPMode {operation_mode}")
+        else:
+            warnings.warn(
+                f"Operation mode '{self.operation_mode}' not allowed, defaulting to normal operation mode",
+                ResourceWarning
+            )
+            self.device.write(":SOUR:OPMode NORMal")
+
 
     @check_device_initialized
     def turn_on(self):

--- a/src/qililab/instruments/rohde_schwarz/sgs100a.py
+++ b/src/qililab/instruments/rohde_schwarz/sgs100a.py
@@ -181,7 +181,7 @@ class SGS100A(Instrument):
             value = str(value).lower()
             if value not in ("normal", "bypass"):
                 raise ParameterNotFound(self, parameter)
-            self.settings.operation_mode = str(value)
+            self.settings.operation_mode = value
             if self.is_device_active():
                 operation_mode = "NORMal" if value == "normal" else "BBBYpass"
                 self.device.write(f":SOUR:OPMode {operation_mode}")

--- a/src/qililab/instruments/rohde_schwarz/sgs100a.py
+++ b/src/qililab/instruments/rohde_schwarz/sgs100a.py
@@ -52,7 +52,7 @@ class SGS100A(Instrument):
         alc: bool = True
         iq_modulation: bool = False
         iq_wideband: bool = True
-        operation_mode: str = str("normal")
+        operation_mode: str = "normal"
 
     settings: SGS100ASettings
     device: RohdeSchwarzSGS100A
@@ -181,7 +181,7 @@ class SGS100A(Instrument):
             value = str(value).lower()
             if value not in ("normal", "bypass"):
                 raise ParameterNotFound(self, parameter)
-            self.settings.operation_mode = value
+            self.settings.operation_mode = str(value)
             if self.is_device_active():
                 operation_mode = "NORMal" if value == "normal" else "BBBYpass"
                 self.device.write(f":SOUR:OPMode {operation_mode}")

--- a/src/qililab/typings/enums.py
+++ b/src/qililab/typings/enums.py
@@ -322,7 +322,7 @@ class InstrumentControllerName(str, Enum):
 @yaml.register_class
 class Parameter(str, Enum):
     """Parameter names."""
-
+    OPERATION_MODE = "operation_mode"
     ALC = "alc"
     IQ_WIDEBAND = "iq_wideband"
     IQ_MODULATION = "iq_modulation"

--- a/tests/instruments/rohde_schwarz/test_rohde_schwarz_sgs100a.py
+++ b/tests/instruments/rohde_schwarz/test_rohde_schwarz_sgs100a.py
@@ -197,7 +197,7 @@ def fixture_sdg100a_wrong_op_mode() -> SGS100A:
         {
             "alias": "qdac",
             "power": 10,
-            "frequency": 13e9,
+            "frequency": 8e9,
             "rf_on": True,
             "iq_modulation": True,
             "iq_wideband": True,
@@ -326,12 +326,12 @@ class TestSGS100A:
 
     @patch("qililab.instruments.rohde_schwarz.sgs100a.warnings.warn")
     @patch("qililab.instruments.rohde_schwarz.SGS100A.get_rs_options")
-    def test_initial_setup_method_wideband_off(self, mock_get_rs_options, mock_warn, sdg100a_wrong_op_mode: SGS100A):
+    def test_initial_setup_method_wrong_bypass(self, mock_get_rs_options, mock_warn, sdg100a_wrong_op_mode: SGS100A):
         """Test initial method when the runcard sets rf_on as False"""
         mock_get_rs_options.return_value = "Some,other,SGS-B112V"
         sdg100a_wrong_op_mode.initial_setup()
         assert sdg100a_wrong_op_mode.settings.operation_mode=="normal"
-        sdg100a_wrong_op_mode.write.assert_any_call(":SOUR:OPMode NORMal")
+        sdg100a_wrong_op_mode.device.write.assert_any_call(":SOUR:OPMode NORMal")
 
         mock_warn.assert_any_call(
             "Operation mode 'wrong_operation_mode' not allowed, defaulting to normal operation mode", ResourceWarning

--- a/tests/instruments/rohde_schwarz/test_rohde_schwarz_sgs100a.py
+++ b/tests/instruments/rohde_schwarz/test_rohde_schwarz_sgs100a.py
@@ -324,7 +324,7 @@ class TestSGS100A:
         sdg100a_bypass_mode.initial_setup()
         assert sdg100a_bypass_mode.settings.operation_mode == "bypass"
 
-    @patch("warnings.warn")
+    @patch("qililab.instruments.rohde_schwarz.sgs100a.warnings.warn")
     @patch("qililab.instruments.rohde_schwarz.SGS100A.get_rs_options")
     def test_initial_setup_method_wideband_off(self, mock_get_rs_options, mock_warn, sdg100a_wrong_op_mode: SGS100A):
         """Test initial method when the runcard sets rf_on as False"""

--- a/tests/instruments/rohde_schwarz/test_rohde_schwarz_sgs100a.py
+++ b/tests/instruments/rohde_schwarz/test_rohde_schwarz_sgs100a.py
@@ -30,7 +30,7 @@ def fixture_sdg100a() -> SGS100A:
 
 @pytest.fixture(name="sdg100a_iq")
 def fixture_sdg100a_iq() -> SGS100A:
-    """Fixture that returns an instance of a dummy QDAC-II."""
+    """Fixture that returns an instance of a dummy SGS100a."""
     sdg100a_iq = SGS100A(
         {
             "alias": "qdac",
@@ -49,7 +49,7 @@ def fixture_sdg100a_iq() -> SGS100A:
 
 @pytest.fixture(name="sdg100a_rf_off")
 def fixture_sdg100a_rf_off() -> SGS100A:
-    """Fixture that returns an instance of a dummy QDAC-II."""
+    """Fixture that returns an instance of a dummy SGS100a."""
     sdg100a_rf_off = SGS100A(
         {
             "alias": "qdac",
@@ -67,7 +67,7 @@ def fixture_sdg100a_rf_off() -> SGS100A:
 
 @pytest.fixture(name="sdg100a_alc_off")
 def fixture_sdg100a_alc_off() -> SGS100A:
-    """Fixture that returns an instance of a dummy QDAC-II."""
+    """Fixture that returns an instance of a dummy SGS100a."""
     sdg100a_alc_off = SGS100A(
         {
             "alias": "qdac",
@@ -85,7 +85,7 @@ def fixture_sdg100a_alc_off() -> SGS100A:
 
 @pytest.fixture(name="sdg100a_iq_mod_off")
 def fixture_sdg100a_iq_mod_off() -> SGS100A:
-    """Fixture that returns an instance of a dummy QDAC-II."""
+    """Fixture that returns an instance of a dummy SGS100a."""
     sdg100a_iq_mod_off = SGS100A(
         {
             "alias": "qdac",
@@ -103,7 +103,7 @@ def fixture_sdg100a_iq_mod_off() -> SGS100A:
 
 @pytest.fixture(name="sdg100a_wideband_off")
 def fixture_sdg100a_wideband_off() -> SGS100A:
-    """Fixture that returns an instance of a dummy QDAC-II."""
+    """Fixture that returns an instance of a dummy SGS100a."""
     sdg100a_wideband_off = SGS100A(
         {
             "alias": "qdac",
@@ -121,7 +121,7 @@ def fixture_sdg100a_wideband_off() -> SGS100A:
 
 @pytest.fixture(name="sdg100a_wideband_off_large_freq")
 def fixture_sdg100a_wideband_off_large_freq() -> SGS100A:
-    """Fixture that returns an instance of a dummy QDAC-II."""
+    """Fixture that returns an instance of a dummy SGS100a."""
     sdg100a_wideband_off_large_freq = SGS100A(
         {
             "alias": "qdac",
@@ -139,7 +139,7 @@ def fixture_sdg100a_wideband_off_large_freq() -> SGS100A:
 
 @pytest.fixture(name="sdg100a_wrong_power")
 def fixture_sdg100a_wrong_power() -> SGS100A:
-    """Fixture that returns an instance of a dummy QDAC-II."""
+    """Fixture that returns an instance of a dummy SGS100a."""
     sdg100a_wrong_power = SGS100A(
         {
             "alias": "qdac",
@@ -157,7 +157,7 @@ def fixture_sdg100a_wrong_power() -> SGS100A:
 
 @pytest.fixture(name="sdg100a_wrong_freq")
 def fixture_sdg100a_wrong_freq() -> SGS100A:
-    """Fixture that returns an instance of a dummy QDAC-II."""
+    """Fixture that returns an instance of a dummy SGS100a."""
     sdg100a_wrong_freq = SGS100A(
         {
             "alias": "qdac",
@@ -174,7 +174,7 @@ def fixture_sdg100a_wrong_freq() -> SGS100A:
 
 @pytest.fixture(name="sdg100a_bypass_mode")
 def fixture_sdg100a_bypass_mode() -> SGS100A:
-    """Fixture that returns an instance of a dummy QDAC-II."""
+    """Fixture that returns an instance of a dummy SGS100a."""
     sdg100a_wrong_op_mode = SGS100A(
         {
             "alias": "qdac",
@@ -190,9 +190,9 @@ def fixture_sdg100a_bypass_mode() -> SGS100A:
     sdg100a_wrong_op_mode.device = MagicMock()
     return sdg100a_wrong_op_mode
 
-@pytest.fixture(name="sdg100a_wrong_freq")
+@pytest.fixture(name="sdg100a_wrong_op_mode")
 def fixture_sdg100a_wrong_op_mode() -> SGS100A:
-    """Fixture that returns an instance of a dummy QDAC-II."""
+    """Fixture that returns an instance of a dummy SGS100a."""
     sdg100a_wrong_op_mode = SGS100A(
         {
             "alias": "qdac",
@@ -323,6 +323,19 @@ class TestSGS100A:
         mock_get_rs_options.return_value = "Some,other,SGS-B112V"
         sdg100a_bypass_mode.initial_setup()
         assert sdg100a_bypass_mode.settings.operation_mode == "bypass"
+
+    @patch("warnings.warn")
+    @patch("qililab.instruments.rohde_schwarz.SGS100A.get_rs_options")
+    def test_initial_setup_method_wideband_off(self, mock_get_rs_options, mock_warn, sdg100a_wrong_op_mode: SGS100A):
+        """Test initial method when the runcard sets rf_on as False"""
+        mock_get_rs_options.return_value = "Some,other,SGS-B112V"
+        sdg100a_wrong_op_mode.initial_setup()
+        assert sdg100a_wrong_op_mode.settings.operation_mode=="normal"
+        sdg100a_wrong_op_mode.write.assert_any_call(":SOUR:OPMode NORMal")
+
+        mock_warn.assert_any_call(
+            "Operation mode 'wrong_operation_mode' not allowed, defaulting to normal operation mode", ResourceWarning
+        )
 
     @patch("warnings.warn")
     @patch("qililab.instruments.rohde_schwarz.SGS100A.get_rs_options")

--- a/tests/instruments/rohde_schwarz/test_rohde_schwarz_sgs100a.py
+++ b/tests/instruments/rohde_schwarz/test_rohde_schwarz_sgs100a.py
@@ -12,10 +12,10 @@ from qililab.typings.enums import Parameter
 
 @pytest.fixture(name="sdg100a")
 def fixture_sdg100a() -> SGS100A:
-    """Fixture that returns an instance of a dummy QDAC-II."""
+    """Fixture that returns an instance of a dummy SGS100a."""
     sdg100a = SGS100A(
         {
-            "alias": "qdac",
+            "alias": "sgs100a",
             "power": 10,
             "frequency": 80e6,
             "rf_on": True,
@@ -179,7 +179,7 @@ def fixture_sdg100a_bypass_mode() -> SGS100A:
         {
             "alias": "qdac",
             "power": 10,
-            "frequency": 13e9,
+            "frequency": 8e9,
             "rf_on": True,
             "iq_modulation": True,
             "iq_wideband": True,


### PR DESCRIPTION
The R&S SGS100a driver has now the capability to change the operation mode between normal mode and bypass mode. The default mode is the normal mode. The allowed strings for each mode
in the settings are `normal` and `bypass`. If the instrument is reset the native instrument configuration defaults to normal.