### PR TITLE
[QUICKFIX] QDAC2 is now able to use more than one instrument controller

### DIFF
--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -192,3 +192,6 @@ The integration length is defined as the duration of the acquire, not the weight
 
 - Fixed an error inside set_parameter for OUT0_ATT and OUT1_ATT for the QRM-RF and QCM-RF. When the device was disconnected qililab tried to get the non existent device. not it executes as expected.
   [#973](https://github.com/qilimanjaro-tech/qililab/pull/973)
+
+- Fixed an error impeding two instances of QDAC2 to be executed through platform.connect when the runcard included 2 different `qdevil_qdac2` controllers inside `instrument_controllers`.
+  [#990](https://github.com/qilimanjaro-tech/qililab/pull/990)

--- a/src/qililab/instrument_controllers/qdevil/qdevil_qdac2_controller.py
+++ b/src/qililab/instrument_controllers/qdevil/qdevil_qdac2_controller.py
@@ -46,9 +46,9 @@ class QDevilQDac2Controller(SingleInstrumentController):
     def _initialize_device(self):
         """Initialize device attribute to the corresponding device class."""
         if self.settings.connection.name == ConnectionName.TCP_IP:
-            self.device = QDevilQDac2Device(f"{self.name.value}", f"TCPIP::{self.address}::5025::SOCKET")
+            self.device = QDevilQDac2Device(f"{self.name.value}_{self.alias}", f"TCPIP::{self.address}::5025::SOCKET")
         else:
-            self.device = QDevilQDac2Device(f"{self.name.value}", f"ASRL/dev/{self.address}::INSTR")
+            self.device = QDevilQDac2Device(f"{self.name.value}_{self.alias}", f"ASRL/dev/{self.address}::INSTR")
 
     def _check_supported_modules(self):
         """check if all instrument modules loaded are supported modules for the controller."""

--- a/tests/instrument_controllers/qdevil/test_qdevil_qdac2_controller.py
+++ b/tests/instrument_controllers/qdevil/test_qdevil_qdac2_controller.py
@@ -50,7 +50,7 @@ class TestQDevilQDac2Controller:
 
         controller_instance._initialize_device()
 
-        name = f"{controller_instance.name.value}"
+        name = f"{controller_instance.name.value}_{controller_instance.alias}"
         address = (
             f"TCPIP::{controller_instance.address}::5025::SOCKET"
             if controller_instance.connection.name == ConnectionName.TCP_IP


### PR DESCRIPTION
Now the qcods QDAC2Device instance creates a QDAC2 device with an name depending on the intrumentcontroller's name and alias (just like RS)