### PR TITLE
qhc-1307-change-the-auto_norm-default-of-software-filters-to-false

### DIFF
--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -26,6 +26,10 @@
 
 ### Improvements
 
+- Previously, the software filters in the `PulseDistortion` module were normalised by default.
+This PR changes the default value of `auto_norm` to False, as the previous behaviour was considered counterintuitive.
+  [#1075](https://github.com/qilimanjaro-tech/qililab/pull/1075)
+
 - Implemented a new driver for the Becker Nachrichtentechnik RSWU-SP16TR
   [#1020](https://github.com/qilimanjaro-tech/qililab/pull/1020)
 

--- a/src/qililab/pulse_distortion/bias_tee_correction.py
+++ b/src/qililab/pulse_distortion/bias_tee_correction.py
@@ -37,7 +37,7 @@ class BiasTeeCorrection(PulseDistortion):
         sampling_rate (float, optional): Sampling rate. Defaults to 1.
         norm_factor (float, optional): The manual normalization factor that multiplies the envelope in the apply() method. Defaults to 1 (no effect).
         auto_norm (bool, optional): Whether to automatically normalize the corrected envelope with the original max height in the apply() method.
-            (The max height is the furthest number from 0 in the envelope, only checking the real axis/part). Defaults to True.
+            (The max height is the furthest number from 0 in the envelope, only checking the real axis/part). Defaults to False.
 
     Returns:
         PulseDistortion: Distortion to apply to given envelopes in :class:`PulseEvent`.
@@ -68,8 +68,8 @@ class BiasTeeCorrection(PulseDistortion):
 
         Corrects for a bias tee using a linear IIR filter with time constant tau.
 
-        If `self.auto_norm` is True (default) normalizes the resulting envelope to have the same real max height than the starting one.
-        (the max height is the furthest number from 0, only checking the real axis/part)
+        If `self.auto_norm` is True (defaults to False). normalizes the resulting envelope to have the same real max height than the starting one.
+        (the max height is the furthest number from 0, only checking the real axis/part).
         If the corrected envelope is zero everywhere or doesn't have a real part this process is skipped.
 
         Finally it applies the manual `self.norm_factor` to the result, reducing the full envelope by its magnitude.

--- a/src/qililab/pulse_distortion/exponential_decay_correction.py
+++ b/src/qililab/pulse_distortion/exponential_decay_correction.py
@@ -40,7 +40,7 @@ class ExponentialCorrection(PulseDistortion):
         sampling_rate (float, optional): Sampling rate. Defaults to 1.
         norm_factor (float, optional): The manual normalization factor that multiplies the envelope in the apply() method. Defaults to 1 (no effect).
         auto_norm (bool, optional): Whether to automatically normalize the corrected envelope with the original max height in the apply() method.
-            (The max height is the furthest number from 0 in the envelope, only checking the real axis/part). Defaults to True.
+            (The max height is the furthest number from 0 in the envelope, only checking the real axis/part). Defaults to False.
 
     Returns:
         PulseDistortion: Distortion to apply to given envelopes in PulseEvent.
@@ -74,8 +74,8 @@ class ExponentialCorrection(PulseDistortion):
 
         Fitting should be done to y = g*(1+amp*exp(-t/tau)), where g is ignored in the corrections.
 
-        If `self.auto_norm` is True (default) normalizes the resulting envelope to have the same real max height than the starting one.
-        (the max height is the furthest number from 0, only checking the real axis/part)
+        If `self.auto_norm` is True (defaults to False) normalizes the resulting envelope to have the same real max height than the starting one.
+        (the max height is the furthest number from 0, only checking the real axis/part).
         If the corrected envelope is zero everywhere or doesn't have a real part this process is skipped.
 
         Finally it applies the manual `self.norm_factor` to the result, reducing the full envelope by its magnitude.

--- a/src/qililab/pulse_distortion/lfilter_correction.py
+++ b/src/qililab/pulse_distortion/lfilter_correction.py
@@ -58,7 +58,7 @@ class LFilterCorrection(PulseDistortion):
         b (list[float]): The numerator coefficient vector in a 1-D sequence.
         norm_factor (float, optional): The manual normalization factor that multiplies the envelope in the apply() method. Defaults to 1 (no effect).
         auto_norm (bool, optional): Whether to automatically normalize the corrected envelope with the original max height in the apply() method.
-            (The max height is the furthest number from 0 in the envelope, only checking the real axis/part). Defaults to True.
+            (The max height is the furthest number from 0 in the envelope, only checking the real axis/part). Defaults to False.
 
     Returns:
         PulseDistortion: Distortion to apply to given envelopes in PulseEvent.
@@ -89,8 +89,8 @@ class LFilterCorrection(PulseDistortion):
 
         Corrects an envelope applying the scipy.signal.lfilter.
 
-        If `self.auto_norm` is True (default) normalizes the resulting envelope to have the same real max height than the starting one.
-        (the max height is the furthest number from 0, only checking the real axis/part)
+        If `self.auto_norm` is True (Defaults to False) normalizes the resulting envelope to have the same real max height than the starting one.
+        (the max height is the furthest number from 0, only checking the real axis/part).
         If the corrected envelope is zero everywhere or doesn't have a real part this process is skipped.
 
         Finally it applies the manual `self.norm_factor` to the result, reducing the full envelope by its magnitude.

--- a/src/qililab/pulse_distortion/pulse_distortion.py
+++ b/src/qililab/pulse_distortion/pulse_distortion.py
@@ -39,7 +39,7 @@ class PulseDistortion(FactoryElement):
     Whenever you call a `PulseDistortion` interface child, apart than their respective arguments you can also pass the `norm_factor` & `auto_norm` arguments, to
     modify how such normalization is done.
 
-    If `self.auto_norm` is True (default) normalizes the resulting envelope to have the same real max height than the starting one. (the max height is the furthest number
+    If `self.auto_norm` is True (defaults to False.) normalizes the resulting envelope to have the same real max height than the starting one. (the max height is the furthest number
     from 0, only checking the real axis/part).
 
     .. code-block:: python3
@@ -69,7 +69,7 @@ class PulseDistortion(FactoryElement):
     Args:
         norm_factor (float): The manual normalization factor that multiplies the envelope in the apply() method. Defaults to 1 (no effect).
         auto_norm (bool): Whether to automatically normalize the corrected envelope with the original max height in the apply() method.
-            (the max height is the furthest number from 0 in the envelope, only checking the real axis/part). Default to True.
+            (the max height is the furthest number from 0 in the envelope, only checking the real axis/part). Default to False.
 
     Examples:
 
@@ -106,7 +106,7 @@ class PulseDistortion(FactoryElement):
     """
 
     norm_factor: float = 1.0  #: Normalization factor.
-    auto_norm: bool = True  #: Auto-normalization flag. Defaults to True.
+    auto_norm: bool = False  #: Auto-normalization flag. Defaults to False.
 
     @abstractmethod
     def apply(self, envelope: np.ndarray) -> np.ndarray:
@@ -155,8 +155,8 @@ class PulseDistortion(FactoryElement):
     def normalize_envelope(self, envelope: np.ndarray, corr_envelope: np.ndarray) -> np.ndarray:
         """Normalizes the envelope depending on the `norm_factor` and `auto_norm` attributes.
 
-        If `self.auto_norm` is `True` (default) normalizes the resulting envelope to have the same real max height than the starting one.
-        (the max height is the furthest number from 0, only checking the real axis/part)
+        If `self.auto_norm` is `True` (default is False) normalizes the resulting envelope to have the same real max height than the starting one.
+        (the max height is the furthest number from 0, only checking the real axis/part).
         If the corrected envelope is zero everywhere or doesn't have a real part this process is skipped.
 
         Finally it applies the manual `self.norm_factor` to the result, reducing the full envelope by its magnitude.

--- a/tests/pulse_distortion/test_pulse_distortions.py
+++ b/tests/pulse_distortion/test_pulse_distortions.py
@@ -9,7 +9,7 @@ from qililab.typings import PulseDistortionName
 
 def test_bias_tee_correction_apply_returns_normalized_copy():
     envelope = np.ones(10, dtype=float)
-    distortion = BiasTeeCorrection(tau_bias_tee=0.5, sampling_rate=2.0)
+    distortion = BiasTeeCorrection(tau_bias_tee=0.5, sampling_rate=2.0, auto_norm=True)
 
     corrected = distortion.apply(envelope)
 


### PR DESCRIPTION
Previously, the software filters in the `PulseDistortion` module were normalised by default.
This PR changes the default value of `auto_norm` to `False`, as the previous behaviour was considered counterintuitive.