### PR TITLE
Fix qcodes version

### DIFF
--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -2,6 +2,9 @@
 
 ### New features since last release
 
+- Fix `qcodes` version to `0.54.3` to avoid breaking changes introduced in later releases.
+  [#1091](https://github.com/qilimanjaro-tech/qililab/pull/1091)
+
 - Previously, `QProgram.set_offset` required both I and Q offsets (`offset_path0` and `offset_path1`) to be of the same type (either both constants or both variables).
  This restriction has been removed: it is now possible to mix constants and variables between I and Q.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "pydantic-settings>=2.12.0",
     "pyvisa-py>=0.7.2",
     "qblox-instruments==0.16.0",
-    "qcodes>=0.54.3",
+    "qcodes==0.54.3",
     "qcodes-contrib-drivers>=0.23.0",
     "qpysequence>=0.10.8",
     "rich>=14.0.0",


### PR DESCRIPTION
Fix `qcodes` version to `0.54.3` to avoid breaking changes introduced in later releases.