### PR TITLE
Qhc 1317 add resistances to calibration file

### DIFF
--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -4,6 +4,7 @@
 
 - Previously, `QProgram.set_offset` required both I and Q offsets (`offset_path0` and `offset_path1`) to be of the same type (either both constants or both variables).
  This restriction has been removed: it is now possible to mix constants and variables between I and Q.
+
   ```
   qp = ql.QProgram()
   offset = qp.variable(label="offset", domain=ql.Domain.Voltage)
@@ -11,6 +12,7 @@
       qp.set_offset(bus="drive", offset_path0= offset, offset_path1=0.5)
       qp.set_offset(bus="drive", offset_path0=0.1, offset_path1=offset)
   ```
+
   [#1024](https://github.com/qilimanjaro-tech/qililab/pull/1024)
 
 - This release introduces a significant architectural refactor of the digital and pulse-related layers, removes legacy dependencies, and aligns naming and abstractions with established superconducting-qubit literature.
@@ -23,6 +25,9 @@
 
   Finally, the `Drag` gate has been renamed to `Rmw` to better reflect standard terminology in the literature and to avoid confusion with pulse-level DRAG correction schemes, which are now explicitly implemented via **IQDrag**.
   [#991](https://github.com/qilimanjaro-tech/qililab/pull/991)
+
+- Added resistances inside `CrosstalkMatrix()` they can be set by `crosstalk.set_resistances()` in the same way as `crosstalk.set_offset`. Also they can be set inside the calibration file as resistances.
+  [#1077](https://github.com/qilimanjaro-tech/qililab/pull/1077)
 
 ### Improvements
 

--- a/src/qililab/qprogram/crosstalk_matrix.py
+++ b/src/qililab/qprogram/crosstalk_matrix.py
@@ -25,6 +25,7 @@ class CrosstalkMatrix:
         """Initializes an empty crosstalk matrix."""
         self.matrix: dict[str, dict[str, float]] = {}
         self.flux_offsets: dict[str, float] = {}
+        self.resistances: dict[str, float | None] = {}
 
     def to_array(self) -> np.ndarray:
         """Returns the np.array representation of the crosstalk matrix.
@@ -82,6 +83,9 @@ class CrosstalkMatrix:
         if key not in self.flux_offsets:
             self.flux_offsets[key] = 0.0
 
+        if key not in self.resistances:
+            self.resistances[key] = None
+
     def __repr__(self) -> str:
         """Returns a string representation of the CrosstalkMatrix.
 
@@ -121,6 +125,15 @@ class CrosstalkMatrix:
         for bus in offset:
             self.flux_offsets[bus] = offset[bus]
 
+    def set_resistances(self, resistances: dict[str, float]):
+        """Modifies the resistances dictionary based on the given bus and resistance value.
+
+        Args:
+            resistances (dict[str, float]): dictionary containing the resistances for each bus to be added or modified and the value of said resistance
+        """
+        for bus in resistances:
+            self.resistances[bus] = resistances[bus]
+
     @classmethod
     def from_array(cls, buses: list[str], matrix_array: np.ndarray) -> "CrosstalkMatrix":
         """Creates crosstalk matrix from an array and corresponding set of buses. For a set of buses
@@ -147,6 +160,10 @@ class CrosstalkMatrix:
         if not instance.flux_offsets:
             for bus in buses:
                 instance.flux_offsets[bus] = 0.0
+
+        if not instance.resistances:
+            for bus in buses:
+                instance.resistances[bus] = None
         return instance
 
     @classmethod
@@ -167,6 +184,10 @@ class CrosstalkMatrix:
         if not instance.flux_offsets:
             for bus in buses:
                 instance.flux_offsets[bus] = 0.0
+
+        if not instance.resistances:
+            for bus in buses:
+                instance.resistances[bus] = None
         return instance
 
 

--- a/tests/qprogram/test_crosstalk_matrix.py
+++ b/tests/qprogram/test_crosstalk_matrix.py
@@ -141,6 +141,21 @@ class TestCrosstalkMatrix:
         assert isinstance(crosstalk_matrix.flux_offsets, dict)
         assert crosstalk_matrix.flux_offsets == {"bus1": -1.0, "bus2": 0.5}
 
+    def test_set_resistances(self):
+        """Test set_resistances function"""
+        crosstalk_matrix = CrosstalkMatrix()
+        crosstalk_matrix["bus1"] = {"bus1": 1, "bus2": 0.5}
+        crosstalk_matrix["bus2"]["bus1"] = 0.7
+        crosstalk_matrix["bus2"]["bus2"] = 1
+
+        # Before setting the resistance but after doing a set for bus_1 and bus_2
+        assert crosstalk_matrix.resistances == {"bus1": None}
+
+        crosstalk_matrix.set_resistances(resistances={"bus1": 1000, "bus2": 1005})
+
+        assert isinstance(crosstalk_matrix.resistances, dict)
+        assert crosstalk_matrix.resistances == {"bus1": 1000, "bus2": 1005}
+
     def test_str_method(self):
         """Test __str__ method"""
         crosstalk_matrix = CrosstalkMatrix()


### PR DESCRIPTION
Added resistances inside `CrosstalkMatrix()` they can be set by `crosstalk.set_resistances()` in the same way as `crosstalk.set_offset`. Also they can be set inside the calibration file as resistances.