### PR TITLE
qhc-1334-empty-qblox-acquisition-matrix

### DIFF
--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -31,6 +31,19 @@
 
 ### Improvements
 
+- For Qblox, the acquisition matrix needs to be reset at each `initial_setup` and `acquire_qprogram_results` call for QRM and QRM-RF instruments. The reset is performed by uploading an empty sequence. This ensures that users do not encounter limitations on the number of available bins due to previously run experiments.
+
+  The empty sequence uploaded is:
+  ```
+  empty_sequence = {
+              "waveforms": {},
+                  "weights": {},
+                  "acquisitions": {},
+                  "program": "",
+          }
+  ```
+  [#1082](https://github.com/qilimanjaro-tech/qililab/pull/1082)
+
 - Previously, the software filters in the `PulseDistortion` module were normalised by default.
 This PR changes the default value of `auto_norm` to False, as the previous behaviour was considered counterintuitive.
   [#1075](https://github.com/qilimanjaro-tech/qililab/pull/1075)

--- a/src/qililab/instruments/qblox/qblox_qrm.py
+++ b/src/qililab/instruments/qblox/qblox_qrm.py
@@ -84,6 +84,13 @@ class QbloxQRM(QbloxModule):
             sequencer_id = sequencer.identifier
             # Remove all acquisition data
             self.device.delete_acquisition_data(sequencer=sequencer_id, all=True)
+            empty_sequence = {
+                "waveforms": {},
+                    "weights": {},
+                    "acquisitions": {},
+                    "program": "",
+                    }
+            self.device.sequencers[sequencer_id].sequence(empty_sequence)
             self._set_integration_length(
                 value=cast("QbloxADCSequencer", sequencer).integration_length, sequencer_id=sequencer_id
             )
@@ -166,6 +173,13 @@ class QbloxQRM(QbloxModule):
 
                 # always deleting acquisitions without checking save_adc flag
                 self.device.delete_acquisition_data(sequencer=sequencer.identifier, name=acquisition)
+                empty_sequence = {
+                "waveforms": {},
+                    "weights": {},
+                    "acquisitions": {},
+                    "program": "",
+                    }
+                self.device.sequencers[sequencer.identifier].sequence(empty_sequence)
         return results
 
     def _set_device_hardware_demodulation(self, value: bool, sequencer_id: int):

--- a/src/qililab/instruments/qblox/qblox_qrm.py
+++ b/src/qililab/instruments/qblox/qblox_qrm.py
@@ -86,10 +86,10 @@ class QbloxQRM(QbloxModule):
             self.device.delete_acquisition_data(sequencer=sequencer_id, all=True)
             empty_sequence = {
                 "waveforms": {},
-                    "weights": {},
-                    "acquisitions": {},
-                    "program": "",
-                    }
+                "weights": {},
+                "acquisitions": {},
+                "program": "",
+            }
             self.device.sequencers[sequencer_id].sequence(empty_sequence)
             self._set_integration_length(
                 value=cast("QbloxADCSequencer", sequencer).integration_length, sequencer_id=sequencer_id
@@ -174,11 +174,11 @@ class QbloxQRM(QbloxModule):
                 # always deleting acquisitions without checking save_adc flag
                 self.device.delete_acquisition_data(sequencer=sequencer.identifier, name=acquisition)
                 empty_sequence = {
-                "waveforms": {},
+                    "waveforms": {},
                     "weights": {},
                     "acquisitions": {},
                     "program": "",
-                    }
+                }
                 self.device.sequencers[sequencer.identifier].sequence(empty_sequence)
         return results
 

--- a/tests/instruments/qblox/test_qblox_qrm.py
+++ b/tests/instruments/qblox/test_qblox_qrm.py
@@ -338,6 +338,7 @@ class TestQbloxQRM:
 
         sequence = Sequence(program=Program(), waveforms=Waveforms(), acquisitions=acquisitions, weights=Weights())
         qrm.upload_qpysequence(qpysequence=sequence, channel_id=0)
+        assert qrm.device.sequencers[0].sequence.call_count == 1 # uploading the desired sequence
 
         qp_acqusitions = {
             "acquisition_0": AcquisitionData(bus="readout_q0", save_adc=False, shape=(-1,), intertwined=1),
@@ -350,6 +351,7 @@ class TestQbloxQRM:
         assert qrm.device.store_scope_acquisition.call_count == 1
         assert qrm.device.get_acquisitions.call_count == 2
         assert qrm.device.delete_acquisition_data.call_count == 2
+        assert qrm.device.sequencers[0].sequence.call_count == 3 # after uploading the empty sequence
 
     def test_clear_cache(self, qrm: QbloxQRM):
         """Test clearing the cache of the QCM module."""


### PR DESCRIPTION
For Qblox, the acquisition matrix needs to be reset at each `initial_setup` and `acquire_qprogram_results` call for QRM and QRM-RF instruments. The reset is performed by uploading an empty sequence. This ensures that users do not encounter limitations on the number of available bins due to previously run experiments.

The empty sequence uploaded is:

```
empty_sequence = {
            "waveforms": {},
                "weights": {},
                "acquisitions": {},
                "program": "",
        }
```