### PR TITLE
qhc-1071 add calibration file to qbloxdraw

### DIFF
--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -4,6 +4,9 @@
 
 ### Improvements
 
+- QbloxDraw now supports passing a calibration file as an argument when plotting from both the platform and qprogram.
+[#977](https://github.com/qilimanjaro-tech/qililab/pull/977)
+
 - Previously, `platform.draw(qprogram)` and `qprogram.draw()` returned the plotly object and the raw data being plotted. Now they return only the plotly object. This change ensures:
 
   - When calling `qprogram.draw()` or  `platform.draw(qprogram)` directly, the figure is displayed.

--- a/src/qililab/platform/platform.py
+++ b/src/qililab/platform/platform.py
@@ -1641,6 +1641,7 @@ class Platform:
         averages_displayed: bool = False,
         acquisition_showing: bool = True,
         bus_mapping: dict[str, str] | None = None,
+        calibration: Calibration | None = None
     ):
         """Draw the QProgram using QBlox Compiler whilst adding the knowledge of the platform
 
@@ -1657,7 +1658,7 @@ class Platform:
         """
         runcard_data = self._data_draw()
         qblox_draw = QbloxDraw()
-        sequencer = self.compile_qprogram(qprogram, bus_mapping)
+        sequencer = self.compile_qprogram(qprogram, bus_mapping, calibration)
         plotly_figure, _ = qblox_draw.draw(
             sequencer, runcard_data, time_window, averages_displayed, acquisition_showing
         )

--- a/src/qililab/qprogram/qprogram.py
+++ b/src/qililab/qprogram/qprogram.py
@@ -723,9 +723,8 @@ class QProgram(StructuredProgram):
         time_window: int | None = None,
         averages_displayed: bool = False,
         acquisition_showing: bool = True,
-        calibration: Calibration | None = None
-        ):
-        
+        calibration: Calibration | None = None,
+    ):
         """Draw the QProgram using QBlox Compiler
 
         Args:
@@ -744,6 +743,11 @@ class QProgram(StructuredProgram):
         qblox_draw = QbloxDraw()
         compiler = QbloxCompiler()
         sequencer = compiler.compile(qprogram=self, calibration=calibration)
-        plotly_figure, _ = qblox_draw.draw(sequencer=sequencer, time_window=time_window, averages_displayed=averages_displayed, acquisition_showing=acquisition_showing)
+        plotly_figure, _ = qblox_draw.draw(
+            sequencer=sequencer,
+            time_window=time_window,
+            averages_displayed=averages_displayed,
+            acquisition_showing=acquisition_showing,
+        )
         logger.warning("The drawing feature is currently only supported for QBlox.")
         return plotly_figure

--- a/src/qililab/qprogram/qprogram.py
+++ b/src/qililab/qprogram/qprogram.py
@@ -718,7 +718,14 @@ class QProgram(StructuredProgram):
             self.qprogram._active_block.append(operation)
             self.qprogram._buses.add(bus)
 
-    def draw(self, time_window=None, averages_displayed=False, acquisition_showing=True):
+    def draw(
+        self,
+        time_window: int | None = None,
+        averages_displayed: bool = False,
+        acquisition_showing: bool = True,
+        calibration: Calibration | None = None
+        ):
+        
         """Draw the QProgram using QBlox Compiler
 
         Args:
@@ -736,7 +743,7 @@ class QProgram(StructuredProgram):
 
         qblox_draw = QbloxDraw()
         compiler = QbloxCompiler()
-        sequencer = compiler.compile(self)
+        sequencer = compiler.compile(qprogram=self, calibration=calibration)
         plotly_figure, _ = qblox_draw.draw(sequencer=sequencer, time_window=time_window, averages_displayed=averages_displayed, acquisition_showing=acquisition_showing)
         logger.warning("The drawing feature is currently only supported for QBlox.")
         return plotly_figure


### PR DESCRIPTION
QbloxDraw now supports passing a calibration file as an argument when plotting from both the platform and qprogram.