### PR TITLE
(BUG) QbloxDraw acquire_weighted to take weights as integration duration

### DIFF
--- a/src/qililab/instruments/qblox/qblox_draw.py
+++ b/src/qililab/instruments/qblox/qblox_draw.py
@@ -83,10 +83,10 @@ class QbloxDraw:
             param["acquire_idx"] += 1
             classical_duration_acquire = self._get_value(program_line[1].split(',')[-1].strip(), register)
 
-            # If plotting from qprogram - assume that the integration_length is the classical duration of the Q1ASM command
-            integration_length = param.get("integration_length")
-            if integration_length is None:
-                integration_length = classical_duration_acquire
+            # the integration is different from the acquire duration but qililab always equate both, if qililab ever allows to have a different
+            # integration length from acquisition duration, the below line should be modified and the rest of the code will be able to handle
+            # the difference
+            integration_length = classical_duration_acquire
 
             #  Essentially interrupting the previous acquire that is still running and extend the acquiring status to the current acquire
             if len(param["acquiring_status"]) != param["classical_time_counter"]:


### PR DESCRIPTION
Previously, when plotting from the platform, the integration length was incorrectly taken from the runcard parameter. However, since Qililab currently only implements acquire_weighted, the integration length should instead be determined by the duration of the weight.
This has been corrected and now the behaviour of the acquire is the same when plotting from the platform or the qprogram
The integration length is defined as the duration of the acquire, not the weight, because Qililab ensures they are always equal.
As a result, two acquires cannot overlap in Qililab. However, in QbloxDraw’s logic, interruptions remain possible, similar to Play.