### PR TITLE
[QHC-1279] Database measurement calibration table and multiple autocalibration qubits

### DIFF
--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -32,6 +32,9 @@
 - For Autocalibration database, moved `sample_name` and `cooldown` from `AutocalMeasurement` (independent experiment) to `CalibrationRun` (full calibration tree). This way the database does not include redundant information, as these variables do not change from one measurement to another, only in different calibration runs.
   [#1053](https://github.com/qilimanjaro-tech/qililab/pull/1053)
 
+- Added sequence run table to measurements database. This table works similar to calibration run and is intended to store a series of experiment runs one after the other. Added `add_sequence_run` to database manager to operate it. Also modified the quibit index on the autocalibration database from integer to string to take into account two qubit gate experiments.
+  [#1070](https://github.com/qilimanjaro-tech/qililab/pull/1070)
+
 ### Breaking changes
 
 - All references to **Qibo** have been removed, and any functionality relying on Qibo-based components has been eliminated.

--- a/src/qililab/result/database/__init__.py
+++ b/src/qililab/result/database/__init__.py
@@ -41,7 +41,7 @@ Functions
 
 from .database_autocal import AutocalMeasurement, CalibrationRun
 from .database_manager import DatabaseManager, get_db_manager, load_by_id
-from .database_measurements import Cooldown, Measurement, Sample
+from .database_measurements import Cooldown, Measurement, Sample, SequenceRun
 from .database_qaas import QaaS_Experiment
 
 __all__ = [

--- a/src/qililab/result/database/__init__.py
+++ b/src/qililab/result/database/__init__.py
@@ -52,6 +52,7 @@ __all__ = [
     "Measurement",
     "QaaS_Experiment",
     "Sample",
+    "SequenceRun",
     "get_db_manager",
     "load_by_id",
 ]

--- a/src/qililab/result/database/database_autocal.py
+++ b/src/qililab/result/database/database_autocal.py
@@ -81,7 +81,7 @@ class AutocalMeasurement(base):  # type: ignore
     calibration_id: Column = Column("calibration_id", ForeignKey(CalibrationRun.calibration_id), nullable=False)
     result_path: Column = Column("result_path", String, unique=True, nullable=False)
     fitting_path: Column = Column("fitting_path", String, unique=True, nullable=True)
-    qbit_idx: Column = Column("qbit_idx", Integer)
+    qbit_idx: Column = Column("qbit_idx", String)
     platform_after: Column = Column("platform_after", JSONB)
     platform_before: Column = Column("platform_before", JSONB)
     qprogram: Column = Column("qprogram", JSONB)

--- a/src/qililab/result/database/database_manager.py
+++ b/src/qililab/result/database/database_manager.py
@@ -168,7 +168,7 @@ class DatabaseManager:
             running_session.add(sequence_obj)
             try:
                 running_session.commit()
-                self.current_sequence = sequence_obj.sequence_id
+                self.current_sequence = sequence_obj.sequence_id  # type: ignore[assignment]
                 return sequence_obj
 
             except Exception as e:

--- a/src/qililab/result/database/database_manager.py
+++ b/src/qililab/result/database/database_manager.py
@@ -226,12 +226,6 @@ class DatabaseManager:
                 running_session.query(AutocalMeasurement).where(AutocalMeasurement.measurement_id == id).one_or_none()
             )
 
-            if measurement_by_id is not None:
-                path = measurement_by_id.result_path
-                if not os.path.isfile(path):
-                    new_path = path.replace(self.base_path_local, self.base_path_share)
-                    measurement_by_id.result_path = new_path
-
             return measurement_by_id
 
     def load_experiment_by_id(self, id: int) -> QaaS_Experiment | None:

--- a/src/qililab/result/database/database_manager.py
+++ b/src/qililab/result/database/database_manager.py
@@ -604,7 +604,7 @@ class DatabaseManager:
             experiment_completed=experiment_completed,
             start_time=start_time,
             cooldown=cooldown,
-            sequence_id = self.current_sequence,
+            sequence_id=self.current_sequence,
             optional_identifier=optional_identifier,
             end_time=end_time,
             run_length=run_length,

--- a/src/qililab/result/database/database_manager.py
+++ b/src/qililab/result/database/database_manager.py
@@ -158,7 +158,7 @@ class DatabaseManager:
             sequence_tree (dict): Full experiment sequence tree of the run.
         """
         sequence_obj = SequenceRun(
-            date=datetime.datetime.now(),
+            start_time=datetime.datetime.now(),
             sequence_tree=sequence_tree,
             sequence_completed=False,
             sample_name=sample_name,

--- a/src/qililab/result/database/database_measurements.py
+++ b/src/qililab/result/database/database_measurements.py
@@ -96,6 +96,29 @@ class Sample(base):  # type: ignore
         return f"{self.sample_name} {self.manufacturer} {self.additional_info}"
 
 
+class SequenceRun(base):  # type: ignore
+    """Creates and manipulates a sequence of measurements run metadata database"""
+
+    __tablename__ = "sequence_run"
+
+    sequence_id: Column = Column("sequence_id", Integer, primary_key=True)
+    date: Column = Column("date", DateTime)
+    sequence_tree: Column = Column("sequence_tree", JSONB)
+    sequence_completed: Column = Column("sequence_completed", Boolean, nullable=False)
+    cooldown: Column = Column("cooldown", ForeignKey(Cooldown.cooldown), index=True)
+    sample_name: Column = Column("sample_name", ForeignKey(Sample.sample_name), nullable=False)
+
+    def __init__(self, date, sequence_tree, sequence_completed, sample_name, cooldown):
+        self.date = date
+        self.sequence_tree = sequence_tree
+        self.sequence_completed = sequence_completed
+        self.sample_name = sample_name
+        self.cooldown = cooldown
+        
+    def __repr__(self):
+        return f"{self.sequence_id} {self.date} {self.sequence_completed} {self.sample_name} {self.cooldown}"
+
+
 class Measurement(base):  # type: ignore
     """Creates and manipulates Measurement metadata database"""
 
@@ -108,8 +131,8 @@ class Measurement(base):  # type: ignore
     end_time: Column = Column("end_time", DateTime)
     run_length: Column = Column("run_length", Interval)
     experiment_completed: Column = Column("experiment_completed", Boolean, nullable=False)
-    # TODO: add temperature = Column("temperature", ARRAY(Integer)) when available
     cooldown: Column = Column("cooldown", ForeignKey(Cooldown.cooldown), index=True)
+    sequence_id: Column = Column("sequence_id", Integer)
     sample_name: Column = Column("sample_name", ForeignKey(Sample.sample_name), nullable=False)
     result_path: Column = Column("result_path", String, unique=True, nullable=False)
     platform: Column = Column("platform", JSONB)
@@ -197,6 +220,7 @@ class Measurement(base):  # type: ignore
         experiment_completed,
         start_time,
         cooldown=None,
+        sequence_id=None,
         optional_identifier=None,
         end_time=None,
         run_length=None,
@@ -217,6 +241,7 @@ class Measurement(base):  # type: ignore
 
         # Optional fields
         self.cooldown = cooldown
+        self.sequence_id = sequence_id
         self.optional_identifier = optional_identifier
         self.end_time = end_time
         self.run_length = run_length

--- a/src/qililab/result/database/database_measurements.py
+++ b/src/qililab/result/database/database_measurements.py
@@ -114,7 +114,7 @@ class SequenceRun(base):  # type: ignore
         self.sequence_completed = sequence_completed
         self.sample_name = sample_name
         self.cooldown = cooldown
-        
+
     def __repr__(self):
         return f"{self.sequence_id} {self.date} {self.sequence_completed} {self.sample_name} {self.cooldown}"
 

--- a/src/qililab/result/database/database_measurements.py
+++ b/src/qililab/result/database/database_measurements.py
@@ -143,7 +143,7 @@ class SequenceRun(base):  # type: ignore
                 raise e
 
     def __repr__(self):
-        return f"{self.sequence_id} {self.date} {self.sequence_completed} {self.sample_name} {self.cooldown}"
+        return f"{self.sequence_id} {self.start_time} {self.sequence_completed} {self.sample_name} {self.cooldown}"
 
 
 class Measurement(base):  # type: ignore

--- a/tests/result/test_database.py
+++ b/tests/result/test_database.py
@@ -658,7 +658,7 @@ class Testdatabase:
             result = db_manager.load_calibration_by_id(123)
 
         db_manager._mock_session.query.assert_called
-        assert result.result_path == "/shared_test/results/file.h5"
+        assert result.result_path == "/local_test/results/file.h5"
 
     def test_load_calibration_by_id_path_not_found(self, db_manager: DatabaseManager):
         # Setup a mock measurement


### PR DESCRIPTION
Oscar requested a new table on the measurement database to handle sequences of measurements such as the ones in seqtante. The main purpose will be for calibrating the crosstalk matrix but this can give many other users as it allows for total flexibility

We also need to modify the data type of the quibit index to be a string, as it can be either a int or a list.

Create the table and columns in the measurement database en pgAdmin and qililab database_measurement.py