### PR TITLE
qhc-1388-bug-qpqbloxplay-with-0-duration

### DIFF
--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -133,6 +133,9 @@ With `execute_qprogram(..., crosstalk= True / False)` the parameter introduced i
 
 ### Bug fixes
 
+- Fixed a bug where `qp.qblox.play` with `wait_time=0` was treated as no `wait_time` provided, producing incorrect Q1ASM. The wait time is now correctly clamped to the minimum valid value of 4 ns.
+  [#1114](https://github.com/qilimanjaro-tech/qililab/pull/1114)
+
 - The save_platform function was not saving bus distortions because it wasn't added to the Bus.to_dict after the refactor. The property has been added.
   [#1100](https://github.com/qilimanjaro-tech/qililab/pull/1100)
 

--- a/src/qililab/qprogram/qblox_compiler.py
+++ b/src/qililab/qprogram/qblox_compiler.py
@@ -1680,7 +1680,7 @@ class QbloxCompiler:
         if waveform_variables:
             logger.error("Variables in waveforms are not supported in Qblox.")
             return
-        if element.wait_time:
+        if element.wait_time is not None:
             # The qp.qblox.play() was used. Don't apply optimizations
             index_I, index_Q, _ = self._append_to_waveforms_of_bus(
                 bus=element.bus, waveform_I=waveform_I, waveform_Q=waveform_Q

--- a/tests/qprogram/test_qblox_compiler.py
+++ b/tests/qprogram/test_qblox_compiler.py
@@ -1023,6 +1023,13 @@ def average_only_two_measures() -> QProgram:
     return qp
 
 
+@pytest.fixture(name="qblox_play_zero_wait_time")
+def fixture_qblox_play_zero_wait_time() -> QProgram:
+    qp = QProgram()
+    qp.qblox.play(bus="drive", waveform=Square(amplitude=1, duration=200), wait_time=0)
+    return qp
+
+
 class TestQBloxCompiler:
     def test_play_named_operation_and_bus_mapping(self, play_named_operation: QProgram, calibration: Calibration):
         compiler = QbloxCompiler()
@@ -1317,7 +1324,6 @@ class TestQBloxCompiler:
             "Qblox requires an offset for the two paths, the offset of the second path has been set to the same as the first path."
             in caplog.text
         )
-
 
     def test_set_offset_with_loop(
         self, offset_loop: QProgram
@@ -5023,3 +5029,23 @@ other_max_duration_0:
                                 stop"""
 
         assert is_q1asm_equal(sequences["readout"], expected_q1asm)
+
+    def test_qblox_play_zero_wait_time(self, qblox_play_zero_wait_time: QProgram):
+        compiler = QbloxCompiler()
+        sequences, _ = compiler.compile(qprogram=qblox_play_zero_wait_time)
+
+        assert sequences["drive"]._program._compiled
+
+        drive_str = """
+            setup:
+                            wait_sync        4
+                            set_mrk          0
+                            upd_param        4
+
+            main:
+                            play             0, 1, 4
+                            set_mrk          0
+                            upd_param        4
+                            stop
+        """
+        assert is_q1asm_equal(sequences["drive"], drive_str)

--- a/tests/qprogram/test_qblox_compiler.py
+++ b/tests/qprogram/test_qblox_compiler.py
@@ -1033,7 +1033,7 @@ def fixture_qblox_play_zero_wait_time() -> QProgram:
 @pytest.fixture(name="qblox_play_none_wait_time")
 def fixture_qblox_play_none_wait_time() -> QProgram:
     qp = QProgram()
-    qp.qblox.play(bus="drive", waveform=Square(amplitude=1, duration=200), wait_time=None)
+    qp.qblox.play(bus="drive", waveform=Square(amplitude=1, duration=99), wait_time=None)
     return qp
 
 
@@ -5070,7 +5070,7 @@ other_max_duration_0:
                             upd_param        4
 
             main:
-                            play             0, 1, 4
+                            play             0, 1, 99
                             set_mrk          0
                             upd_param        4
                             stop

--- a/tests/qprogram/test_qblox_compiler.py
+++ b/tests/qprogram/test_qblox_compiler.py
@@ -1030,6 +1030,13 @@ def fixture_qblox_play_zero_wait_time() -> QProgram:
     return qp
 
 
+@pytest.fixture(name="qblox_play_none_wait_time")
+def fixture_qblox_play_none_wait_time() -> QProgram:
+    qp = QProgram()
+    qp.qblox.play(bus="drive", waveform=Square(amplitude=1, duration=200), wait_time=None)
+    return qp
+
+
 class TestQBloxCompiler:
     def test_play_named_operation_and_bus_mapping(self, play_named_operation: QProgram, calibration: Calibration):
         compiler = QbloxCompiler()
@@ -5033,6 +5040,26 @@ other_max_duration_0:
     def test_qblox_play_zero_wait_time(self, qblox_play_zero_wait_time: QProgram):
         compiler = QbloxCompiler()
         sequences, _ = compiler.compile(qprogram=qblox_play_zero_wait_time)
+
+        assert sequences["drive"]._program._compiled
+
+        drive_str = """
+            setup:
+                            wait_sync        4
+                            set_mrk          0
+                            upd_param        4
+
+            main:
+                            play             0, 1, 4
+                            set_mrk          0
+                            upd_param        4
+                            stop
+        """
+        assert is_q1asm_equal(sequences["drive"], drive_str)
+
+    def test_qblox_play_none_wait_time(self, qblox_play_none_wait_time: QProgram):
+        compiler = QbloxCompiler()
+        sequences, _ = compiler.compile(qprogram=qblox_play_none_wait_time)
 
         assert sequences["drive"]._program._compiled
 


### PR DESCRIPTION
Fixed a bug where `qp.qblox.play` with `wait_time=0` was treated as no `wait_time` provided, producing incorrect Q1ASM. The wait time is now correctly clamped to the minimum valid value of 4 ns.