### PR TITLE
qhc-1111-optimise-q1asm-length

### DIFF
--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -176,7 +176,7 @@ The data automatically selects between the local or shared domains depending on 
 
 ### Bug fixes
 
-- Qblox Draw- When dealing with real time and classical time, the real duration was put instead of the wait duration. Note: do not include in the next release.
+- Qblox Draw- When dealing with real time and classical time, the real duration was put instead of the wait duration. Note: do not include this comment in the next release changelog as the bug was not in the previous release.
 
 - Fixed a bug in the QBlox Compiler handling of the wait, long waits that were a multiple of 65532 (the maximum wait) up to 65535 were giving out an error. This has been solved by checking if the remainder would be below 4. If the remainder is 0 it appends a wait of 65532 and if the remainder is between 1 and 3, the duration of the last wait is computed as : `(INST_MAX_WAIT + remainder) - INST_MIN_WAIT` (where `INST_MAX_WAIT` is 65532 and `INST_MIN_WAIT` is 4) and a wait of `INST_MIN_WAIT` is added.
   [#1006](https://github.com/qilimanjaro-tech/qililab/pull/1006)

--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -176,6 +176,8 @@ The data automatically selects between the local or shared domains depending on 
 
 ### Bug fixes
 
+- Qblox Draw- When dealing with real time and classical time, the real duration was put instead of the wait duration. Note: do not include in the next release.
+
 - Fixed a bug in the QBlox Compiler handling of the wait, long waits that were a multiple of 65532 (the maximum wait) up to 65535 were giving out an error. This has been solved by checking if the remainder would be below 4. If the remainder is 0 it appends a wait of 65532 and if the remainder is between 1 and 3, the duration of the last wait is computed as : `(INST_MAX_WAIT + remainder) - INST_MIN_WAIT` (where `INST_MAX_WAIT` is 65532 and `INST_MIN_WAIT` is 4) and a wait of `INST_MIN_WAIT` is added.
   [#1006](https://github.com/qilimanjaro-tech/qililab/pull/1006)
 

--- a/src/qililab/instruments/qblox/qblox_draw.py
+++ b/src/qililab/instruments/qblox/qblox_draw.py
@@ -52,7 +52,7 @@ class QbloxDraw:
             param["classical_time_counter"] += int(wait_duration)
             real_wait = wait_duration - param["real_time_counter"]
             if real_wait <= 0:
-                param["real_time_counter"] = param["real_time_counter"] - real_wait  # update the real time counter
+                param["real_time_counter"] = param["real_time_counter"] - wait_duration  # update the real time counter
             else:
                 data_draw = self._handle_wait_draw(data_draw, param, real_wait)
                 param["real_time_counter"] = max(0, param["real_time_counter"] - wait_duration)
@@ -78,8 +78,7 @@ class QbloxDraw:
             elif wf_length < classical_duration_play:
                 real_play_wait = classical_duration_play - wf_length
                 data_draw = self._handle_wait_draw(data_draw, param, real_play_wait)
-                # The counter is not being reset to 0 here because this allows overlaying a future acquire if needed
-                param["real_time_counter"] = param["real_time_counter"] - classical_duration_play
+                param["real_time_counter"] = 0
 
         elif action_type == "acquire_weighed":
             param["acquire_idx"] += 1

--- a/tests/instruments/qblox/test_qblox_draw.py
+++ b/tests/instruments/qblox/test_qblox_draw.py
@@ -155,7 +155,6 @@ def fixture_play_interrupted_by_another_play():
     qp.qblox.play("drive",Square(1,10),7)
     qp.qblox.play("drive",Square(-1,10),1)
     qp.wait("drive", 5)
-    qp.wait("drive", 10)
     return qp
 
 @pytest.fixture(name="qp_not_sub")
@@ -451,18 +450,15 @@ class TestQBloxDraw:
 
     def test_play_interrupted_by_another_play(self, qp_play_interrupted_by_another_play: QProgram):
         expected_data_draw_i = [ 0.70710678,  0.70710678,  0.70710678,  0.70710678,  0.70710678,
-          0.70710678,  0.70710678, -0.70710678, -0.70710678, -0.70710678,
-         -0.70710678, -0.70710678, -0.70710678, -0.70710678, -0.70710678,
-         -0.70710678, -0.70710678,  0.        ,  0.        ,  0.        ]
-        expected_data_draw_q = [0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
-         0., 0., 0.]
+                  0.70710678,  0.70710678, -0.70710678, -0.70710678, -0.70710678,
+                 -0.70710678, -0.70710678, -0.70710678, -0.70710678, -0.70710678,
+                 -0.70710678, -0.70710678]
         compiler = QbloxCompiler()
         qblox_draw = QbloxDraw()
         results = compiler.compile(qp_play_interrupted_by_another_play)
         pio.renderers.default = "json"
         _, data_draw = qblox_draw.draw(sequencer=results, runcard_data= None)
         np.testing.assert_allclose(data_draw["drive"][0], expected_data_draw_i, rtol=1e-2, atol=1e-12)
-        np.testing.assert_allclose(data_draw["drive"][1], expected_data_draw_q, rtol=1e-2, atol=1e-12)
 
     def test_qp_not_sub(self, qp_not_sub: QProgram):
         expected_data_draw_i = [ 7.07106781e-01,  5.72061403e-01,  2.18508014e-01, -2.18508009e-01,


### PR DESCRIPTION
[BUG] -  When dealing with real time classical time in the qblox draw the real duration was put instead of the wait duration