### PR TITLE
[QHC-1270] Pulses for one waveform and one channel

### DIFF
--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -38,8 +38,8 @@
 - Changed internal structure of waveform generation on the qblox compiler.
 Added a check in the platform for QCM and QRM modules with only one channel.
 Now whenever a single waveform is given instead of giving this waveform to I and creating an empty Q, it checks first how many channels does it have based on platform:
-- If it has 2 channels the behavior is the same (waveform to I and an empty Q)
-- If it has 1 channel, I and Q are identical waveforms and register as one single waveform (effectively doubling the Q1ASM waveform compilation available size and setting the correct amplitude).
+  - If it has 2 channels the behavior is the same (waveform to I and an empty Q)
+  - If it has 1 channel, I and Q are identical waveforms and register as one single waveform (effectively doubling the Q1ASM waveform compilation available size and setting the correct amplitude).
 
 This check is automatic and requires no input from the user aside from setting the runcard correctly.
   [#1076](https://github.com/qilimanjaro-tech/qililab/pull/1076)

--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -39,7 +39,7 @@
 Added a check in the platform for QCM and QRM modules with only one channel.
 Now whenever a single waveform is given instead of giving this waveform to I and creating an empty Q, it checks first how many channels does it have based on platform:
   - If it has 2 channels the behavior is the same (waveform to I and an empty Q)
-  - If it has 1 channel, I and Q are identical waveforms and register as one single waveform (effectively doubling the Q1ASM waveform compilation available size and setting the correct amplitude).
+  - If it has 1 channel, I and Q are identical waveforms and register as one single waveform (effectively doubling the Q1ASM waveform compilation available size and setting the correct amplitude). If the user gives an IQPair regardless, the behavior remains unchanged and a Q wave will be saved in memory but never sent through the machine.
 
 This check is automatic and requires no input from the user aside from setting the runcard correctly.
   [#1076](https://github.com/qilimanjaro-tech/qililab/pull/1076)

--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -35,6 +35,15 @@
 - Added sequence run table to measurements database. This table works similar to calibration run and is intended to store a series of experiment runs one after the other. Added `add_sequence_run` to database manager to operate it. Also modified the quibit index on the autocalibration database from integer to string to take into account two qubit gate experiments.
   [#1070](https://github.com/qilimanjaro-tech/qililab/pull/1070)
 
+- Changed internal structure of waveform generation on the qblox compiler.
+Added a check in the platform for QCM and QRM modules with only one channel.
+Now whenever a single waveform is given instead of giving this waveform to I and creating an empty Q, it checks first how many channels does it have based on platform:
+- If it has 2 channels the behavior is the same (waveform to I and an empty Q)
+- If it has 1 channel, I and Q are identical waveforms and register as one single waveform (effectively doubling the Q1ASM waveform compilation available size and setting the correct amplitude).
+
+This check is automatic and requires no input from the user aside from setting the runcard correctly.
+  [#1076](https://github.com/qilimanjaro-tech/qililab/pull/1076)
+
 ### Breaking changes
 
 - All references to **Qibo** have been removed, and any functionality relying on Qibo-based components has been eliminated.

--- a/src/qililab/platform/platform.py
+++ b/src/qililab/platform/platform.py
@@ -1242,7 +1242,7 @@ class Platform:
             # Determine what should be the initial value of the markers for each bus.
             # This depends on the model of the associated Qblox module and the `output` setting of the associated sequencer.
             markers = {}
-            single_channel = {}
+            single_channel = []
             for bus in buses:
                 for instrument, channel in zip(bus.instruments, bus.channels):
                     if isinstance(instrument, QbloxModule):
@@ -1257,7 +1257,8 @@ class Platform:
                             )[::-1]
                         else:
                             markers[bus.alias] = "0000"
-                            single_channel[bus.alias] = False if len(sequencer.outputs) > 1 else True
+                            if len(sequencer.outputs)==1:
+                                single_channel.append(bus.alias)
 
             compiled_qdac = None
             if qdac_buses:

--- a/src/qililab/platform/platform.py
+++ b/src/qililab/platform/platform.py
@@ -1242,6 +1242,7 @@ class Platform:
             # Determine what should be the initial value of the markers for each bus.
             # This depends on the model of the associated Qblox module and the `output` setting of the associated sequencer.
             markers = {}
+            single_channel = {}
             for bus in buses:
                 for instrument, channel in zip(bus.instruments, bus.channels):
                     if isinstance(instrument, QbloxModule):
@@ -1256,6 +1257,7 @@ class Platform:
                             )[::-1]
                         else:
                             markers[bus.alias] = "0000"
+                            single_channel[bus.alias] = False if len(sequencer.outputs) > 1 else True
 
             compiled_qdac = None
             if qdac_buses:
@@ -1286,6 +1288,7 @@ class Platform:
                     markers=markers,
                     ext_trigger=ext_trigger,
                     qblox_buses=qblox_buses,
+                    single_channel=single_channel,
                 ),
                 qdac=compiled_qdac,
             )

--- a/src/qililab/platform/platform.py
+++ b/src/qililab/platform/platform.py
@@ -1257,7 +1257,7 @@ class Platform:
                             )[::-1]
                         else:
                             markers[bus.alias] = "0000"
-                            if len(sequencer.outputs)==1:
+                            if len(sequencer.outputs) == 1:
                                 single_channel.append(bus.alias)
 
             compiled_qdac = None

--- a/src/qililab/qprogram/qblox_compiler.py
+++ b/src/qililab/qprogram/qblox_compiler.py
@@ -232,7 +232,7 @@ class QbloxCompiler:
         self._markers: dict[str, str] | None
         self._qblox_buses: list[str]
         self._acquisition_metadata: dict[str, dict[UUID, int]] = {}
-        self._single_channel: dict[str, bool] = {}
+        self._single_channel: list[str] = []
 
     def traverse_qprogram_acquire(self, block: Block):
         """Traverses a QProgram to gather information on the acquisition."""
@@ -253,7 +253,7 @@ class QbloxCompiler:
         markers: dict[str, str] | None = None,
         ext_trigger: bool = False,
         qblox_buses: list[str] | None = None,
-        single_channel: dict[str, bool] | None = None,
+        single_channel: list[str] | None = None,
     ) -> QbloxCompilationOutput:
         """Compile QProgram to qpysequence.Sequence
 
@@ -325,7 +325,7 @@ class QbloxCompiler:
         self._sync_counter = 0
         self._buses = self._populate_buses()
         self._ext_trigger = ext_trigger
-        self._single_channel = single_channel if single_channel is not None else {}
+        self._single_channel = single_channel if single_channel is not None else []
 
         # Pre-processing: Update time of flight
         if times_of_flight is not None:
@@ -520,7 +520,7 @@ class QbloxCompiler:
             return index, len(envelope)
 
         index_I, length_I = handle_waveform(waveform_I, 0)
-        if waveform_Q is None and bus in self._single_channel and self._single_channel[bus]:
+        if waveform_Q is None and bus in self._single_channel:
             index_Q, _ = handle_waveform(waveform_I, 0)
         else:
             index_Q, _ = handle_waveform(waveform_Q, len(waveform_I.envelope()))

--- a/src/qililab/qprogram/qblox_compiler.py
+++ b/src/qililab/qprogram/qblox_compiler.py
@@ -232,6 +232,7 @@ class QbloxCompiler:
         self._markers: dict[str, str] | None
         self._qblox_buses: list[str]
         self._acquisition_metadata: dict[str, dict[UUID, int]] = {}
+        self._single_channel: dict[str, bool] = {}
 
     def traverse_qprogram_acquire(self, block: Block):
         """Traverses a QProgram to gather information on the acquisition."""
@@ -252,6 +253,7 @@ class QbloxCompiler:
         markers: dict[str, str] | None = None,
         ext_trigger: bool = False,
         qblox_buses: list[str] | None = None,
+        single_channel: dict[str, bool] | None = None,
     ) -> QbloxCompilationOutput:
         """Compile QProgram to qpysequence.Sequence
 
@@ -323,6 +325,7 @@ class QbloxCompiler:
         self._sync_counter = 0
         self._buses = self._populate_buses()
         self._ext_trigger = ext_trigger
+        self._single_channel = single_channel if single_channel is not None else {}
 
         # Pre-processing: Update time of flight
         if times_of_flight is not None:
@@ -499,7 +502,9 @@ class QbloxCompiler:
             waveform_Q (Waveform | None): Q waveform.
         """
 
-        def handle_waveform(waveform: Waveform | None, default_length: int = 0):
+        def handle_waveform(waveform: Waveform | None, default_length: int = 0, waveform_I: Waveform | None = None):
+            if waveform is None and bus in self._single_channel and self._single_channel[bus]:
+                waveform = waveform_I
             _hash = QbloxCompiler._hash_waveform(waveform) if waveform else f"zeros {default_length}"
 
             if _hash in self._buses[bus].waveform_to_index:
@@ -517,7 +522,7 @@ class QbloxCompiler:
             return index, len(envelope)
 
         index_I, length_I = handle_waveform(waveform_I, 0)
-        index_Q, _ = handle_waveform(waveform_Q, len(waveform_I.envelope()))
+        index_Q, _ = handle_waveform(waveform_Q, len(waveform_I.envelope()), waveform_I)
         return index_I, index_Q, length_I
 
     def _append_to_weights_of_bus(self, bus: str, weights: IQWaveform):

--- a/src/qililab/qprogram/qblox_compiler.py
+++ b/src/qililab/qprogram/qblox_compiler.py
@@ -502,9 +502,7 @@ class QbloxCompiler:
             waveform_Q (Waveform | None): Q waveform.
         """
 
-        def handle_waveform(waveform: Waveform | None, default_length: int = 0, waveform_I: Waveform | None = None):
-            if waveform is None and bus in self._single_channel and self._single_channel[bus]:
-                waveform = waveform_I
+        def handle_waveform(waveform: Waveform | None, default_length: int = 0):
             _hash = QbloxCompiler._hash_waveform(waveform) if waveform else f"zeros {default_length}"
 
             if _hash in self._buses[bus].waveform_to_index:
@@ -522,7 +520,10 @@ class QbloxCompiler:
             return index, len(envelope)
 
         index_I, length_I = handle_waveform(waveform_I, 0)
-        index_Q, _ = handle_waveform(waveform_Q, len(waveform_I.envelope()), waveform_I)
+        if waveform_Q is None and bus in self._single_channel and self._single_channel[bus]:
+            index_Q, _ = handle_waveform(waveform_I, 0)
+        else:
+            index_Q, _ = handle_waveform(waveform_Q, len(waveform_I.envelope()))
         return index_I, index_Q, length_I
 
     def _append_to_weights_of_bus(self, bus: str, weights: IQWaveform):

--- a/tests/data.py
+++ b/tests/data.py
@@ -356,6 +356,18 @@ class Galadriel:
                 Parameter.OFFSET_Q.value: 0,
                 Parameter.HARDWARE_MODULATION.value: False,
             },
+            {
+                "identifier": 5,
+                "outputs": [0],
+                Parameter.IF.value: 100_000_000,
+                Parameter.GAIN_I.value: 1,
+                Parameter.GAIN_Q.value: 1,
+                Parameter.GAIN_IMBALANCE.value: 0,
+                Parameter.PHASE_IMBALANCE.value: 0,
+                Parameter.OFFSET_I.value: 0,
+                Parameter.OFFSET_Q.value: 0,
+                Parameter.HARDWARE_MODULATION.value: True,
+            },
         ],
     }
 
@@ -704,6 +716,11 @@ class Galadriel:
             RUNCARD.ALIAS: "flux_line_q3_bus",
             RUNCARD.INSTRUMENTS: [InstrumentName.QBLOX_QCM.value, "rs_0"],
             RUNCARD.CHANNELS: [4, None],
+        },
+        {
+            RUNCARD.ALIAS: "drive_line_q0_bus_baseband",
+            RUNCARD.INSTRUMENTS: [InstrumentName.QBLOX_QCM.value],
+            RUNCARD.CHANNELS: [5],
         },
         {
             RUNCARD.ALIAS: "flux_line_too_many_instr",

--- a/tests/platform/test_platform.py
+++ b/tests/platform/test_platform.py
@@ -1220,6 +1220,39 @@ class TestMethods:
         # assure only one debug was called
         assert patched_open.call_count == 1
 
+    def test_execute_qprogram_single_baseband_channel(self, platform: Platform):
+        """Test that the execute method compiles the qprogram, calls the buses to run and return the results."""
+        drive_wf = Square(amplitude=1.0, duration=40)
+        qprogram = QProgram()
+        qprogram.play(bus="drive_line_q0_bus_baseband", waveform=drive_wf)
+
+        with (
+            patch("builtins.open") as patched_open,
+            patch.object(Bus, "upload_qpysequence") as upload,
+            patch.object(Bus, "run") as run,
+            patch.object(Bus, "acquire_qprogram_results") as acquire_qprogram_results,
+            patch.object(QbloxModule, "sync_sequencer") as sync_sequencer,
+            patch.object(QbloxModule, "desync_sequencer") as desync_sequencer,
+        ):
+            acquire_qprogram_results.return_value = [123]
+            platform.execute_qprogram(qprogram=qprogram)
+
+            acquire_qprogram_results.return_value = [456]
+            platform.execute_qprogram(qprogram=qprogram)
+
+            _ = platform.execute_qprogram(qprogram=qprogram, debug=True)
+
+        # assert upload executed only once (4 because there are 4 buses)
+        assert upload.call_count == 1
+
+        # assert run executed all three times (12 because there are 4 buses)
+        assert run.call_count == 3
+        assert sync_sequencer.call_count == 3  # called as many times as run
+        assert desync_sequencer.call_count == 3
+
+        # assure only one debug was called
+        assert patched_open.call_count == 1
+
     def test_execute_qprogram_with_qblox_and_qdac_timeout_error(self, platform_qblox_qdac: Platform):
         """Test that the execute_qprogram method raises the exception if the qprogram failes"""
 

--- a/tests/qprogram/test_qblox_compiler.py
+++ b/tests/qprogram/test_qblox_compiler.py
@@ -1915,6 +1915,39 @@ set_freq         R5
         """
         assert is_q1asm_equal(sequences["drive"], drive_str)
 
+    def test_no_Q_waveform_single_channel(self, multiple_play_operations_with_no_Q_waveform: QProgram):
+        compiler = QbloxCompiler()
+        sequences, _ = compiler.compile(
+            qprogram=multiple_play_operations_with_no_Q_waveform, single_channel={"drive": True}
+        )
+
+        assert len(sequences) == 1
+        assert "drive" in sequences
+
+        for bus in sequences:
+            assert isinstance(sequences[bus], QPy.Sequence)
+
+        assert len(sequences["drive"]._waveforms._waveforms) == 1
+        assert len(sequences["drive"]._acquisitions._acquisitions) == 0
+        assert len(sequences["drive"]._weights._weights) == 0
+        assert sequences["drive"]._program._compiled
+
+        drive_str = """
+            setup:
+                            wait_sync        4
+                            set_mrk          0
+                            upd_param        4
+
+            main:
+                            play             0, 0, 40
+                            play             0, 0, 40
+                            play             0, 0, 40
+                            set_mrk          0
+                            upd_param        4
+                            stop
+        """
+        assert is_q1asm_equal(sequences["drive"], drive_str)
+
     def test_play_square_waveforms_with_optimization(self, play_square_waveforms_with_optimization: QProgram):
         compiler = QbloxCompiler()
         sequences, _ = compiler.compile(qprogram=play_square_waveforms_with_optimization)


### PR DESCRIPTION
Changed internal structure of waveform generation on the qblox compiler. 
Added a check in the platform for QCM and QRM modules with only one channel.
Now whenever a single waveform is given instead of giving this waveform to I and creating an empty Q, it checks first how many channels does it have based on platform:
- If it has 2 channels the behaviour is the same (waveform to I and an empty Q)
- If it has 1 channel, I and Q are identical waveforms and register as one single waveform (efectively doubling the Q1ASM waveform compilation available size and setting the correct amplitude).

This check is automatic and requires no input from the user.

Tested with the drawer and checked the Q1ASM.