### PR TITLE
qhc-1295-bug-vna-set_parameter-with-enums

### DIFF
--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -58,6 +58,9 @@
 
 ### Bug fixes
 
+- [BUG] - VNA E5080B Driver. Enum Parameters were passing the entire Enum to the device causing an error when setting the parameter. Now the value of the Enum is passed to the device.
+  [#1072](https://github.com/qilimanjaro-tech/qililab/pull/1072)
+
 - Calibration file: The `with_calibration` method in `qprogram` was not storing the needed information to import blocks, this information is now being stored.
   The `insert_block` method in `structured_qprogram` has been modified such that the block is flattened, hence each element is added separately, rather than adding the block. Adding the block directly was causing problems at compilation because adding twice in a single `qprogram` the same block meant they shared the same UUID.
   [#1050](https://github.com/qilimanjaro-tech/qililab/pull/1050)

--- a/src/qililab/instruments/keysight/e5080b_vna.py
+++ b/src/qililab/instruments/keysight/e5080b_vna.py
@@ -362,13 +362,13 @@ class E5080B(Instrument):
 
         if parameter == Parameter.SWEEP_TYPE:
             self.settings.sweep_type = VNASweepTypes(value)
-            if self.is_device_active() and self.sweep_type.value is not None:
+            if self.is_device_active() and self.sweep_type is not None:
                 self.device.sweep_type(self.sweep_type.value)
             return
 
         if parameter == Parameter.SWEEP_MODE:
             self.settings.sweep_mode = VNASweepModes(value)
-            if self.is_device_active() and self.sweep_mode.value is not None:
+            if self.is_device_active() and self.sweep_mode is not None:
                 self.device.sweep_mode(self.sweep_mode.value)
             return
 

--- a/src/qililab/instruments/keysight/e5080b_vna.py
+++ b/src/qililab/instruments/keysight/e5080b_vna.py
@@ -362,31 +362,31 @@ class E5080B(Instrument):
 
         if parameter == Parameter.SWEEP_TYPE:
             self.settings.sweep_type = VNASweepTypes(value)
-            if self.is_device_active():
+            if self.is_device_active() and self.sweep_type.value is not None:
                 self.device.sweep_type(self.sweep_type.value)
             return
 
         if parameter == Parameter.SWEEP_MODE:
             self.settings.sweep_mode = VNASweepModes(value)
-            if self.is_device_active():
+            if self.is_device_active() and self.sweep_mode.value is not None:
                 self.device.sweep_mode(self.sweep_mode.value)
             return
 
         if parameter == Parameter.TRIGGER_SLOPE:
             self.settings.trigger_slope = VNATriggerSlope(value)
-            if self.is_device_active():
+            if self.is_device_active() and self.trigger_slope is not None:
                 self.device.trigger_slope(self.trigger_slope.value)
             return
 
         if parameter == Parameter.TRIGGER_SOURCE:
             self.settings.trigger_source = VNATriggerSource(value)
-            if self.is_device_active():
+            if self.is_device_active() and self.trigger_source is not None:
                 self.device.trigger_source(self.trigger_source.value)
             return
 
         if parameter == Parameter.TRIGGER_TYPE:
             self.settings.trigger_type = VNATriggerType(value)
-            if self.is_device_active():
+            if self.is_device_active() and self.trigger_type is not None:
                 self.device.trigger_type(self.trigger_type.value)
             return
 
@@ -410,7 +410,7 @@ class E5080B(Instrument):
 
         if parameter == Parameter.SCATTERING_PARAMETER:
             self.settings.scattering_parameter = VNAScatteringParameters(value)
-            if self.is_device_active():
+            if self.is_device_active() and self.scattering_parameter is not None:
                 self.device.scattering_parameter(self.scattering_parameter.value)
             return
 
@@ -428,7 +428,7 @@ class E5080B(Instrument):
 
         if parameter == Parameter.AVERAGES_MODE:
             self.settings.averages_mode = VNAAverageModes(value)
-            if self.is_device_active():
+            if self.is_device_active() and self.averages_mode is not None:
                 self.device.averages_mode(self.averages_mode.value)
             return
 
@@ -440,7 +440,7 @@ class E5080B(Instrument):
 
         if parameter == Parameter.FORMAT_BORDER:
             self.settings.format_border = VNAFormatBorder(value)
-            if self.is_device_active():
+            if self.is_device_active() and self.format_border is not None:
                 self.device.format_border(self.format_border.value)
             return
 

--- a/src/qililab/instruments/keysight/e5080b_vna.py
+++ b/src/qililab/instruments/keysight/e5080b_vna.py
@@ -363,31 +363,31 @@ class E5080B(Instrument):
         if parameter == Parameter.SWEEP_TYPE:
             self.settings.sweep_type = VNASweepTypes(value)
             if self.is_device_active():
-                self.device.sweep_type(self.sweep_type)
+                self.device.sweep_type(self.sweep_type.value)
             return
 
         if parameter == Parameter.SWEEP_MODE:
             self.settings.sweep_mode = VNASweepModes(value)
             if self.is_device_active():
-                self.device.sweep_mode(self.sweep_mode)
+                self.device.sweep_mode(self.sweep_mode.value)
             return
 
         if parameter == Parameter.TRIGGER_SLOPE:
             self.settings.trigger_slope = VNATriggerSlope(value)
             if self.is_device_active():
-                self.device.trigger_slope(self.trigger_slope)
+                self.device.trigger_slope(self.trigger_slope.value)
             return
 
         if parameter == Parameter.TRIGGER_SOURCE:
             self.settings.trigger_source = VNATriggerSource(value)
             if self.is_device_active():
-                self.device.trigger_source(self.trigger_source)
+                self.device.trigger_source(self.trigger_source.value)
             return
 
         if parameter == Parameter.TRIGGER_TYPE:
             self.settings.trigger_type = VNATriggerType(value)
             if self.is_device_active():
-                self.device.trigger_type(self.trigger_type)
+                self.device.trigger_type(self.trigger_type.value)
             return
 
         if parameter == Parameter.SWEEP_GROUP_COUNT:
@@ -411,7 +411,7 @@ class E5080B(Instrument):
         if parameter == Parameter.SCATTERING_PARAMETER:
             self.settings.scattering_parameter = VNAScatteringParameters(value)
             if self.is_device_active():
-                self.device.scattering_parameter(self.scattering_parameter)
+                self.device.scattering_parameter(self.scattering_parameter.value)
             return
 
         if parameter == Parameter.AVERAGES_ENABLED:
@@ -429,7 +429,7 @@ class E5080B(Instrument):
         if parameter == Parameter.AVERAGES_MODE:
             self.settings.averages_mode = VNAAverageModes(value)
             if self.is_device_active():
-                self.device.averages_mode(self.averages_mode)
+                self.device.averages_mode(self.averages_mode.value)
             return
 
         if parameter == Parameter.RF_ON:
@@ -441,7 +441,7 @@ class E5080B(Instrument):
         if parameter == Parameter.FORMAT_BORDER:
             self.settings.format_border = VNAFormatBorder(value)
             if self.is_device_active():
-                self.device.format_border(self.format_border)
+                self.device.format_border(self.format_border.value)
             return
 
         if parameter == Parameter.ELECTRICAL_DELAY:


### PR DESCRIPTION
[BUG] - VNA E5080B Driver. Enum Parameters were passing the entire Enum to the device causing an error when setting the parameter. Now the value of the Enum is passed to the device.