### PR TITLE
Qhc 1403 bug fix crosstalk matrix to array fails to fill with zeroes

### DIFF
--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -11,3 +11,7 @@
 ### Documentation
 
 ### Bug fixes
+
+- Fixed a bug where `CrosstalkMatrix.to_array()` crashed instead of creating the right array when some field of the matrix dictionary where missing (missing values of the matrix), this should default to the identity (values of 1 in the diagonal and 0 outside the diagonal). Now it creates an array even if there are missing elements of the matrix and defaults them to 0 or 1 if those elements are in the diagonal of the matrix.
+Also fixed the `str` representation of the same crosstalk matrix as the same missing values were represented with ones instead of zeroes.
+  [#1125](https://github.com/qilimanjaro-tech/qililab/pull/1125)

--- a/src/qililab/qprogram/crosstalk_matrix.py
+++ b/src/qililab/qprogram/crosstalk_matrix.py
@@ -42,10 +42,11 @@ class CrosstalkMatrix:
 
         sorted_buses = sorted(buses)
 
-        xtalk_matrix = np.empty(shape=[len(self.matrix), len(self.matrix)])
+        xtalk_matrix = np.eye(len(self.matrix))
         for i, bus1 in enumerate(sorted_buses):
             for j, bus2 in enumerate(sorted_buses):
-                xtalk_matrix[i, j] = self.matrix[bus1][bus2]
+                if bus1 in self.matrix and bus2 in self.matrix[bus1]:
+                    xtalk_matrix[i, j] = self.matrix[bus1][bus2]
         return xtalk_matrix
 
     def inverse(self) -> "CrosstalkMatrix":
@@ -115,7 +116,7 @@ class CrosstalkMatrix:
         for bus1 in sorted_buses:
             row = [f"{bus1:{col_width}}"]
             for bus2 in sorted_buses:
-                row.append(f"{self.matrix.get(bus1, {}).get(bus2, 1.0):{col_width}}")
+                row.append(f"{self.matrix.get(bus1, {}).get(bus2, 0.0):{col_width}}")
             rows.append(" ".join(row))
         return header + "\n".join(rows)
 

--- a/tests/qprogram/test_crosstalk_matrix.py
+++ b/tests/qprogram/test_crosstalk_matrix.py
@@ -52,6 +52,29 @@ class TestCrosstalkMatrix:
 
     def test_to_array(self, crosstalk_matrix, crosstalk_array_buses):
         assert np.allclose(crosstalk_matrix.to_array(), crosstalk_array_buses[0])
+        
+    def test_to_array_two_independent_qubits(self):
+        """Test to_array method when two independent qubits added
+        The matrix has missing elements of the dictionary.
+        """
+        # Create the CrosstalkMatrix for qubit 1, only flux1_z and flux1_x
+        crosstalk_matrix = CrosstalkMatrix.from_buses(
+            buses={"flux1_z": {"flux1_x": 0.1, "flux1_z": 1.0}, "flux1_x": {"flux1_x": 1.0, "flux1_z": 0.5}}
+        )
+
+        # Add the elements for qubit 2, only flux2_z and flux2_x
+        crosstalk_matrix["flux2_x"] = {"flux2_z": 0.3, "flux2_x": 1}
+        crosstalk_matrix["flux2_z"] = {"flux2_z": 1, "flux2_x": 0.4}
+
+        crosstalk_q1 = np.array([[1.0, 0.5], [0.1, 1.0]])
+        crosstalk_q2 = np.array([[1.0, 0.3], [0.4, 1.0]])
+        full_crosstalk = np.eye(4)
+        full_crosstalk[0:2, 0:2] = crosstalk_q1  # first component is qubit 1
+        full_crosstalk[2:4, 2:4] = crosstalk_q2  # second component is qubit 2
+        # Elements outside the diagonal should be empty
+
+        # Get and compare the crosstalk matrix as an array
+        assert np.allclose(crosstalk_matrix.to_array(), full_crosstalk)
 
     def test_inverse(self, crosstalk_matrix):
         inv_array = np.linalg.inv(crosstalk_matrix.to_array())
@@ -147,6 +170,25 @@ class TestCrosstalkMatrix:
             == """            bus1     bus2
 bus1         -0.5      0.5
 bus2          0.7     -0.5"""
+        )
+
+    def test_str_method_independent_value(self):
+        """Test __str__ method"""
+        crosstalk_matrix = CrosstalkMatrix()
+        crosstalk_matrix["bus1"]["bus1"] = -0.5
+        crosstalk_matrix["bus1"]["bus2"] = 0.5
+        crosstalk_matrix["bus2"]["bus1"] = 0.7
+        crosstalk_matrix["bus2"]["bus2"] = -0.5
+        # New bus
+        crosstalk_matrix["bus3"]["bus3"] = 0.2
+
+        string = str(crosstalk_matrix)
+        assert (
+            string
+            == """            bus1     bus2     bus3
+bus1         -0.5      0.5      0.0
+bus2          0.7     -0.5      0.0
+bus3          0.0      0.0      0.2"""
         )
 
     def test_repr_method(self):


### PR DESCRIPTION
Fixed a bug where `CrosstalkMatrix.to_array()` crashed instead of creating the right array when some field of the matrix dictionary where missing (missing values of the matrix), this should default to the identity (values of 1 in the diagonal and 0 outside the diagonal). Now it creates an array even if there are missing elements of the matrix and defaults them to 0 or 1 if those elements are in the diagonal of the matrix.
Also fixed the str representation of the same crosstalk matrix as the same missing values were represented with ones instead of zeroes.