### PR TITLE
[FIX] Measurement database folder processing for parallel qprogram with same folder path

### DIFF
--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -21,9 +21,6 @@
 - For Autocalibration database, moved `sample_name` and `cooldown` from `AutocalMeasurement` (independent experiment) to `CalibrationRun` (full calibration tree). This way the database does not include redundant information, as these variables do not change from one measurement to another, only in different calibration runs.
   [#1053](https://github.com/qilimanjaro-tech/qililab/pull/1053)
 
-- Added sequence run table to measurements database. This table works similar to calibration run and is intended to store a series of experiment runs one after the other. Added `add_sequence_run` to database manager to operate it. Also modified the quibit index on the autocalibration database from integer to string to take into account two qubit gate experiments.
-  [#1070](https://github.com/qilimanjaro-tech/qililab/pull/1070)
-
 - Added a `data_folder` option to `get_db_manager` to overwrite other base paths generated.
   [#1074](https://github.com/qilimanjaro-tech/qililab/pull/1074)
 

--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -24,6 +24,9 @@
 - Added sequence run table to measurements database. This table works similar to calibration run and is intended to store a series of experiment runs one after the other. Added `add_sequence_run` to database manager to operate it. Also modified the quibit index on the autocalibration database from integer to string to take into account two qubit gate experiments.
   [#1070](https://github.com/qilimanjaro-tech/qililab/pull/1070)
 
+- Added a `data_folder` option to `get_db_manager` to overwrite other base paths generated.
+  [#1074](https://github.com/qilimanjaro-tech/qililab/pull/1074)
+
 ### Breaking changes
 
 ### Deprecations / Removals
@@ -31,3 +34,6 @@
 ### Documentation
 
 ### Bug fixes
+
+- Fixed conflict with base path not being unique for parallel qprogram executions in StreamArray. To fix it, the path now includes the target index whenever there is one, which is the case for parallel executions. For any other existing case the behavior remains the same.
+  [#1074](https://github.com/qilimanjaro-tech/qililab/pull/1074)

--- a/src/qililab/result/database/__init__.py
+++ b/src/qililab/result/database/__init__.py
@@ -40,7 +40,7 @@ Functions
 """
 from .database_autocal import AutocalMeasurement, CalibrationRun
 from .database_manager import DatabaseManager, get_db_manager, load_by_id
-from .database_measurements import Cooldown, Measurement, Sample, SequenceRun
+from .database_measurements import Cooldown, Measurement, Sample
 from .database_qaas import QaaS_Experiment
 
 __all__ = [
@@ -51,7 +51,6 @@ __all__ = [
     "Measurement",
     "QaaS_Experiment",
     "Sample",
-    "SequenceRun",
     "get_db_manager",
     "load_by_id",
 ]

--- a/src/qililab/result/database/database_manager.py
+++ b/src/qililab/result/database/database_manager.py
@@ -431,7 +431,7 @@ class DatabaseManager:
         with self.session() as running_session:
             calibration_id = running_session.query(CalibrationRun).order_by(CalibrationRun.calibration_id.desc()).first().calibration_id  # type: ignore
 
-        base_path = calibration.parameters["base_path"]
+        base_path = calibration.parameters["data_folder"]
 
         result_path = os.path.join(base_path, f"{experiment_name}.h5")
 
@@ -524,6 +524,7 @@ class DatabaseManager:
         debug_file: str | None = None,
         parameters: list[str] | None = None,
         data_shape: np.ndarray | None = None,
+        target: str | int | None = None,
     ):
         """Add measurement metadata and data path
 
@@ -562,10 +563,12 @@ class DatabaseManager:
             if base_path[-1] == "/"
             else f"{base_path}/{self.current_sample}/{self.current_cd}/{formatted_time}"
         )
+        if target is not None:
+            dir_path = f"{dir_path}/{target}" if isinstance(target, str) else f"{dir_path}/q_{target}"
         result_path = f"{dir_path}/{experiment_name}.h5"
 
         folder = dir_path
-        if not os.path.isfile(folder):
+        if not os.path.isdir(folder):
             os.makedirs(folder)
             warnings.warn(f"Data folder did not exist. Created one at {folder}")
 

--- a/src/qililab/result/database/database_manager.py
+++ b/src/qililab/result/database/database_manager.py
@@ -25,7 +25,7 @@ from sqlalchemy import create_engine, exists
 from sqlalchemy.orm import Session, sessionmaker
 
 from qililab.result.database.database_autocal import AutocalMeasurement, CalibrationRun
-from qililab.result.database.database_measurements import Cooldown, Measurement, Sample, SequenceRun
+from qililab.result.database.database_measurements import Cooldown, Measurement, Sample
 from qililab.result.database.database_qaas import QaaS_Experiment
 from qililab.utils.serialization import serialize
 
@@ -52,7 +52,6 @@ class DatabaseManager:
         self.session: sessionmaker[Session] = sessionmaker(bind=self.engine, expire_on_commit=False)
         self.current_cd: str | None = None
         self.current_sample: str | None = None
-        self.current_sequence: int | None = None
 
         self.base_path_local: str | None = None
         self.base_path_share: str | None = None
@@ -150,30 +149,6 @@ class DatabaseManager:
             running_session.add(sample_obj)
             try:
                 running_session.commit()
-            except Exception as e:
-                running_session.rollback()
-                raise e
-
-    def add_sequence_run(self, sequence_tree: dict, sample_name: str, cooldown: str | None = None) -> SequenceRun:
-        """Add sequence of experiments metadata.
-
-        Args:
-            sequence_tree (dict): Full experiment sequence tree of the run.
-        """
-        sequence_obj = SequenceRun(
-            start_time=datetime.datetime.now(),
-            sequence_tree=sequence_tree,
-            sequence_completed=False,
-            sample_name=sample_name,
-            cooldown=cooldown,
-        )
-        with self.session() as running_session:
-            running_session.add(sequence_obj)
-            try:
-                running_session.commit()
-                self.current_sequence = sequence_obj.sequence_id  # type: ignore[assignment]
-                return sequence_obj
-
             except Exception as e:
                 running_session.rollback()
                 raise e
@@ -560,7 +535,7 @@ class DatabaseManager:
 
         start_time = datetime.datetime.now()
         formatted_time = start_time.strftime("%Y-%m-%d/%H_%M_%S")
-        
+
         if self.data_folder is not None:
             base_path = self.data_folder
         else:
@@ -588,7 +563,6 @@ class DatabaseManager:
             experiment_completed=experiment_completed,
             start_time=start_time,
             cooldown=cooldown,
-            sequence_id=self.current_sequence,
             optional_identifier=optional_identifier,
             end_time=end_time,
             run_length=run_length,

--- a/src/qililab/result/database/database_manager.py
+++ b/src/qililab/result/database/database_manager.py
@@ -41,7 +41,7 @@ class DatabaseManager:
 
     calibration_measurement: AutocalMeasurement
 
-    def __init__(self, filename: str, database_name: str):
+    def __init__(self, filename: str, database_name: str, data_folder: str | None):
         """
         Args:
             filename (str): location of the database `.ini`.
@@ -57,10 +57,13 @@ class DatabaseManager:
         self.base_path_local: str | None = None
         self.base_path_share: str | None = None
         self.folder_path: str | None = None
+        self.data_folder: str | None = None
 
         if "base_path_local" in config:
             self.base_path_local = config["base_path_local"]
+        if "base_path_shared" in config:
             self.base_path_share = config["base_path_shared"]
+        if "data_write_folder" in config:
             self.folder_path = config["data_write_folder"]
 
     def set_sample_and_cooldown(self, sample: str, cooldown: str | None = None):
@@ -431,7 +434,10 @@ class DatabaseManager:
         with self.session() as running_session:
             calibration_id = running_session.query(CalibrationRun).order_by(CalibrationRun.calibration_id.desc()).first().calibration_id  # type: ignore
 
-        base_path = calibration.parameters["data_folder"]
+        if self.data_folder is not None:
+            base_path = self.data_folder
+        else:
+            base_path = calibration.parameters["data_folder"]
 
         result_path = os.path.join(base_path, f"{experiment_name}.h5")
 
@@ -554,10 +560,13 @@ class DatabaseManager:
 
         start_time = datetime.datetime.now()
         formatted_time = start_time.strftime("%Y-%m-%d/%H_%M_%S")
-
-        base_path = f"{self.base_path_local}{self.folder_path}"
-        if not os.path.isdir(base_path):
-            base_path = f"{self.base_path_share}{self.folder_path}"
+        
+        if self.data_folder is not None:
+            base_path = self.data_folder
+        else:
+            base_path = f"{self.base_path_local}{self.folder_path}"
+            if not os.path.isdir(base_path):
+                base_path = f"{self.base_path_share}{self.folder_path}"
         dir_path = (
             f"{base_path}{self.current_sample}/{self.current_cd}/{formatted_time}"
             if base_path[-1] == "/"
@@ -701,10 +710,10 @@ def _load_config(filename, section):
     raise ReferenceError("Section {0} not found in the {1} file".format(section, filename))
 
 
-def get_db_manager(path: str = "~/database.ini", database_name: str = "postgresql") -> DatabaseManager:
+def get_db_manager(path: str = "~/database.ini", database_name: str = "postgresql", data_folder: str | None = None) -> DatabaseManager:
     """Automatic DatabaseManager generator based on default load_config"""
     filename = os.path.expanduser(path)
-    return DatabaseManager(filename, database_name)
+    return DatabaseManager(filename, database_name, data_folder)
 
 
 def get_engine(user: str, passwd: str, host: str, port: str, database: str):

--- a/src/qililab/result/database/database_manager.py
+++ b/src/qililab/result/database/database_manager.py
@@ -41,7 +41,7 @@ class DatabaseManager:
 
     calibration_measurement: AutocalMeasurement
 
-    def __init__(self, filename: str, database_name: str, data_folder: str | None):
+    def __init__(self, filename: str, database_name: str, data_folder: str | None = None):
         """
         Args:
             filename (str): location of the database `.ini`.
@@ -56,7 +56,7 @@ class DatabaseManager:
         self.base_path_local: str | None = None
         self.base_path_share: str | None = None
         self.folder_path: str | None = None
-        self.data_folder: str | None = None
+        self.data_folder: str | None = data_folder
 
         if "base_path_local" in config:
             self.base_path_local = config["base_path_local"]

--- a/src/qililab/result/database/database_measurements.py
+++ b/src/qililab/result/database/database_measurements.py
@@ -96,56 +96,6 @@ class Sample(base):  # type: ignore
         return f"{self.sample_name} {self.manufacturer} {self.additional_info}"
 
 
-class SequenceRun(base):  # type: ignore
-    """Creates and manipulates a sequence of measurements run metadata database"""
-
-    __tablename__ = "sequence_run"
-
-    sequence_id: Column = Column("sequence_id", Integer, primary_key=True)
-    start_time: Column = Column("start_time", DateTime, nullable=False)
-    end_time: Column = Column("end_time", DateTime)
-    run_length: Column = Column("run_length", Interval)
-    sequence_tree: Column = Column("sequence_tree", JSONB)
-    sequence_completed: Column = Column("sequence_completed", Boolean, nullable=False)
-    cooldown: Column = Column("cooldown", ForeignKey(Cooldown.cooldown), index=True)
-    sample_name: Column = Column("sample_name", ForeignKey(Sample.sample_name), nullable=False)
-
-    def __init__(
-        self, start_time, sequence_tree, sequence_completed, sample_name, end_time=None, run_length=None, cooldown=None
-    ):
-        self.start_time = start_time
-        self.end_time = end_time
-        self.run_length = run_length
-        self.sequence_tree = sequence_tree
-        self.sequence_completed = sequence_completed
-        self.sample_name = sample_name
-        self.cooldown = cooldown
-
-    def end_sequence(self, session: sessionmaker[Session], traceback: str | None = None):
-        """Function to end sequence of experiments. The function sets inside the database information
-        about the end of the sequence: the finishing time, completeness status and sequence length."""
-
-        with session() as running_session:
-            # Merge the detached instance into the current session
-            persistent_instance = running_session.merge(self)
-            persistent_instance.end_time = datetime.datetime.now()  # type: ignore[assignment]
-            persistent_instance.run_length = persistent_instance.end_time - persistent_instance.start_time  # type: ignore[assignment]
-            self.end_time = persistent_instance.end_time
-            self.run_length = persistent_instance.run_length
-            try:
-                if traceback is None:
-                    persistent_instance.sequence_completed = True  # type: ignore[assignment]
-                    self.sequence_completed = True  # type: ignore[assignment]
-                running_session.commit()
-                return persistent_instance
-            except Exception as e:
-                running_session.rollback()
-                raise e
-
-    def __repr__(self):
-        return f"{self.sequence_id} {self.start_time} {self.sequence_completed} {self.sample_name} {self.cooldown}"
-
-
 class Measurement(base):  # type: ignore
     """Creates and manipulates Measurement metadata database"""
 
@@ -159,7 +109,6 @@ class Measurement(base):  # type: ignore
     run_length: Column = Column("run_length", Interval)
     experiment_completed: Column = Column("experiment_completed", Boolean, nullable=False)
     cooldown: Column = Column("cooldown", ForeignKey(Cooldown.cooldown), index=True)
-    sequence_id: Column = Column("sequence_id", Integer)
     sample_name: Column = Column("sample_name", ForeignKey(Sample.sample_name), nullable=False)
     result_path: Column = Column("result_path", String, unique=True, nullable=False)
     platform: Column = Column("platform", JSONB)
@@ -247,7 +196,6 @@ class Measurement(base):  # type: ignore
         experiment_completed,
         start_time,
         cooldown=None,
-        sequence_id=None,
         optional_identifier=None,
         end_time=None,
         run_length=None,
@@ -268,7 +216,6 @@ class Measurement(base):  # type: ignore
 
         # Optional fields
         self.cooldown = cooldown
-        self.sequence_id = sequence_id
         self.optional_identifier = optional_identifier
         self.end_time = end_time
         self.run_length = run_length

--- a/src/qililab/result/stream_results.py
+++ b/src/qililab/result/stream_results.py
@@ -63,7 +63,7 @@ class StreamArray:
         bus_mapping: dict[str, str] | None = None,
         optional_identifier: str | None = None,
         autocalibration: bool = False,
-        qubit_idx: int | None = None,
+        qubit_idx: str | int | None = None,
     ):
         self.results: np.ndarray
         self.shape = [shape] if isinstance(shape, int) else shape
@@ -107,6 +107,7 @@ class StreamArray:
                     qprogram=serialize(self.qprogram) if self.qprogram else None,
                     calibration=serialize(self.calibration) if self.calibration else None,
                     debug_file=self._get_debug() if self.platform and self.qprogram else None,
+                    target=self.qubit_idx,
                 )
             self.path = self.measurement.result_path
 

--- a/tests/result/test_database.py
+++ b/tests/result/test_database.py
@@ -776,6 +776,42 @@ class Testdatabase:
 
     @patch("qililab.result.database.database_manager.os.makedirs")
     @patch("qililab.result.database.database_manager.datetime")
+    def test_add_autocal_measurement_data_folder(self, mock_datetime, mock_makedirs, db_manager: DatabaseManager):
+        # Setup
+        mock_session_instance = MagicMock()
+        mock_session_context = MagicMock()
+        mock_session_context.__enter__.return_value = mock_session_instance
+        db_manager.session = MagicMock(return_value=mock_session_context)
+
+        mock_calibration_id = MagicMock()
+        mock_query = MagicMock()
+        mock_order_by = MagicMock()
+        mock_calibration_id.calibration_id = 1  
+        mock_order_by.first.return_value = mock_calibration_id
+        mock_query.order_by.return_value = mock_order_by
+        mock_session_instance.query.return_value = mock_query
+
+        fixed_time = datetime.datetime(2023, 1, 1, 12, 0, 0)
+        mock_datetime.datetime.now.return_value = fixed_time
+        mock_datetime.datetime.strftime = datetime.datetime.strftime  # fallback
+
+        calibration = Calibration()
+        calibration.parameters = {"sample_name": "sampleA", "cooldown": "cdX", "data_folder": "/shared_test/"}
+
+        db_manager.data_folder = "/shared_test/"
+
+        # Act
+        measurement = db_manager.add_autocal_measurement(experiment_name="exp1", qubit_idx=0, calibration=calibration)
+
+        # Assert
+        expected_path = "/shared_test/exp1.h5"
+        assert measurement.result_path == expected_path
+        db_manager._mock_session.add.assert_called_once
+        db_manager._mock_session.commit.assert_called_once
+        mock_makedirs.assert_called_once_with("/shared_test/")
+
+    @patch("qililab.result.database.database_manager.os.makedirs")
+    @patch("qililab.result.database.database_manager.datetime")
     def test_add_autocal_measurement_raises_exception(self, mock_datetime, mock_makedirs, db_manager: DatabaseManager):
 
         fixed_time = datetime.datetime(2023, 1, 1, 12, 0, 0)
@@ -873,6 +909,28 @@ class Testdatabase:
         # Setup
         db_manager.current_sample = "sampleA"
         db_manager.current_cd = "cdX"
+
+        fixed_time = datetime.datetime(2023, 1, 1, 12, 0, 0)
+        mock_datetime.datetime.now.return_value = fixed_time
+        mock_datetime.datetime.strftime = datetime.datetime.strftime  # fallback
+
+        # Act
+        measurement = db_manager.add_measurement("exp1", experiment_completed=True)
+
+        # Assert
+        expected_path = "/shared_test/measurement_folder/sampleA/cdX/2023-01-01/12_00_00/exp1.h5"
+        assert measurement.result_path == expected_path
+        db_manager._mock_session.add.assert_called_once
+        db_manager._mock_session.commit.assert_called_once
+        mock_makedirs.assert_called_once_with("/shared_test/measurement_folder/sampleA/cdX/2023-01-01/12_00_00")
+
+    @patch("qililab.result.database.database_manager.os.makedirs")
+    @patch("qililab.result.database.database_manager.datetime")
+    def test_add_measurement_data_folder(self, mock_datetime, mock_makedirs, db_manager: DatabaseManager):
+        # Setup
+        db_manager.current_sample = "sampleA"
+        db_manager.current_cd = "cdX"
+        db_manager.data_folder = "/shared_test/measurement_folder"
 
         fixed_time = datetime.datetime(2023, 1, 1, 12, 0, 0)
         mock_datetime.datetime.now.return_value = fixed_time

--- a/tests/result/test_database.py
+++ b/tests/result/test_database.py
@@ -926,6 +926,27 @@ class Testdatabase:
 
     @patch("qililab.result.database.database_manager.os.makedirs")
     @patch("qililab.result.database.database_manager.datetime")
+    def test_add_measurement_with_target(self, mock_datetime, mock_makedirs, db_manager: DatabaseManager):
+        # Setup
+        db_manager.current_sample = "sampleA"
+        db_manager.current_cd = "cdX"
+
+        fixed_time = datetime.datetime(2023, 1, 1, 12, 0, 0)
+        mock_datetime.datetime.now.return_value = fixed_time
+        mock_datetime.datetime.strftime = datetime.datetime.strftime  # fallback
+
+        # Act
+        measurement = db_manager.add_measurement("exp1", experiment_completed=True, target=1)
+
+        # Assert
+        expected_path = "/shared_test/measurement_folder/sampleA/cdX/2023-01-01/12_00_00/exp1.h5"
+        assert measurement.result_path == expected_path
+        db_manager._mock_session.add.assert_called_once
+        db_manager._mock_session.commit.assert_called_once
+        mock_makedirs.assert_called_once_with("/shared_test/measurement_folder/sampleA/cdX/2023-01-01/12_00_00/q_1")
+
+    @patch("qililab.result.database.database_manager.os.makedirs")
+    @patch("qililab.result.database.database_manager.datetime")
     def test_add_measurement_data_folder(self, mock_datetime, mock_makedirs, db_manager: DatabaseManager):
         # Setup
         db_manager.current_sample = "sampleA"

--- a/tests/result/test_database.py
+++ b/tests/result/test_database.py
@@ -589,7 +589,7 @@ class Testdatabase:
             result = db_manager.load_calibration_by_id(123)
 
         db_manager._mock_session.query.assert_called
-        assert result.result_path == "/shared_test/results/file.h5"
+        assert result.result_path == "/local_test/results/file.h5"
 
     def test_load_calibration_by_id_path_not_found(self, db_manager: DatabaseManager):
         # Setup a mock measurement
@@ -763,7 +763,7 @@ class Testdatabase:
         mock_datetime.datetime.strftime = datetime.datetime.strftime  # fallback
 
         calibration = Calibration()
-        calibration.parameters = {"sample_name": "sampleA", "cooldown": "cdX", "base_path": "/shared_test/"}
+        calibration.parameters = {"sample_name": "sampleA", "cooldown": "cdX", "data_folder": "/shared_test/"}
         # Act
         measurement = db_manager.add_autocal_measurement(experiment_name="exp1", qubit_idx=0, calibration=calibration)
 
@@ -787,7 +787,7 @@ class Testdatabase:
         mock_session.commit.side_effect = Exception("DB error")
 
         calibration = Calibration()
-        calibration.parameters = {"sample_name": "sampleA", "cooldown": "cdX", "base_path": "/shared_test/"}
+        calibration.parameters = {"sample_name": "sampleA", "cooldown": "cdX", "data_folder": "/shared_test/"}
 
         db_manager.session = MagicMock(return_value=mock_session)
 
@@ -812,7 +812,7 @@ class Testdatabase:
         mock_session_instance.query.return_value = mock_query
 
         calibration = Calibration()
-        calibration.parameters = {"sample_name": "sampleA", "cooldown": "cdX", "base_path": "/shared_test/"}
+        calibration.parameters = {"sample_name": "sampleA", "cooldown": "cdX", "data_folder": "/shared_test/"}
         # Act
         db_manager.add_autocal_measurement(experiment_name="exp1", qubit_idx=0, calibration=calibration)
 
@@ -1030,7 +1030,7 @@ def test_load_config_missing_section(mock_config_parser):
 def test_get_db_manager(mock_db_manager):
     filename = os.path.expanduser("~/database.ini")
     get_db_manager()
-    mock_db_manager.assert_called_once_with(filename, "postgresql")
+    mock_db_manager.assert_called_once_with(filename, "postgresql", None)
 
 
 @patch("qililab.result.database.database_manager.create_engine")

--- a/tests/result/test_database.py
+++ b/tests/result/test_database.py
@@ -939,7 +939,7 @@ class Testdatabase:
         measurement = db_manager.add_measurement("exp1", experiment_completed=True, target=1)
 
         # Assert
-        expected_path = "/shared_test/measurement_folder/sampleA/cdX/2023-01-01/12_00_00/exp1.h5"
+        expected_path = "/shared_test/measurement_folder/sampleA/cdX/2023-01-01/12_00_00/q_1/exp1.h5"
         assert measurement.result_path == expected_path
         db_manager._mock_session.add.assert_called_once
         db_manager._mock_session.commit.assert_called_once

--- a/tests/result/test_database.py
+++ b/tests/result/test_database.py
@@ -22,7 +22,7 @@ from qililab.result.database.database_manager import (
     get_engine,
     load_by_id,
 )
-from qililab.result.database.database_measurements import Measurement, SequenceRun
+from qililab.result.database.database_measurements import Measurement
 
 mpl.use("Agg")  # Use non-interactive backend for testing
 
@@ -69,17 +69,6 @@ def fixture_measurement():
         experiment_completed=False,
         start_time=datetime.datetime(2023, 1, 1, 12, 0, 0),
         cooldown="CDX",
-    )
-
-
-@pytest.fixture(name="sequence_run")
-def fixture_sequence_run():
-    return SequenceRun(
-        sequence_tree={"test_run":"test_experiment"},
-        sample_name="sampleA",
-        cooldown="CDX",
-        sequence_completed=False,
-        start_time=datetime.datetime(2023, 1, 1, 12, 0, 0),
     )
 
 
@@ -495,106 +484,6 @@ class Testdatabase:
 
         mock_session.rollback.assert_called_once
 
-    def test_add_sequence_run(self, db_manager: DatabaseManager):
-        sequence_tree = {
-            "nodes": [
-                {
-                    "name": "TwoTone",
-                    "experiment": "two_tone",
-                    "parameters": {
-                        "qubit_idx": [11, 13],
-                        "hw_avg": 2000,
-                        "repetition_duration": 200000,
-                        "sweep_values": [-5e6, 5e6, 0.2e6],
-                    },
-                },
-                {
-                    "name": "Rabi",
-                    "experiment": "rabi",
-                    "parameters": {
-                        "qubit_idx": [11, 13],
-                        "hw_avg": 4000,
-                        "repetition_duration": 200000,
-                        "sweep_values": [0, 1, 61],
-                    },
-                },
-            ],
-            "dependencies": [["TwoTone", "Rabi"]],
-        }
-
-        db_manager.add_sequence_run(sequence_tree=sequence_tree, sample_name="sampleA", cooldown="CDX")
-
-        db_manager._mock_session.add.assert_called
-        db_manager._mock_session.commit.assert_called
-        
-    def test_add_sequence_run_raises_exception(self, db_manager: DatabaseManager):
-        sequence_tree = {
-            "nodes": [
-                {
-                    "name": "TwoTone",
-                    "experiment": "two_tone",
-                    "parameters": {
-                        "qubit_idx": [11, 13],
-                        "hw_avg": 2000,
-                        "repetition_duration": 200000,
-                        "sweep_values": [-5e6, 5e6, 0.2e6],
-                    },
-                },
-                {
-                    "name": "Rabi",
-                    "experiment": "rabi",
-                    "parameters": {
-                        "qubit_idx": [11, 13],
-                        "hw_avg": 4000,
-                        "repetition_duration": 200000,
-                        "sweep_values": [0, 1, 61],
-                    },
-                },
-            ],
-            "dependencies": [["TwoTone", "Rabi"]],
-        }
-
-        mock_session = MagicMock()
-        mock_session.__enter__.return_value = mock_session
-        mock_session.commit.side_effect = Exception("DB error")
-
-        db_manager.session = MagicMock(return_value=mock_session)
-
-        with pytest.raises(Exception, match="DB error"):
-            db_manager.add_sequence_run(sequence_tree=sequence_tree, sample_name="sampleA", cooldown="CDX")
-
-        mock_session.rollback.assert_called_once
-    
-    @patch("qililab.result.database.database_measurements.datetime")
-    def test_end_sequence(self, mock_datetime, sequence_run):
-        fixed_now = datetime.datetime(2023, 1, 1, 12, 0, 0)
-        mock_datetime.datetime.now.return_value = fixed_now
-
-        mock_session_context = MagicMock()
-        mock_session = MagicMock()
-        mock_session_context.__enter__.end_sequence = mock_session
-        mock_session.merge.return_value = sequence_run
-
-        result = sequence_run.end_sequence(lambda: mock_session_context)
-
-        assert result.end_time == fixed_now
-        assert result.sequence_completed is True
-
-    @patch("qililab.result.database.database_measurements.datetime")
-    def test_end_sequence_raises_exception(self, mock_datetime, sequence_run):
-        fixed_now = datetime.datetime(2023, 1, 1, 12, 0, 0)
-        mock_datetime.datetime.now.return_value = fixed_now
-
-        mock_session_context = MagicMock()
-        mock_session = MagicMock()
-        mock_session_context.__enter__.return_value = mock_session
-        mock_session.merge.return_value = sequence_run
-        mock_session.commit.side_effect = Exception("Measurement error")
-
-        with pytest.raises(Exception, match="Measurement error"):
-            result = sequence_run.end_sequence(lambda: mock_session_context)
-
-        mock_session.rollback.assert_called_once()
 
     def test_add_calibration_run(self, db_manager: DatabaseManager):
         calibration_tree = {
@@ -700,7 +589,7 @@ class Testdatabase:
             result = db_manager.load_calibration_by_id(123)
 
         db_manager._mock_session.query.assert_called
-        assert result.result_path == "/local_test/results/file.h5"
+        assert result.result_path == "/shared_test/results/file.h5"
 
     def test_load_calibration_by_id_path_not_found(self, db_manager: DatabaseManager):
         # Setup a mock measurement


### PR DESCRIPTION
Added target to measurements database manager and creates a folder based on target value.
added optional data_folder path to get_db_manager for easy access without Qilimanjaro's infrastructure.
Removed sequence run as it will have conflicts with bsc's database.

