### PR TITLE
Fix ExperimentExecutor with databases test creating a file

### DIFF
--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -106,6 +106,7 @@ platform.execute_experiment(experiment)
 ```
 
 [#938](https://github.com/qilimanjaro-tech/qililab/pull/938)
+[#997](https://github.com/qilimanjaro-tech/qililab/pull/997)
 
 - Minor modification at database `DatabaseManager`, as it now requires the config file to contain a `base_path_local`, `base_path_shared` and `data_write_folder`. following the structure:
 

--- a/tests/qprogram/test_experiment_executor.py
+++ b/tests/qprogram/test_experiment_executor.py
@@ -274,54 +274,6 @@ class TestExperimentExecutor:
             assert qprogram2_measurement1_data.shape == (3, 11, 2)
             assert np.allclose(qprogram2_measurement1_data, measurement_data[None, :, :])
 
-    # @patch("qililab.platform.platform.get_db_manager")
-    # @patch("qililab.result.experiment_results_writer.h5py.File")
-    # def test_execute_database(self, mock_h5_file, mock_get_db_manager, platform, experiment):
-    #     """Test the execute with database as True."""
-    #     platform.save_experiment_results_in_database = True
-    #     platform.db_optional_identifier = "test"
-
-    #     expected_result_path = "/tmp/20250710/155901/experiment.h5"
-
-    #     mock_measurement = Mock()
-    #     mock_measurement.result_path = expected_result_path
-
-    #     mock_db_manager = Mock()
-    #     mock_db_manager.current_sample = "sample"
-    #     mock_db_manager.current_cd = "cd"
-    #     mock_db_manager.add_measurement.return_value = mock_measurement
-    #     mock_get_db_manager.return_value = mock_db_manager
-
-    #     mock_file = Mock()
-    #     mock_h5_file.return_value = mock_file
-
-    #     mock_writer = MagicMock()
-    #     mock_writer.__enter__.return_value = mock_writer
-    #     mock_writer.__exit__.return_value = None
-    #     mock_writer.results_path = "/tmp/test/path"
-    #     mock_writer.execution_time = 0.0
-    #     mock_writer_cls = MagicMock()
-    #     mock_writer_cls.return_value = mock_writer
-
-    #     executor = ExperimentExecutor(
-    #         platform=platform,
-    #         experiment=experiment,
-    #         live_plot=False,
-    #         slurm_execution=False,
-    #     )
-
-    #     mock_writer = MagicMock()
-    #     mock_writer.__enter__.return_value = mock_writer
-    #     mock_writer.__exit__.return_value = None
-    #     mock_writer.results_path = "/tmp/test/path"
-    #     mock_writer.execution_time = 0.0
-    #     mock_writer_cls = MagicMock()
-    #     mock_writer_cls.return_value = mock_writer
-
-    #     executor.execute()
-
-    # assert executor._db_metadata is not None
-
     @patch("qililab.platform.platform.get_db_manager")
     @patch("qililab.result.experiment_results_writer.h5py.File")
     def test_execute_database_metadata_only(self, mock_h5_file, mock_get_db_manager, platform, experiment):


### PR DESCRIPTION
Due to a missing mock on the H5py.File a file was created everytime the tests were run. This has been fixed.

In addition, the assertions for the database have been modified following the rest of the tests code.