### PR TITLE
[QHC-1322] [BUG] RSWUSP16TR InstrumentFactory import interaction

### DIFF
--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -152,7 +152,10 @@ With `execute_qprogram(..., crosstalk= True / False)` the parameter introduced i
   [#1030](https://github.com/qilimanjaro-tech/qililab/pull/1030)
 
 - Fixed a bug in the Qblox compiler where the bin acquisition index was not incrementing correctly when multiple `measure` calls are used sequentially inside an `average` block with an outer sweep loop.  Each sequential acquire now gets its own bin register initialised to its position offset, and the bin register is advanced by the total number of acquires per sweep step (instead of always 1), so that consecutive acquires write to consecutive bins and the full acquisition matrix is filled correctly.
-  [#1098](https://github.com/qilimanjaro-tech/qililab/pull/1098
+  [#1098](https://github.com/qilimanjaro-tech/qililab/pull/1098)
 
 - Fixed a bug where the qblox instrument controller parameter `ext_trigger` and the qdac instrument controller parameter `reference_clock` where not correctly translated to dictionary from the runcard and therefore not saved with `ql.save_platform(platform)`.
   [#1104](https://github.com/qilimanjaro-tech/qililab/pull/1104)
+
+- Fixed bug were the RSWU_SP16TR `Instrument` and `InstrumentController` wouldn't be registred causing `build_platform` to fail.
+  [#1120](https://github.com/qilimanjaro-tech/qililab/pull/1120)

--- a/src/qililab/instrument_controllers/__init__.py
+++ b/src/qililab/instrument_controllers/__init__.py
@@ -14,6 +14,7 @@
 
 """Instrument Controllers module."""
 
+from .becker import RSWUSP16TRController
 from .instrument_controller import InstrumentController
 from .instrument_controllers import InstrumentControllers
 from .keithley import Keithley2600Controller
@@ -37,6 +38,7 @@ __all__ = [
     "QDevilQDac2Controller",
     "QbloxClusterController",
     "QbloxSPIRackController",
+    "RSWUSP16TRController",
     "SGS100AController",
     "SingleInstrumentController",
 ]

--- a/src/qililab/instruments/__init__.py
+++ b/src/qililab/instruments/__init__.py
@@ -14,6 +14,7 @@
 
 """__init__.py"""
 
+from .becker import RSWUSP16TR
 from .decorators import check_device_initialized, log_set_parameter
 from .instrument import Instrument, ParameterNotFound
 from .instruments import Instruments
@@ -23,6 +24,7 @@ from .signal_generator import SignalGenerator
 from .utils import InstrumentFactory
 
 __all__ = [
+    "RSWUSP16TR",
     "SGS100A",
     "Attenuator",
     "Instrument",


### PR DESCRIPTION
The instruments weren't on the init so they weren't getting imported. That means they weren't getting registered in the InstrumentFactories. 
I couldn't replicate it because in my tests I was importing them.