### PR TITLE
qhc-1338-remove-the-empty-flux-schedule-for-circuits

### DIFF
--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -10,3 +10,6 @@
 
 ### Documentation
 
+### Bug fixes
+- Circuits: fixed a `KeyError` caused by incorrectly creating an empty flux bus schedule to apply an offset. This process was unintentionally adding all instruments from the settings (including the S4g) to the pulse schedule, which is incorrect. The unnecessary flux bus schedule has been removed, as the instrument already applies the offset automatically.
+[#1085](https://github.com/qilimanjaro-tech/qililab/pull/1085)

--- a/src/qililab/digital/circuit_to_pulses.py
+++ b/src/qililab/digital/circuit_to_pulses.py
@@ -26,7 +26,6 @@ from qililab.pulse.pulse_event import PulseEvent
 from qililab.pulse.pulse_schedule import PulseSchedule
 from qililab.settings.digital.digital_compilation_settings import DigitalCompilationSettings
 from qililab.settings.digital.gate_event_settings import GateEventSettings
-from qililab.typings.enums import Line
 from qililab.utils import Factory
 
 from .native_gates import Drag, Wait

--- a/src/qililab/digital/circuit_to_pulses.py
+++ b/src/qililab/digital/circuit_to_pulses.py
@@ -99,13 +99,6 @@ class CircuitToPulses:
                 delay = self.settings.buses[gate_event.bus].delay
                 pulse_schedule.add_event(pulse_event=pulse_event, bus_alias=gate_event.bus, delay=delay)  # type: ignore
 
-        for bus_alias in self.settings.buses:
-            # If we find a flux port, create empty schedule for that port.
-            # This is needed because for Qblox instrument working in flux buses as DC sources, if we don't
-            # add an empty schedule its offsets won't be activated and the results will be misleading.
-            if self.settings.buses[bus_alias].line == Line.FLUX:
-                pulse_schedule.create_schedule(bus_alias=bus_alias)
-
         return pulse_schedule
 
     def _gate_schedule_from_settings(self, gate: gates.Gate) -> list[GateEventSettings]:

--- a/tests/digital/test_circuit_transpiler.py
+++ b/tests/digital/test_circuit_transpiler.py
@@ -597,8 +597,7 @@ class TestCircuitTranspiler:
         assert isinstance(pulse_schedule, PulseSchedule)
 
         # there are 6 different buses + 3 empty for unused flux lines
-        assert len(pulse_schedule) == 12
-        assert all(len(schedule_element.timeline) == 0 for schedule_element in pulse_schedule.elements[-3:])
+        assert len(pulse_schedule) == 9
 
         # we can ignore empty elements from here on
         pulse_schedule.elements = [element for element in pulse_schedule.elements if element.timeline]

--- a/tests/platform/test_platform.py
+++ b/tests/platform/test_platform.py
@@ -822,7 +822,7 @@ class TestMethods:
         circuit.add(gates.Y(1))
         circuit.add(gates.M(0, 1, 2))
 
-        self._compile_and_assert(platform, circuit, 6, optimize=optimize)
+        self._compile_and_assert(platform, circuit, 5, optimize=optimize)
 
     def test_compile_circuit_raises_error_if_digital_settings_missing(self, platform: Platform):
         """Test the compilation of a qibo Circuit."""
@@ -843,17 +843,21 @@ class TestMethods:
         Test that platform.compile() raises a ValueError if a bus alias defined
         in runcard.digital.buses is not present in the main runcard.buses list.
         """
-        platform = platform_with_orphan_digital_bus
-        circuit = Circuit(1)
-        circuit.add(gates.X(0))
-        circuit.add(gates.M(0))
-
-        # This is the expected error message format. Adjust if your PR has a different one.
-        # The alias used in the fixture is "orphan_digital_q2_flux_bus_that_does_not_exist_in_main_buses"
+        orphan_alias = "orphan_digital_q2_flux_bus_that_does_not_exist_in_main_buses"
+        pulse_schedule = PulseSchedule()
+        pulse_schedule.add_event(
+            PulseEvent(
+                pulse=Pulse(amplitude=1.0, phase=0.0, duration=40, frequency=0, pulse_shape=Rectangular()),
+                start_time=0,
+                qubit=2,
+            ),
+            bus_alias=orphan_alias,
+        delay=0,
+    )
         expected_error_message = "Bus with alias 'orphan_digital_q2_flux_bus_that_does_not_exist_in_main_buses' defined in Digital/Buses section of the Runcard, not found in main Buses section of the same Runcard."
 
         with pytest.raises(ValueError, match=re.escape(expected_error_message)):
-            platform.compile(program=circuit, num_avg=1000, repetition_duration=200_000, num_bins=1)
+            platform_with_orphan_digital_bus.compile(program=pulse_schedule, num_avg=1000, repetition_duration=200_000, num_bins=1)
 
     def test_compile_pulse_schedule(self, platform: Platform):
         """Test the compilation of a qibo Circuit."""


### PR DESCRIPTION
[BUG] Circuits: fixed a `KeyError` caused by incorrectly creating an empty flux bus schedule to apply an offset. This process was unintentionally adding all instruments from the settings (including the S4g) to the pulse schedule, which is incorrect. The unnecessary flux bus schedule has been removed, as the instrument already applies the offset automatically.