### PR TITLE
[QUICKFIX] Counts documentation update

### DIFF
--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -5,7 +5,7 @@
 ### Improvements
 
 - QbloxDraw now supports passing a calibration file as an argument when plotting from both the platform and qprogram.
-[#977](https://github.com/qilimanjaro-tech/qililab/pull/977)
+  [#977](https://github.com/qilimanjaro-tech/qililab/pull/977)
 
 - Previously, `platform.draw(qprogram)` and `qprogram.draw()` returned the plotly object and the raw data being plotted. Now they return only the plotly object. This change ensures:
 
@@ -150,8 +150,8 @@ The data automatically selects between the local or shared domains depending on 
 ### Bug fixes
 
 - Qblox Draw: Previously, when plotting from the platform, the integration length was incorrectly taken from the runcard parameter. However, since Qililab currently only implements acquire_weighted, the integration length should instead be determined by the duration of the weight.
-This has been corrected and now the behaviour of the acquire is the same when plotting from the platform or the qprogram.
-The integration length is defined as the duration of the acquire, not the weight, because Qililab ensures they are always equal. As a result, two acquires cannot overlap in Qililab. However, in QbloxDraw’s logic, interruptions remain possible, similar to Play.
+  This has been corrected and now the behaviour of the acquire is the same when plotting from the platform or the qprogram.
+  The integration length is defined as the duration of the acquire, not the weight, because Qililab ensures they are always equal. As a result, two acquires cannot overlap in Qililab. However, in QbloxDraw’s logic, interruptions remain possible, similar to Play.
   [#982](https://github.com/qilimanjaro-tech/qililab/pull/982)
 
 - Removed the unsupported zorder kwarg from QbloxDraw plotting to prevent Plotly errors across environments.
@@ -191,4 +191,7 @@ The integration length is defined as the duration of the acquire, not the weight
   [#969](https://github.com/qilimanjaro-tech/qililab/pull/969)
 
 - Fixed an error inside set_parameter for OUT0_ATT and OUT1_ATT for the QRM-RF and QCM-RF. When the device was disconnected qililab tried to get the non existent device. not it executes as expected.
+  [#973](https://github.com/qilimanjaro-tech/qililab/pull/973)
+
+- Fixed documentation for results `counts`, now it warns the user that instead of `num_avg` they must use `num_bins`.
   [#973](https://github.com/qilimanjaro-tech/qililab/pull/973)

--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -194,4 +194,4 @@ The data automatically selects between the local or shared domains depending on 
   [#973](https://github.com/qilimanjaro-tech/qililab/pull/973)
 
 - Fixed documentation for results `counts`, now it warns the user that instead of `num_avg` they must use `num_bins`.
-  [#973](https://github.com/qilimanjaro-tech/qililab/pull/973)
+  [#989](https://github.com/qilimanjaro-tech/qililab/pull/989)

--- a/src/qililab/platform/platform.py
+++ b/src/qililab/platform/platform.py
@@ -174,7 +174,14 @@ class Platform:
             The obtained values correspond to the integral of the I/Q signals received by the digitizer.
             And they have shape `(#sequencers, 2, #bins)`, in this case you only have 1 sequencer and 1 bin.
 
-        You could also get the results in a more standard format, as already classified ``counts`` or ``probabilities`` dictionaries, with:
+        You could also get the results in a more standard format, as already classified ``counts`` or ``probabilities`` dictionaries.
+        To do so the call to execute circuit must be slightly different, as the number of averages must be 1:
+
+        .. code-block:: python
+            # Executing the platform with the same amount of loops but using bins:
+            result = platform.execute(program=circuit, num_avg=1, num_bins=1000, repetition_duration=6000)
+
+        Then:
 
         >>> result.counts
         {'0': 501, '1': 499}
@@ -1427,9 +1434,7 @@ class Platform:
 
             # Create platform:
             platform = build_platform(runcard="<path_to_runcard>")
-            transp_config = DigitalTranspilationConfig(
-                routing=True, optimize=False, router=Sabre, placer=ReverseTraversal
-            )
+            transp_config = DigitalTranspilationConfig(routing=True, optimize=False, router=Sabre, placer=ReverseTraversal)
 
             # Execute with automatic transpilation:
             result = platform.execute(c, num_avg=1000, transpilation_config=transp_config)
@@ -1638,7 +1643,7 @@ class Platform:
         averages_displayed: bool = False,
         acquisition_showing: bool = True,
         bus_mapping: dict[str, str] | None = None,
-        calibration: Calibration | None = None
+        calibration: Calibration | None = None,
     ):
         """Draw the QProgram using QBlox Compiler whilst adding the knowledge of the platform
 

--- a/src/qililab/platform/platform.py
+++ b/src/qililab/platform/platform.py
@@ -178,6 +178,7 @@ class Platform:
         To do so the call to execute circuit must be slightly different, as the number of averages must be 1:
 
         .. code-block:: python
+
             # Executing the platform with the same amount of loops but using bins:
             result = platform.execute(program=circuit, num_avg=1, num_bins=1000, repetition_duration=6000)
 

--- a/src/qililab/result/qblox_results/qblox_bins_acquisitions.py
+++ b/src/qililab/result/qblox_results/qblox_bins_acquisitions.py
@@ -62,7 +62,9 @@ class QbloxBinsAcquisitions(Acquisitions):
         counts_object = Counts(n_qubits=len(self.bins))
         for seq in self.bins:
             if any(bin_avg > 1 for bin_avg in seq.avg_cnt):
-                raise ValueError("Counts cannot be used when using a hardware average higher than 1.")
+                raise ValueError(
+                    "Counts cannot be used with a hardware average higher than 1. Try setting the num_avg to 1 and the num_bin as the desired value."
+                )
         for bin_idx in range(num_bins):
             # The threshold inside of a qblox bin is the name they use for already classified data as a value between
             # 0 and 1, not the value used in the comparator to perform such classification.


### PR DESCRIPTION
Fixed documentation for results `counts`, now it warns the user that instead of `num_avg` they must use `num_bins`.