### PR TITLE
qhc-1061-update-qblox-instruments-to-0160-and-qblox-firmware-to-011

### DIFF
--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -4,6 +4,9 @@
 
 ### Improvements
 
+- Update qblox-instruments to 0.16.0 and qblox firmware to 0.11
+[#1015](https://github.com/qilimanjaro-tech/qililab/pull/1015)
+
 - This PR is the beginning of a series that will aim to reduce the length of the Q1ASM, which can be limiting for some experiments. This PR has two distinct improvements:
   1. When possible, waits will be combined together. For example, before this PR the following Q1ASM could be generated:
       ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "papermill>=2.6.0",
     "psycopg2-binary>=2.9.10",
     "pyvisa-py>=0.7.2",
-    "qblox-instruments==0.14.2",
+    "qblox-instruments==0.16.0",
     "qcodes>=0.51.0",
     "qcodes-contrib-drivers>=0.23.0",
     "qibo==0.2.15",

--- a/uv.lock
+++ b/uv.lock
@@ -2991,7 +2991,7 @@ wheels = [
 
 [[package]]
 name = "qblox-instruments"
-version = "0.14.2"
+version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastjsonschema" },
@@ -3000,7 +3000,7 @@ dependencies = [
     { name = "qcodes" },
     { name = "spirack" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/3b/b6371da7190c080530e731979f755d58310f6649e73dd0472b1810193aaa/qblox_instruments-0.14.2.tar.gz", hash = "sha256:92a3a6c5530cbaf912a525147314c7de4fe23897d5824ad798fd02e7f179c03f", size = 1349262 }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/48/7974ef40f055866a48091477d691b8f85ea5312a60a8f3ced5af6a1edede/qblox_instruments-0.16.0.tar.gz", hash = "sha256:8a9785d916af27a35c0c51a6a870de5ed879cadb56fff1ee47f4a79a2cf0ad62", size = 2289124 }
 
 [[package]]
 name = "qcodes"
@@ -3140,7 +3140,7 @@ requires-dist = [
     { name = "papermill", specifier = ">=2.6.0" },
     { name = "psycopg2-binary", specifier = ">=2.9.10" },
     { name = "pyvisa-py", specifier = ">=0.7.2" },
-    { name = "qblox-instruments", specifier = "==0.14.2" },
+    { name = "qblox-instruments", specifier = "==0.16.0" },
     { name = "qcodes", specifier = ">=0.51.0" },
     { name = "qcodes-contrib-drivers", specifier = ">=0.23.0" },
     { name = "qibo", specifier = "==0.2.15" },


### PR DESCRIPTION
Update qblox-instruments to 0.16.0