### PR TITLE
qhc-1356-bug-bin-aquisition-index-not-incrementing-qblox-bsc

### DIFF
--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -18,3 +18,6 @@
 - Qblox: After each acquisition, an empty sequence is re-uploaded to ensure that bin allocation is properly reset (introduced in [this PR](https://github.com/qilimanjaro-tech/qililab/pull/1082)). Previously, the upload cache compared sequence hashes and skipped re-uploading if no changes were detected. However, since the acquisition portion of the sequence had been removed, this led to an inconsistency: the cached sequence was not re-uploaded, resulting in an error during execution.
 The cache has now been removed so that the sequence is always re-uploaded, ensuring correct bin allocation and preventing this error before each run.
   [#1089](https://github.com/qilimanjaro-tech/qililab/pull/1089)
+
+- Fixed a bug in the Qblox compiler where the bin acquisition index was not incrementing correctly when multiple `measure` calls are used sequentially inside an `average` block with an outer sweep loop.  Each sequential acquire now gets its own bin register initialised to its position offset, and the bin register is advanced by the total number of acquires per sweep step (instead of always 1), so that consecutive acquires write to consecutive bins and the full acquisition matrix is filled correctly.
+  [#1101](https://github.com/qilimanjaro-tech/qililab/pull/1101)

--- a/src/qililab/qprogram/qblox_compiler.py
+++ b/src/qililab/qprogram/qblox_compiler.py
@@ -191,6 +191,9 @@ class BusCompilationInfo:
         # Used in instances where there are no loop on the bin
         self.single_bin_counter: int = 0
 
+        # Bin index used in the move instruction
+        self.start_bin_idx: int = 0
+
 
 class QbloxCompiler:
     """A class for compiling QProgram to QBlox hardware."""
@@ -1385,11 +1388,16 @@ class QbloxCompiler:
         block_index_for_add_instruction = loops[-1][0] if loops else -1
         block_index_for_move_instruction = loops[0][0] - 1 if loops else -2
 
+        # True when the innermost active block is an average loop.
+        in_avg_block = isinstance(self._buses[element.bus].qpy_block_stack[-1], QPyProgram.Loop)
+        is_avg_multi_acquire = in_avg_block and self._buses[element.bus].counter_acquire > 1
+
         if self._buses[element.bus].count_nested_level_acquire > MAX_ACQUISITION_INDEX:
             raise ValueError(f"Acquisition index {self._buses[element.bus].count_nested_level_acquire} exceeds maximum of {MAX_ACQUISITION_INDEX}.")
 
         # if it is the first acquire at this nested level, set everything up
         if self._buses[element.bus].count_nested_level_acquire != self._buses[element.bus].prev_nested_level_acquire:
+            self._buses[element.bus].start_bin_idx = 0
             self._buses[element.bus].shape_acquire = tuple(loop[1].iterations for loop in loops)
             self._buses[element.bus].num_bins_per_acquire = math.prod(loop[1].iterations for loop in loops)
 
@@ -1411,6 +1419,22 @@ class QbloxCompiler:
                     component=QPyInstructions.Move(var=0, register=self._buses[element.bus].bin_register),
                     bot_position=len(self._buses[element.bus].qpy_block_stack[block_index_for_move_instruction].components),
                 )
+        
+                self._buses[element.bus].start_bin_idx += 1
+
+        elif is_avg_multi_acquire and self._buses[element.bus].num_bins_per_acquire > 1:
+            # Each sequential acquire directly inside an average block gets its own register, initialised
+            # to the start_bin_idx so that consecutive acquires write to consecutive bins.
+            # The register is never modified inside the average, it is modified in the add outside the average.
+            start_bin_idx = self._buses[element.bus].start_bin_idx
+            self._buses[element.bus].bin_register = QPyProgram.Register()
+            self._buses[element.bus].qpy_block_stack[block_index_for_move_instruction].append_component(
+                component=QPyInstructions.Move(var=start_bin_idx, register=self._buses[element.bus].bin_register),
+                bot_position=len(
+                    self._buses[element.bus].qpy_block_stack[block_index_for_move_instruction].components
+                ),
+            )
+            self._buses[element.bus].start_bin_idx += 1
 
         index_I, index_Q, integration_length = self._append_to_weights_of_bus(element.bus, element.weights)
 
@@ -1427,8 +1451,11 @@ class QbloxCompiler:
                     wait_time=integration_length,
                 )
             )
+
+            # Advance by N bins per step, where N is the number of acquires sharing this avg block.
+            bins_per_step = self._buses[element.bus].counter_acquire if is_avg_multi_acquire else 1
             self._buses[element.bus].qpy_block_stack[block_index_for_add_instruction].append_component(
-                component=QPyInstructions.Add(origin=self._buses[element.bus].bin_register, var=1, destination=self._buses[element.bus].bin_register)
+                component=QPyInstructions.Add(origin=self._buses[element.bus].bin_register, var=bins_per_step, destination=self._buses[element.bus].bin_register)
             )
         else:  # if only 1 bin, the use of register can be avoided
 

--- a/src/qililab/qprogram/qblox_compiler.py
+++ b/src/qililab/qprogram/qblox_compiler.py
@@ -1419,7 +1419,7 @@ class QbloxCompiler:
                     component=QPyInstructions.Move(var=0, register=self._buses[element.bus].bin_register),
                     bot_position=len(self._buses[element.bus].qpy_block_stack[block_index_for_move_instruction].components),
                 )
-        
+
                 self._buses[element.bus].start_bin_idx += 1
 
         elif is_avg_multi_acquire and self._buses[element.bus].num_bins_per_acquire > 1:

--- a/tests/qprogram/test_qblox_compiler.py
+++ b/tests/qprogram/test_qblox_compiler.py
@@ -759,6 +759,43 @@ def fixture_dynamic_wait_three_buses_static_static() -> QProgram:
         qp.sync()
     return qp
 
+@pytest.fixture(name="inner_average_outer_sweep")
+def inner_average_outer_sweep() -> QProgram:
+    readout_pair = IQPair(I=Square(amplitude=1.0, duration=1000), Q=Square(amplitude=0.0, duration=1000))
+    weights_pair = IQPair(I=Square(amplitude=1.0, duration=2000), Q=Square(amplitude=0.0, duration=2000))
+    qp = QProgram()
+    frequency = qp.variable(label="frequency", domain=Domain.Frequency)
+    with qp.for_loop(variable=frequency, start=100, stop=200, step=10):
+        with qp.average(shots=100):
+            qp.measure(bus="readout", waveform=readout_pair, weights=weights_pair)
+    return qp
+
+@pytest.fixture(name="inner_average_outer_sweep_two_measures")
+def inner_average_outer_sweep_two_measures() -> QProgram:
+    readout_pair = IQPair(I=Square(amplitude=1.0, duration=1000), Q=Square(amplitude=0.0, duration=1000))
+    weights_pair = IQPair(I=Square(amplitude=1.0, duration=2000), Q=Square(amplitude=0.0, duration=2000))
+    qp = QProgram()
+    frequency = qp.variable(label="frequency", domain=Domain.Frequency)
+    with qp.for_loop(variable=frequency, start=100, stop=200, step=10):
+        with qp.average(shots=100):
+            qp.measure(bus="readout", waveform=readout_pair, weights=weights_pair)
+            qp.measure(bus="readout", waveform=readout_pair, weights=weights_pair)
+    return qp
+
+@pytest.fixture(name="inner_average_outer_sweep_three_measures")
+def inner_average_outer_sweep_three_measures() -> QProgram:
+    readout_pair = IQPair(I=Square(amplitude=1.0, duration=1000), Q=Square(amplitude=0.0, duration=1000))
+    weights_pair = IQPair(I=Square(amplitude=1.0, duration=2000), Q=Square(amplitude=0.0, duration=2000))
+    qp = QProgram()
+    frequency = qp.variable(label="frequency", domain=Domain.Frequency)
+    with qp.for_loop(variable=frequency, start=100, stop=200, step=10):
+        with qp.average(shots=100):
+            qp.measure(bus="readout", waveform=readout_pair, weights=weights_pair)
+            qp.measure(bus="readout", waveform=readout_pair, weights=weights_pair)
+            qp.measure(bus="readout", waveform=readout_pair, weights=weights_pair)
+    return qp
+
+
 class TestQBloxCompiler:
     def test_play_named_operation_and_bus_mapping(self, play_named_operation: QProgram, calibration: Calibration):
         compiler = QbloxCompiler()
@@ -3995,3 +4032,110 @@ other_max_duration_0:
         assert is_q1asm_equal(sequences["drive_q0_bus"], drive_str)
         assert is_q1asm_equal(sequences["readout_q0_bus"], readout_str)
 
+    def test_inner_average_outer_sweep(self, inner_average_outer_sweep: QProgram):
+
+        compiler = QbloxCompiler()
+        sequences, _ = compiler.compile(qprogram=inner_average_outer_sweep)
+        expected_q1asm =    """setup:
+                                            wait_sync        4              
+                                            set_mrk          0              
+                                            upd_param        4              
+
+                            main:
+                                            move             1, R0          
+                                            move             0, R1          
+                                            move             0, R2          
+                                            move             11, R3         
+                                            move             100, R4        
+                            loop_0:
+                                            move             100, R5        
+                            avg_0:
+                                            play             0, 1, 4        
+                                            acquire_weighed  0, R2, R1, R0, 2000
+                                            loop             R5, @avg_0     
+                                            add              R2, 1, R2      
+                                            add              R4, 10, R4     
+                                            loop             R3, @loop_0    
+                                            set_mrk          0              
+                                            upd_param        4              
+                                            stop                       """
+
+
+        assert is_q1asm_equal(sequences["readout"], expected_q1asm)
+
+    
+    
+    def test_inner_average_outer_sweep_two_measures(self, inner_average_outer_sweep_two_measures: QProgram):
+
+        compiler = QbloxCompiler()
+        sequences, _ = compiler.compile(qprogram=inner_average_outer_sweep_two_measures)
+        expected_q1asm =    """setup:
+                                                wait_sync        4              
+                                                set_mrk          0              
+                                                upd_param        4              
+
+                                main:
+                                                move             1, R0          
+                                                move             1, R1          
+                                                move             0, R2          
+                                                move             0, R3          
+                                                move             11, R4         
+                                                move             100, R5        
+                                loop_0:
+                                                move             100, R6        
+                                avg_0:
+                                                play             0, 1, 4        
+                                                acquire_weighed  0, R3, R2, R1, 2000
+                                                play             0, 1, 4        
+                                                acquire_weighed  0, R0, R2, R1, 2000
+                                                loop             R6, @avg_0     
+                                                add              R3, 2, R3      
+                                                add              R0, 2, R0      
+                                                add              R5, 10, R5     
+                                                loop             R4, @loop_0    
+                                                set_mrk          0              
+                                                upd_param        4              
+                                                stop  """
+
+
+        assert is_q1asm_equal(sequences["readout"], expected_q1asm)
+
+
+    def test_inner_average_outer_sweep_three_measures(self, inner_average_outer_sweep_three_measures: QProgram):
+
+        compiler = QbloxCompiler()
+        sequences, _ = compiler.compile(qprogram=inner_average_outer_sweep_three_measures)
+        expected_q1asm =    """setup:
+                                                wait_sync        4              
+                                                set_mrk          0              
+                                                upd_param        4              
+
+                                main:
+                                                move             2, R0
+                                                move             1, R1          
+                                                move             1, R2          
+                                                move             0, R3          
+                                                move             0, R4          
+                                                move             11, R5         
+                                                move             100, R6        
+                                loop_0:
+                                                move             100, R7        
+                                avg_0:
+                                                play             0, 1, 4        
+                                                acquire_weighed  0, R4, R3, R2, 2000
+                                                play             0, 1, 4        
+                                                acquire_weighed  0, R1, R3, R2, 2000
+                                                play             0, 1, 4        
+                                                acquire_weighed  0, R0, R3, R2, 2000
+                                                loop             R7, @avg_0     
+                                                add              R4, 3, R4      
+                                                add              R1, 3, R1   
+                                                add              R0, 3, R0    
+                                                add              R6, 10, R6     
+                                                loop             R5, @loop_0    
+                                                set_mrk          0              
+                                                upd_param        4              
+                                                stop  """
+
+
+        assert is_q1asm_equal(sequences["readout"], expected_q1asm)

--- a/tests/qprogram/test_qblox_compiler.py
+++ b/tests/qprogram/test_qblox_compiler.py
@@ -795,6 +795,15 @@ def inner_average_outer_sweep_three_measures() -> QProgram:
             qp.measure(bus="readout", waveform=readout_pair, weights=weights_pair)
     return qp
 
+@pytest.fixture(name="average_only_two_measures")
+def average_only_two_measures() -> QProgram:
+    readout_pair = IQPair(I=Square(amplitude=1.0, duration=1000), Q=Square(amplitude=0.0, duration=1000))
+    weights_pair = IQPair(I=Square(amplitude=1.0, duration=2000), Q=Square(amplitude=0.0, duration=2000))
+    qp = QProgram()
+    with qp.average(shots=100):
+        qp.measure(bus="readout", waveform=readout_pair, weights=weights_pair)
+        qp.measure(bus="readout", waveform=readout_pair, weights=weights_pair)
+    return qp
 
 class TestQBloxCompiler:
     def test_play_named_operation_and_bus_mapping(self, play_named_operation: QProgram, calibration: Calibration):
@@ -4137,5 +4146,27 @@ other_max_duration_0:
                                                 upd_param        4              
                                                 stop  """
 
+
+        assert is_q1asm_equal(sequences["readout"], expected_q1asm)
+
+    def test_average_only_two_measures(self, average_only_two_measures: QProgram):
+        compiler = QbloxCompiler()
+        sequences, _ = compiler.compile(qprogram=average_only_two_measures)
+        expected_q1asm = """setup:
+                                wait_sync        4
+                                set_mrk          0
+                                upd_param        4
+
+                            main:
+                                move             100, R0
+                            avg_0:
+                                play             0, 1, 4
+                                acquire_weighed  0, 0, 0, 1, 2000
+                                play             0, 1, 4
+                                acquire_weighed  0, 1, 0, 1, 2000
+                                loop             R0, @avg_0
+                                set_mrk          0
+                                upd_param        4
+                                stop"""
 
         assert is_q1asm_equal(sequences["readout"], expected_q1asm)


### PR DESCRIPTION
[BUG] Fixed a bug in the Qblox compiler where the bin acquisition index was not incrementing correctly when multiple `measure` calls are used sequentially inside an `average` block with an outer sweep loop.  Each sequential acquire now gets its own bin register initialised to its position offset, and the bin register is advanced by the total number of acquires per sweep step (instead of always 1), so that consecutive acquires write to consecutive bins and the full acquisition matrix is filled correctly.