### PR TITLE
Quickfix to replace FlatTop variable sigma by smooth_duration

### DIFF
--- a/src/qililab/qprogram/qblox_compiler.py
+++ b/src/qililab/qprogram/qblox_compiler.py
@@ -685,14 +685,14 @@ class QbloxCompiler:
         elif (
             isinstance(waveform_I, FlatTop)
             and (waveform_Q is None or isinstance(waveform_Q, FlatTop))
-            and ((waveform_I.duration - (waveform_I.sigma + waveform_I.buffer) * 2) >= 100)
+            and ((waveform_I.duration - (waveform_I.smooth_duration + waveform_I.buffer) * 2) >= 100)
         ):
             smooth_waveform_I: FlatTop = deepcopy(waveform_I)
             smooth_waveform_Q: FlatTop | None = deepcopy(waveform_Q)
             duration = smooth_waveform_I.duration
             smooth_duration_I = (
-                smooth_waveform_I.sigma + smooth_waveform_I.buffer
-                if smooth_waveform_I.sigma + smooth_waveform_I.buffer > INST_MIN_WAIT
+                smooth_waveform_I.smooth_duration + smooth_waveform_I.buffer
+                if smooth_waveform_I.smooth_duration + smooth_waveform_I.buffer > INST_MIN_WAIT
                 else INST_MIN_WAIT
             )
             square_duration = duration - smooth_duration_I * 2
@@ -704,7 +704,7 @@ class QbloxCompiler:
 
             if isinstance(smooth_waveform_Q, FlatTop):
                 if (
-                    smooth_waveform_Q.sigma + smooth_waveform_Q.buffer != smooth_duration_I
+                    smooth_waveform_Q.smooth_duration + smooth_waveform_Q.buffer != smooth_duration_I
                     and smooth_duration_I != INST_MIN_WAIT
                 ):
                     raise ValueError("smooth_duration + buffer of both I and Q must be the same.")

--- a/src/qililab/waveforms/flat_top.py
+++ b/src/qililab/waveforms/flat_top.py
@@ -31,17 +31,17 @@ class FlatTop(Waveform):
     Args:
         duration (int): Duration of the pulse (ns).
         amplitude (float): Maximum amplitude of the pulse.
-        sigma (float, optional): duration of the smoothing component in ns.
+        smooth_duration (float, optional): duration of the smoothing component in ns.
         buffer (float, optional): Buffer of the waveform. Defaults to 0.
     """
 
     @requires_domain("amplitude", Domain.Voltage)
     @requires_domain("duration", Domain.Time)
-    def __init__(self, amplitude: float, duration: int, sigma: int, buffer: int = 0):
+    def __init__(self, amplitude: float, duration: int, smooth_duration: int, buffer: int = 0):
         super().__init__()
         self.amplitude = amplitude
         self.duration = duration
-        self.sigma = sigma
+        self.smooth_duration = smooth_duration
         self.buffer = buffer
 
     def envelope(self, resolution: int = 1) -> np.ndarray:
@@ -55,7 +55,7 @@ class FlatTop(Waveform):
         """
         x = np.arange(-self.duration / 2, self.duration / 2 + 1, resolution)
         A = self.amplitude
-        sigma = self.sigma
+        sigma = self.smooth_duration
         buf = self.buffer
         dur = self.duration
         return (

--- a/tests/qprogram/test_qblox_compiler.py
+++ b/tests/qprogram/test_qblox_compiler.py
@@ -379,31 +379,42 @@ def fixture_play_square_smooth_waveforms_with_optimization() -> QProgram:
     qp = QProgram()
     qp.play(
         bus="drive",
-        waveform=IQPair(I=FlatTop(1.0, duration=25, sigma=10), Q=FlatTop(0.5, duration=25, sigma=10)),
+        waveform=IQPair(
+            I=FlatTop(1.0, duration=25, smooth_duration=10), Q=FlatTop(0.5, duration=25, smooth_duration=10)
+        ),
     )
-    qp.play(bus="drive", waveform=FlatTop(1.0, duration=50, sigma=10))
-    qp.play(bus="drive", waveform=FlatTop(1.0, duration=500, sigma=10))
+    qp.play(bus="drive", waveform=FlatTop(1.0, duration=50, smooth_duration=10))
+    qp.play(bus="drive", waveform=FlatTop(1.0, duration=500, smooth_duration=10))
     qp.play(
         bus="drive",
-        waveform=IQPair(I=FlatTop(1.0, duration=25, sigma=1, buffer=1), Q=FlatTop(0.5, duration=25, sigma=1, buffer=1)),
+        waveform=IQPair(
+            I=FlatTop(1.0, duration=25, smooth_duration=1, buffer=1),
+            Q=FlatTop(0.5, duration=25, smooth_duration=1, buffer=1),
+        ),
     )
-    qp.play(bus="drive", waveform=FlatTop(1.0, duration=50, sigma=1, buffer=1))
-    qp.play(bus="drive", waveform=FlatTop(1.0, duration=104, sigma=1, buffer=1))
-    qp.play(bus="drive", waveform=FlatTop(1.0, duration=500, sigma=1, buffer=1))
+    qp.play(bus="drive", waveform=FlatTop(1.0, duration=50, smooth_duration=1, buffer=1))
+    qp.play(bus="drive", waveform=FlatTop(1.0, duration=104, smooth_duration=1, buffer=1))
+    qp.play(bus="drive", waveform=FlatTop(1.0, duration=500, smooth_duration=1, buffer=1))
     qp.play(
         bus="drive",
-        waveform=IQPair(I=FlatTop(1.0, duration=500, sigma=10), Q=FlatTop(0.5, duration=500, sigma=10)),
+        waveform=IQPair(
+            I=FlatTop(1.0, duration=500, smooth_duration=10), Q=FlatTop(0.5, duration=500, smooth_duration=10)
+        ),
     )
-    qp.play(bus="drive", waveform=FlatTop(1.0, duration=50_000, sigma=10))
-    qp.play(bus="drive", waveform=FlatTop(1.0, duration=9790223, sigma=10))
+    qp.play(bus="drive", waveform=FlatTop(1.0, duration=50_000, smooth_duration=10))
+    qp.play(bus="drive", waveform=FlatTop(1.0, duration=9790223, smooth_duration=10))
     qp.play(
         bus="drive",
-        waveform=IQPair(I=FlatTop(1.0, duration=9790223, sigma=10), Q=FlatTop(1.0, duration=9790223, sigma=10)),
+        waveform=IQPair(
+            I=FlatTop(1.0, duration=9790223, smooth_duration=10), Q=FlatTop(1.0, duration=9790223, smooth_duration=10)
+        ),
     )
-    qp.play(bus="drive", waveform=FlatTop(0.5, duration=1234567, sigma=10))
+    qp.play(bus="drive", waveform=FlatTop(0.5, duration=1234567, smooth_duration=10))
     qp.play(
         bus="drive",
-        waveform=IQPair(I=FlatTop(1.0, duration=1234567, sigma=10), Q=FlatTop(1.0, duration=1234567, sigma=10)),
+        waveform=IQPair(
+            I=FlatTop(1.0, duration=1234567, smooth_duration=10), Q=FlatTop(1.0, duration=1234567, smooth_duration=10)
+        ),
     )
     return qp
 
@@ -1506,7 +1517,10 @@ set_freq         R5
         qp = QProgram()
         qp.play(
             bus="drive",
-            waveform=IQPair(I=FlatTop(1.0, duration=250, sigma=10, buffer=10), Q=FlatTop(0.5, duration=250, sigma=10)),
+            waveform=IQPair(
+                I=FlatTop(1.0, duration=250, smooth_duration=10, buffer=10),
+                Q=FlatTop(0.5, duration=250, smooth_duration=10),
+            ),
         )
 
         compiler = QbloxCompiler()

--- a/tests/waveforms/test_flat_top.py
+++ b/tests/waveforms/test_flat_top.py
@@ -7,7 +7,7 @@ from qililab.waveforms import FlatTop
 
 @pytest.fixture(name="flat_top")
 def fixture_flat_top():
-    return FlatTop(amplitude=1, duration=30, sigma=10, buffer=1)
+    return FlatTop(amplitude=1, duration=30, smooth_duration=10, buffer=1)
 
 
 class TestFlatTop:
@@ -17,7 +17,7 @@ class TestFlatTop:
         """Test __init__ method"""
         assert flat_top.amplitude == 1
         assert flat_top.duration == 30
-        assert flat_top.sigma == 10
+        assert flat_top.smooth_duration == 10
         assert flat_top.buffer == 1
 
     def test_envelope(self, flat_top):
@@ -26,7 +26,7 @@ class TestFlatTop:
         # calculate envelope
         x = np.arange(-flat_top.duration / 2, flat_top.duration / 2 + 1, 2)
         A = flat_top.amplitude
-        sigma = flat_top.sigma
+        sigma = flat_top.smooth_duration
         buf = flat_top.buffer
         dur = flat_top.duration
         envelope = (


### PR DESCRIPTION
From petition from the measurement team I changed the name sigma to smooth_duration as matehmatically speacking that variable name had no sense. Now the variable refers to the duration of the smoothing in ns (or us, depending on the instrument).