### PR TITLE
qhc-1387-bug-set-offset-negative-move-register

### DIFF
--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -133,6 +133,9 @@ With `execute_qprogram(..., crosstalk= True / False)` the parameter introduced i
 
 ### Bug fixes
 
+- Fixed a bug in `set_offset` where using a `Variable` on one path and a negative static value on the other would generate a `move` instruction with a negative immediate, which is invalid Q1ASM.
+  [#1112](https://github.com/qilimanjaro-tech/qililab/pull/1112)
+
 - The save_platform function was not saving bus distortions because it wasn't added to the Bus.to_dict after the refactor. The property has been added.
   [#1100](https://github.com/qilimanjaro-tech/qililab/pull/1100)
 

--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -134,7 +134,7 @@ With `execute_qprogram(..., crosstalk= True / False)` the parameter introduced i
 ### Bug fixes
 
 - Fixed a bug in `set_offset` where using a `Variable` on one path and a negative static value on the other would generate a `move` instruction with a negative immediate, which is invalid Q1ASM.
-  [#1112](https://github.com/qilimanjaro-tech/qililab/pull/1112)
+  [#1113](https://github.com/qilimanjaro-tech/qililab/pull/1113)
 
 - The save_platform function was not saving bus distortions because it wasn't added to the Bus.to_dict after the refactor. The property has been added.
   [#1100](https://github.com/qilimanjaro-tech/qililab/pull/1100)

--- a/src/qililab/qprogram/qblox_compiler.py
+++ b/src/qililab/qprogram/qblox_compiler.py
@@ -832,7 +832,7 @@ class QbloxCompiler:
                     component=QPyInstructions.Move(var=abs(value), register=register), bot_position=insert_position
                 )
 
-                if value < 0:
+                if value < 0: # take the two's complement
                     self._buses[element.bus].qpy_block_stack[block_index_for_move_instruction].append_component(
                         component=QPyInstructions.Nop(), bot_position=insert_position
                     )

--- a/src/qililab/qprogram/qblox_compiler.py
+++ b/src/qililab/qprogram/qblox_compiler.py
@@ -824,12 +824,27 @@ class QbloxCompiler:
                     value = offset_0
                     offset_0 = register
 
-                self._buses[element.bus].qpy_block_stack[block_index_for_move_instruction].append_component(
-                    component=QPyInstructions.Move(var=value, register=register),
-                    bot_position=len(
-                        self._buses[element.bus].qpy_block_stack[block_index_for_move_instruction].components
-                    ),
+                insert_position = len(
+                    self._buses[element.bus].qpy_block_stack[block_index_for_move_instruction].components
                 )
+
+                self._buses[element.bus].qpy_block_stack[block_index_for_move_instruction].append_component(
+                    component=QPyInstructions.Move(var=abs(value), register=register), bot_position=insert_position
+                )
+
+                if value < 0:
+                    self._buses[element.bus].qpy_block_stack[block_index_for_move_instruction].append_component(
+                        component=QPyInstructions.Nop(), bot_position=insert_position
+                    )
+                    self._buses[element.bus].qpy_block_stack[block_index_for_move_instruction].append_component(
+                        component=QPyInstructions.Not(register, register), bot_position=insert_position
+                    )
+                    self._buses[element.bus].qpy_block_stack[block_index_for_move_instruction].append_component(
+                        component=QPyInstructions.Nop(), bot_position=insert_position
+                    )
+                    self._buses[element.bus].qpy_block_stack[block_index_for_move_instruction].append_component(
+                        component=QPyInstructions.Add(register, 1, register), bot_position=insert_position
+                    )
             self._buses[element.bus].qpy_block_stack[-1].append_component(component=QPyInstructions.Nop())
             self._buses[element.bus].qpy_block_stack[-1].append_component(
                 component=QPyInstructions.SetAwgOffs(offset_0=offset_0, offset_1=offset_1)

--- a/src/qililab/qprogram/qblox_compiler.py
+++ b/src/qililab/qprogram/qblox_compiler.py
@@ -832,7 +832,7 @@ class QbloxCompiler:
                     component=QPyInstructions.Move(var=abs(value), register=register), bot_position=insert_position
                 )
 
-                if value < 0: # take the two's complement
+                if value < 0:  # take the two's complement
                     self._buses[element.bus].qpy_block_stack[block_index_for_move_instruction].append_component(
                         component=QPyInstructions.Nop(), bot_position=insert_position
                     )

--- a/tests/qprogram/test_qblox_compiler.py
+++ b/tests/qprogram/test_qblox_compiler.py
@@ -130,6 +130,17 @@ def fixture_offset_loop() -> QProgram:
     return qp
 
 
+@pytest.fixture(name="offset_loop_negative")
+def fixture_offset_loop_negative() -> QProgram:
+    qp = QProgram()
+    variable_offset = qp.variable(label="offset", domain=Domain.Voltage)
+    with qp.for_loop(variable=variable_offset, start=0.0, stop=0.2, step=0.1):
+        qp.set_offset(bus="drive", offset_path0=variable_offset, offset_path1=-0.5)
+    with qp.for_loop(variable=variable_offset, start=0.0, stop=0.2, step=0.1):
+        qp.set_offset(bus="drive", offset_path0=-0.5, offset_path1=variable_offset)
+    return qp
+
+
 @pytest.fixture(name="dynamic_wait")
 def fixture_dynamic_wait() -> QProgram:
     drag_pair = IQDrag(amplitude=1.0, duration=40, num_sigmas=4, drag_coefficient=1.2)
@@ -1353,6 +1364,49 @@ class TestQBloxCompiler:
                             loop             R4, @loop_1    
                             set_mrk          0              
                             upd_param        4              
+                            stop
+        """
+        assert is_q1asm_equal(sequences["drive"], drive_str)
+
+    def test_set_offset_with_negative_static_value(self, offset_loop_negative: QProgram):
+        compiler = QbloxCompiler()
+        sequences, _ = compiler.compile(qprogram=offset_loop_negative)
+
+        assert sequences["drive"]._program._compiled
+
+        drive_str = """
+            setup:
+                            wait_sync        4
+                            set_mrk          0
+                            upd_param        4
+
+            main:
+                            move             16383, R0
+                            nop
+                            not              R0, R0
+                            nop
+                            add              R0, 1, R0
+                            move             16383, R1
+                            nop
+                            not              R1, R1
+                            nop
+                            add              R1, 1, R1
+                            move             3, R2
+                            move             0, R3
+            loop_0:
+                            nop
+                            set_awg_offs     R3, R1
+                            add              R3, 3276, R3
+                            loop             R2, @loop_0
+                            move             3, R4
+                            move             0, R5
+            loop_1:
+                            nop
+                            set_awg_offs     R0, R5
+                            add              R5, 3276, R5
+                            loop             R4, @loop_1
+                            set_mrk          0
+                            upd_param        4
                             stop
         """
         assert is_q1asm_equal(sequences["drive"], drive_str)


### PR DESCRIPTION
Fixed a bug in `set_offset` where using a `Variable` on one path and a negative static value on the other would generate a `move` instruction with a negative immediate, which is invalid Q1ASM.