### PR TITLE
qhc-1115-bug-qblox-wait-from-65532-to-65535-raises-an-error

### DIFF
--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -176,6 +176,9 @@ The data automatically selects between the local or shared domains depending on 
 
 ### Bug fixes
 
+- Fixed a bug in the QBlox Compiler handling of the wait, long waits that were a multiple of 65532 (the maximum wait) up to 65535 or a multiple of any of these were giving out an error. This has been solved by checking if the remainder would be below 4 and appending the wait being added as needed.
+  [#1006](https://github.com/qilimanjaro-tech/qililab/pull/1006)
+
 - Exposed `Platform` in the global namespace.
   [#1002](https://github.com/qilimanjaro-tech/qililab/pull/1002)
 

--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -176,7 +176,7 @@ The data automatically selects between the local or shared domains depending on 
 
 ### Bug fixes
 
-- Fixed a bug in the QBlox Compiler handling of the wait, long waits that were a multiple of 65532 (the maximum wait) up to 65535 or a multiple of any of these were giving out an error. This has been solved by checking if the remainder would be below 4 and appending the wait being added as needed.
+- Fixed a bug in the QBlox Compiler handling of the wait, long waits that were a multiple of 65532 (the maximum wait) up to 65535 were giving out an error. This has been solved by checking if the remainder would be below 4. If the remainder is 0 it appends a wait of 65532 and if the remainder is between 1 and 3, the duration of the last wait is computed as : `(INST_MAX_WAIT + remainder) - INST_MIN_WAIT` (where `INST_MAX_WAIT` is 65532 and `INST_MIN_WAIT` is 4) and a wait of `INST_MIN_WAIT` is added.
   [#1006](https://github.com/qilimanjaro-tech/qililab/pull/1006)
 
 - Exposed `Platform` in the global namespace.

--- a/src/qililab/qprogram/qblox_compiler.py
+++ b/src/qililab/qprogram/qblox_compiler.py
@@ -505,28 +505,28 @@ class QbloxCompiler:
             remainder = duration % INST_MAX_WAIT
             if duration > INST_MAX_WAIT:
                 for iteration in range(duration // INST_MAX_WAIT):
-                    if iteration == (duration // INST_MAX_WAIT)-1 and 0 <= remainder < 4: # if last iteration and if the remainder would cause a problem
+                    if iteration == (duration // INST_MAX_WAIT) - 1 and 0 <= remainder < INST_MIN_WAIT:  # handle the remainder at the last iteration if below 4
                         if remainder == 0:
                             self._buses[bus].qpy_block_stack[-1].append_component(
                                 component=QPyInstructions.Wait(wait_time=INST_MAX_WAIT)
                             )
                         else:
-                            self._buses[bus].qpy_block_stack[-1].append_component(component=QPyInstructions.Wait(wait_time=(INST_MAX_WAIT + remainder) - 4))
-                            self._buses[bus].qpy_block_stack[-1].append_component(component=QPyInstructions.Wait(wait_time = 4))
+                            self._buses[bus].qpy_block_stack[-1].append_component(component=QPyInstructions.Wait(wait_time=(INST_MAX_WAIT + remainder) - INST_MIN_WAIT))
+                            self._buses[bus].qpy_block_stack[-1].append_component(component=QPyInstructions.Wait(wait_time=INST_MIN_WAIT))
                             remainder = 0
-        
+
                         break
-                        
+
                     self._buses[bus].qpy_block_stack[-1].append_component(
                         component=QPyInstructions.Wait(wait_time=INST_MAX_WAIT)
                     )
-            
+
             if duration == INST_MAX_WAIT:
                 self._buses[bus].qpy_block_stack[-1].append_component(
                         component=QPyInstructions.Wait(wait_time=INST_MAX_WAIT)
                     )
 
-            elif remainder >= 4:
+            elif remainder >= INST_MIN_WAIT:
                 self._buses[bus].qpy_block_stack[-1].append_component(
                     component=QPyInstructions.Wait(wait_time=duration % INST_MAX_WAIT)
                 )

--- a/tests/qprogram/test_qblox_compiler.py
+++ b/tests/qprogram/test_qblox_compiler.py
@@ -449,6 +449,17 @@ def update_latched_param() -> QProgram:
     qp.wait(bus="drive", duration=6)
     return qp
 
+@pytest.fixture(name="wait_comprised_between_65532_65535")
+def fixture_wait_comprised_between_65532_65535() -> QProgram:
+    qp = QProgram()
+    qp.wait("drive",duration=65532*2)
+    qp.play("drive", Square(1,20))
+    qp.wait(bus="drive", duration=65532)
+    qp.play("drive", Square(1,20))
+    qp.wait(bus="drive", duration=65534)
+
+    return qp
+
 
 class TestQBloxCompiler:
     def test_play_named_operation_and_bus_mapping(self, play_named_operation: QProgram, calibration: Calibration):
@@ -1722,6 +1733,33 @@ set_freq         R5
                             upd_param        6
                             set_mrk          0
                             upd_param        4
+                            stop
+        """
+
+        assert is_q1asm_equal(sequences["drive"], drive_str)
+
+    def test_wait_comprised_between_65532_65535(self, wait_comprised_between_65532_65535: QProgram):
+        compiler = QbloxCompiler()
+        sequences, _ = compiler.compile(qprogram=wait_comprised_between_65532_65535)
+
+        assert "drive" in sequences
+
+        drive_str = """
+            setup:
+                            wait_sync        4              
+                            set_mrk          0              
+                            upd_param        4              
+
+            main:
+                            wait             65532          
+                            wait             65532          
+                            play             0, 1, 20       
+                            wait             65532          
+                            play             0, 1, 20       
+                            wait             65530          
+                            wait             4              
+                            set_mrk          0              
+                            upd_param        4              
                             stop
         """
 


### PR DESCRIPTION
Fixed a bug in the QBlox Compiler handling of the wait, long waits that were a multiple of 65532 (the maximum wait) up to 65535 were giving out an error. This has been solved by checking if the remainder would be below 4. If the remainder is 0 it appends a wait of 65532 and if the remainder is between 1 and 3, the duration of the last wait is computed as : `(INST_MAX_WAIT + remainder) - INST_MIN_WAIT` (where `INST_MAX_WAIT` is 65532 and `INST_MIN_WAIT` is 4) and a wait of `INST_MIN_WAIT` is added.