### PR TITLE
qhc-1071-add-calibration-file-to-qbloxdraw

### DIFF
--- a/src/qililab/platform/platform.py
+++ b/src/qililab/platform/platform.py
@@ -1641,6 +1641,7 @@ class Platform:
         averages_displayed: bool = False,
         acquisition_showing: bool = True,
         bus_mapping: dict[str, str] | None = None,
+        calibration: Calibration | None = None
     ):
         """Draw the QProgram using QBlox Compiler whilst adding the knowledge of the platform
 
@@ -1657,7 +1658,7 @@ class Platform:
         """
         runcard_data = self._data_draw()
         qblox_draw = QbloxDraw()
-        sequencer = self.compile_qprogram(qprogram, bus_mapping)
+        sequencer = self.compile_qprogram(qprogram, bus_mapping, calibration)
         plotly_figure, _ = qblox_draw.draw(
             sequencer, runcard_data, time_window, averages_displayed, acquisition_showing
         )


### PR DESCRIPTION
We can now draw a qprogram with calibration file if using platform. Need to add it to qprogram draw