### PR TITLE
[QHC-1404][BUG] NonLinearFluxVector ForLoop array Missmach

### DIFF
--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -21,3 +21,6 @@
 - Fixed a bug where `CrosstalkMatrix.to_array()` crashed instead of creating the right array when some field of the matrix dictionary where missing (missing values of the matrix), this should default to the identity (values of 1 in the diagonal and 0 outside the diagonal). Now it creates an array even if there are missing elements of the matrix and defaults them to 0 or 1 if those elements are in the diagonal of the matrix.
 Also fixed the `str` representation of the same crosstalk matrix as the same missing values were represented with ones instead of zeroes.
   [#1125](https://github.com/qilimanjaro-tech/qililab/pull/1125)
+
+- Fixed `NonLinearFluxVector` handling of the ForLoop to mach the QbloxCompiler behavior.
+ [#1126](https://github.com/qilimanjaro-tech/qililab/pull/1126)

--- a/src/qililab/qprogram/flux_vector.py
+++ b/src/qililab/qprogram/flux_vector.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import math
 from copy import deepcopy
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, cast
@@ -246,8 +247,16 @@ class NonLinearFluxVector:
 
     @staticmethod
     def _array_from_for_loop(loop: ForLoop):
-        num_div = round((loop.stop - loop.start) / loop.step) + 1
-        return np.linspace(loop.start, loop.stop, num_div)
+        raw_iterations = (loop.stop - loop.start + loop.step) / loop.step
+
+        # If the raw number of iterations is very close to an integer, round it to that integer
+        # This accounts for potential floating-point inaccuracies
+        if abs(raw_iterations - round(raw_iterations)) < 1e-9:
+            raw_iterations = round(raw_iterations)
+        else:  # Otherwise, if we're incrementing, take the ceiling, and if we're decrementing, take the floor
+            raw_iterations = math.floor(raw_iterations) if loop.step > 0 else math.ceil(raw_iterations)
+
+        return np.linspace(loop.start, loop.stop, raw_iterations)
 
     def set_element(self, element: SetGain | SetOffset):
         """Registers a gain or offset value for a bus.

--- a/src/qililab/qprogram/flux_vector.py
+++ b/src/qililab/qprogram/flux_vector.py
@@ -246,17 +246,19 @@ class NonLinearFluxVector:
             )
 
     @staticmethod
-    def _array_from_for_loop(loop: ForLoop):
+    def _iterations_from_loop(loop: ForLoop | Loop):
+        if isinstance(loop, Loop):
+            return loop.values.shape[0]
         raw_iterations = (loop.stop - loop.start + loop.step) / loop.step
 
         # If the raw number of iterations is very close to an integer, round it to that integer
         # This accounts for potential floating-point inaccuracies
         if abs(raw_iterations - round(raw_iterations)) < 1e-9:
             raw_iterations = round(raw_iterations)
-        else:  # Otherwise, if we're incrementing, take the ceiling, and if we're decrementing, take the floor
-            raw_iterations = math.floor(raw_iterations) if loop.step > 0 else math.ceil(raw_iterations)
+        else:
+            raw_iterations = math.floor(raw_iterations)
 
-        return np.linspace(loop.start, loop.stop, raw_iterations)
+        return raw_iterations
 
     def set_element(self, element: SetGain | SetOffset):
         """Registers a gain or offset value for a bus.
@@ -293,11 +295,14 @@ class NonLinearFluxVector:
                 (duplicate variable across active loops).
         """
         if isinstance(loop, Parallel):
-            for in_loop in loop.loops:
+            loop_iterations = [self._iterations_from_loop(in_loop) for in_loop in loop.loops]
+            if not np.allclose(loop_iterations, loop_iterations[0]):
+                raise ValueError("All the loops in a parallel loop should have the same length")
+            for loop_iter, in_loop in zip(loop_iterations, loop.loops):
                 if isinstance(in_loop, ForLoop):
                     self.variables[in_loop.variable.label] = self.VariableContext(
                         in_loop.variable.label,
-                        self._array_from_for_loop(in_loop),
+                        np.linspace(in_loop.start, in_loop.stop, loop_iter),
                         self.curr_loop_id,
                     )
                 elif isinstance(in_loop, Loop):
@@ -309,7 +314,7 @@ class NonLinearFluxVector:
         elif isinstance(loop, ForLoop):
             self.variables[loop.variable.label] = self.VariableContext(
                 loop.variable.label,
-                self._array_from_for_loop(loop),
+                np.linspace(loop.start, loop.stop, self._iterations_from_loop(loop)),
                 self.curr_loop_id,
             )
         self.loops[self.curr_loop_id] = loop

--- a/src/qililab/qprogram/flux_vector.py
+++ b/src/qililab/qprogram/flux_vector.py
@@ -246,7 +246,7 @@ class NonLinearFluxVector:
 
     @staticmethod
     def _array_from_for_loop(loop: ForLoop):
-        num_div = int((loop.stop - loop.start) // loop.step + 1)
+        num_div = round((loop.stop - loop.start) / loop.step) + 1
         return np.linspace(loop.start, loop.stop, num_div)
 
     def set_element(self, element: SetGain | SetOffset):

--- a/src/qililab/qprogram/flux_vector.py
+++ b/src/qililab/qprogram/flux_vector.py
@@ -244,6 +244,11 @@ class NonLinearFluxVector:
                 "Use set_loop to contextualize variables."
             )
 
+    @staticmethod
+    def _array_from_for_loop(loop: ForLoop):
+        num_div = int((loop.stop - loop.start) // loop.step + 1)
+        return np.linspace(loop.start, loop.stop, num_div)
+
     def set_element(self, element: SetGain | SetOffset):
         """Registers a gain or offset value for a bus.
 
@@ -283,7 +288,7 @@ class NonLinearFluxVector:
                 if isinstance(in_loop, ForLoop):
                     self.variables[in_loop.variable.label] = self.VariableContext(
                         in_loop.variable.label,
-                        np.arange(in_loop.start, in_loop.stop, in_loop.step),
+                        self._array_from_for_loop(in_loop),
                         self.curr_loop_id,
                     )
                 elif isinstance(in_loop, Loop):
@@ -295,7 +300,7 @@ class NonLinearFluxVector:
         elif isinstance(loop, ForLoop):
             self.variables[loop.variable.label] = self.VariableContext(
                 loop.variable.label,
-                np.arange(loop.start, loop.stop, loop.step),
+                self._array_from_for_loop(loop),
                 self.curr_loop_id,
             )
         self.loops[self.curr_loop_id] = loop

--- a/tests/qprogram/test_flux_vector.py
+++ b/tests/qprogram/test_flux_vector.py
@@ -124,9 +124,19 @@ class TestNonLinearFluxVector:
         phi = Variable("phi")
         theta = Variable("theta")
         nlfv_no_crosstalk.set_loop(Parallel(loops=[
-            ForLoop(variable=phi, start=0.0, stop=1.0, step=0.1),
-            Loop(variable=theta, values=np.arange(0.0, 2.0, 0.5)),
+            ForLoop(variable=phi, start=0, stop=0.1, step=0.08),
+            ForLoop(variable=theta, start=0.1, stop=0, step=-0.08),
         ]))
+    
+    def test_set_loop_parallel_raises_different_loop_lengths(self, nlfv_no_crosstalk):
+        phi = Variable("phi")
+        theta = Variable("theta")
+        parallel = Parallel(loops=[
+            ForLoop(variable=phi, start=0.0, stop=1.0, step=0.1),
+            Loop(variable=theta, values=np.arange(0.0, 2.0, 0.2)),
+        ])
+        with pytest.raises(ValueError):
+            nlfv_no_crosstalk.set_loop(parallel)
 
     def test_set_loop_raises_on_duplicate_variable(self, nlfv_no_crosstalk):
         phi = Variable("phi")
@@ -155,7 +165,7 @@ class TestNonLinearFluxVector:
         theta = Variable("theta", Domain.Voltage)
         mu = Variable("mu", Domain.Voltage)
         parallel = Parallel(loops=[
-            ForLoop(variable=phi, start=0.0, stop=1.5, step=0.5),
+            ForLoop(variable=phi, start=0.0, stop=1.0, step=0.5),
             Loop(variable=theta, values=np.arange(0.0, 3.0, 1.0)),
         ])
         ex_loop = ForLoop(variable=mu, start=0.0, stop=1.0, step=0.2)
@@ -168,7 +178,7 @@ class TestNonLinearFluxVector:
         nlfv_no_crosstalk.exit_loop(parallel)
         var_exp = (2.0 - mu)
 
-        assert nlfv_no_crosstalk.offset["flux_0"] == pytest.approx(1.5)
+        assert nlfv_no_crosstalk.offset["flux_0"] == pytest.approx(1.0)
         assert nlfv_no_crosstalk.offset["flux_1"] == pytest.approx(2.5)
         assert nlfv_no_crosstalk.offset["flux_2"].right == var_exp.right
         assert nlfv_no_crosstalk.offset["flux_2"].operator == var_exp.operator

--- a/tests/qprogram/test_flux_vector.py
+++ b/tests/qprogram/test_flux_vector.py
@@ -147,8 +147,8 @@ class TestNonLinearFluxVector:
         nlfv_no_crosstalk.offset["flux_0"] = phi
         nlfv_no_crosstalk.gain["flux_1"] = phi + 0.1
         nlfv_no_crosstalk.exit_loop(loop)
-        assert nlfv_no_crosstalk.offset["flux_0"] == pytest.approx(1.0)
-        assert nlfv_no_crosstalk.gain["flux_1"] == pytest.approx(1.1)
+        assert nlfv_no_crosstalk.offset["flux_0"] == pytest.approx(1.5)
+        assert nlfv_no_crosstalk.gain["flux_1"] == pytest.approx(1.6)
 
     def test_exit_loop_parallel_resolves_all_variables(self, nlfv_no_crosstalk):
         phi = Variable("phi", Domain.Voltage)
@@ -168,7 +168,7 @@ class TestNonLinearFluxVector:
         nlfv_no_crosstalk.exit_loop(parallel)
         var_exp = (2.0 - mu)
 
-        assert nlfv_no_crosstalk.offset["flux_0"] == pytest.approx(1.0)
+        assert nlfv_no_crosstalk.offset["flux_0"] == pytest.approx(1.5)
         assert nlfv_no_crosstalk.offset["flux_1"] == pytest.approx(2.5)
         assert nlfv_no_crosstalk.offset["flux_2"].right == var_exp.right
         assert nlfv_no_crosstalk.offset["flux_2"].operator == var_exp.operator
@@ -225,7 +225,7 @@ class TestNonLinearFluxVector:
         nlfv.set_loop(outer)     # loop_2: 4 steps
         result = nlfv.get_corrected_offsets()
         for bus in nlfv.crosstalk.matrix:
-            assert result[bus].shape == (4, 2)
+            assert result[bus].shape == (5, 3)
 
     def test_get_corrected_play_raises_without_crosstalk(self, nlfv_no_crosstalk):
         with pytest.raises(AttributeError):
@@ -280,7 +280,7 @@ class TestNonLinearFluxVector:
             "flux_2": Square(0.1, 100),
         })
         for bus in nlfv.crosstalk.matrix:
-            assert result[bus].shape == (4, 2)
+            assert result[bus].shape == (5, 3)
     
     def test_raise_error_invalid_expresion_operator(self, nlfv):
         phi = Variable("phi", Domain.Voltage)

--- a/tests/qprogram/test_qblox_compiler.py
+++ b/tests/qprogram/test_qblox_compiler.py
@@ -4730,13 +4730,13 @@ other_max_duration_0:
                         play             0, 1, 50       
                         wait             54             
                         nop                             
-                        set_awg_offs     10434, 10434   
+                        set_awg_offs     11374, 11374   
                         upd_param        4              
                         wait             6              
-                        set_awg_gain     3240, 3240     
-                        set_awg_gain     3240, 3240     
+                        set_awg_gain     2668, 2668     
+                        set_awg_gain     2668, 2668     
                         nop                             
-                        set_awg_offs     10434, 10434   
+                        set_awg_offs     11374, 11374   
                         play             0, 1, 50       
                         wait             54             
                         set_mrk          0              
@@ -4761,13 +4761,13 @@ other_max_duration_0:
                         play             0, 1, 50       
                         wait             54             
                         nop                             
-                        set_awg_offs     16936, 16936   
+                        set_awg_offs     17832, 17832   
                         upd_param        4              
                         wait             6              
-                        set_awg_gain     1565, 1565     
-                        set_awg_gain     1565, 1565     
+                        set_awg_gain     421, 421     
+                        set_awg_gain     421, 421     
                         nop                             
-                        set_awg_offs     16936, 16936   
+                        set_awg_offs     17832, 17832   
                         play             0, 1, 50       
                         wait             54             
                         set_mrk          0              
@@ -4852,7 +4852,7 @@ other_max_duration_0:
                         move             400, R3        
         loop_1:
                         nop                             
-                        set_awg_offs     1310, 1310     
+                        set_awg_offs     1638, 1638     
                         set_awg_gain     11374, 11374   
                         set_awg_gain     11374, 11374   
                         play             0, 1, 50       
@@ -4885,7 +4885,7 @@ other_max_duration_0:
                         move             400, R3        
         loop_1:
                         nop                             
-                        set_awg_offs     2621, 2621     
+                        set_awg_offs     3276, 3276     
                         set_awg_gain     17832, 17832   
                         set_awg_gain     17832, 17832   
                         play             0, 1, 50       
@@ -5108,8 +5108,8 @@ other_max_duration_0:
                         nop                             
                         set_awg_offs     0, 0           
                         play             0, 1, 50       
-                        set_awg_gain     2224, 2224     
-                        set_awg_gain     2224, 2224     
+                        set_awg_gain     2724, 2724     
+                        set_awg_gain     2724, 2724     
                         nop                             
                         set_awg_offs     0, 0           
                         play             0, 1, 50       
@@ -5118,7 +5118,7 @@ other_max_duration_0:
                         upd_param        4              
                         wait             6              
                         nop                             
-                        set_awg_offs     10761, 10761   
+                        set_awg_offs     11374, 11374   
                         upd_param        4              
                         wait             6              
                         set_mrk          0              
@@ -5137,8 +5137,8 @@ other_max_duration_0:
                         nop                             
                         set_awg_offs     0, 0           
                         play             0, 1, 50       
-                        set_awg_gain     4055, 4055     
-                        set_awg_gain     4055, 4055     
+                        set_awg_gain     4957, 4957     
+                        set_awg_gain     4957, 4957     
                         nop                             
                         set_awg_offs     0, 0           
                         play             0, 1, 50       
@@ -5147,7 +5147,7 @@ other_max_duration_0:
                         upd_param        4              
                         wait             6              
                         nop                             
-                        set_awg_offs     17591, 17591   
+                        set_awg_offs     17832, 17832   
                         upd_param        4              
                         wait             6              
                         set_mrk          0              
@@ -5188,19 +5188,19 @@ other_max_duration_0:
                         set_awg_gain     11374, 11374   
                         play             0, 1, 50       
                         nop                             
-                        set_awg_offs     327, 327       
+                        set_awg_offs     0, 0       
                         set_awg_gain     11374, 11374   
                         set_awg_gain     11374, 11374   
                         play             0, 1, 50       
                         nop                             
-                        set_awg_offs     12072, 12072   
-                        set_awg_gain     3240, 3240     
-                        set_awg_gain     3240, 3240     
+                        set_awg_offs     13012, 13012   
+                        set_awg_gain     2668, 2668     
+                        set_awg_gain     2668, 2668     
                         play             0, 1, 50       
                         nop                             
-                        set_awg_offs     10761, 10761   
-                        set_awg_gain     3240, 3240     
-                        set_awg_gain     3240, 3240     
+                        set_awg_offs     11374, 11374   
+                        set_awg_gain     2668, 2668     
+                        set_awg_gain     2668, 2668     
                         play             0, 1, 50       
                         set_mrk          0              
                         upd_param        4              
@@ -5219,19 +5219,19 @@ other_max_duration_0:
                         set_awg_gain     17832, 17832   
                         play             0, 1, 50       
                         nop                             
-                        set_awg_offs     655, 655       
+                        set_awg_offs     0, 0       
                         set_awg_gain     17832, 17832   
                         set_awg_gain     17832, 17832   
                         play             0, 1, 50       
                         nop                             
-                        set_awg_offs     20213, 20213   
-                        set_awg_gain     1565, 1565     
-                        set_awg_gain     1565, 1565     
+                        set_awg_offs     21109, 21109   
+                        set_awg_gain     421, 421     
+                        set_awg_gain     421, 421     
                         play             0, 1, 50       
                         nop                             
-                        set_awg_offs     17591, 17591   
-                        set_awg_gain     1565, 1565     
-                        set_awg_gain     1565, 1565     
+                        set_awg_offs     17832, 17832   
+                        set_awg_gain     421, 421     
+                        set_awg_gain     421, 421     
                         play             0, 1, 50       
                         set_mrk          0              
                         upd_param        4              
@@ -5275,13 +5275,13 @@ other_max_duration_0:
                         nop                             
                         set_awg_offs     0, 0           
                         play             0, 1, 50       
-                        set_awg_gain     2224, 2224     
-                        set_awg_gain     2224, 2224     
+                        set_awg_gain     2724, 2724     
+                        set_awg_gain     2724, 2724     
                         nop                             
                         set_awg_offs     0, 0           
                         play             0, 1, 50       
-                        set_awg_gain     2224, 2224     
-                        set_awg_gain     2224, 2224     
+                        set_awg_gain     2724, 2724     
+                        set_awg_gain     2724, 2724     
                         nop                             
                         set_awg_offs     0, 0           
                         play             0, 1, 50       
@@ -5306,13 +5306,13 @@ other_max_duration_0:
                         nop                             
                         set_awg_offs     0, 0           
                         play             0, 1, 50       
-                        set_awg_gain     4055, 4055     
-                        set_awg_gain     4055, 4055     
+                        set_awg_gain     4957, 4957     
+                        set_awg_gain     4957, 4957     
                         nop                             
                         set_awg_offs     0, 0           
                         play             0, 1, 50       
-                        set_awg_gain     4055, 4055     
-                        set_awg_gain     4055, 4055     
+                        set_awg_gain     4957, 4957     
+                        set_awg_gain     4957, 4957     
                         nop                             
                         set_awg_offs     0, 0           
                         play             0, 1, 50       

--- a/tests/qprogram/test_qprogram.py
+++ b/tests/qprogram/test_qprogram.py
@@ -506,10 +506,10 @@ class TestQProgram(TestStructuredProgram):
         assert isinstance(new_qp.body.elements[14], Sync)
         # Repeat loop for second iteration
         assert isinstance(new_qp.body.elements[15], SetOffset)
-        assert math.isclose(new_qp.body.elements[15].offset_path0,0.31843980232472535)
+        assert math.isclose(new_qp.body.elements[15].offset_path0,0.3471177904070214)
         assert new_qp.body.elements[15].bus == "flux1"
         assert isinstance(new_qp.body.elements[16], SetOffset)
-        assert math.isclose(new_qp.body.elements[16].offset_path0, 0.5168796046494507)
+        assert math.isclose(new_qp.body.elements[16].offset_path0, 0.5442355808140428)
         assert new_qp.body.elements[16].bus == "flux2"
         assert isinstance(new_qp.body.elements[17], Wait)
         assert new_qp.body.elements[17].bus == "drive"
@@ -518,10 +518,10 @@ class TestQProgram(TestStructuredProgram):
         assert isinstance(new_qp.body.elements[19], Wait)
         assert new_qp.body.elements[19].bus == "flux2"
         assert isinstance(new_qp.body.elements[20], SetGain)
-        assert math.isclose(new_qp.body.elements[20].gain, 0.09888972435411081)
+        assert math.isclose(new_qp.body.elements[20].gain,0.08143146795214351)
         assert new_qp.body.elements[20].bus == "flux1"
         assert isinstance(new_qp.body.elements[21], SetOffset)
-        assert math.isclose(new_qp.body.elements[21].offset_path0, 0.31843980232472535)
+        assert math.isclose(new_qp.body.elements[21].offset_path0, 0.3471177904070214)
         assert new_qp.body.elements[21].bus == "flux1"
         assert isinstance(new_qp.body.elements[22], Play)
         assert isinstance(new_qp.body.elements[22].waveform, Square)
@@ -529,10 +529,10 @@ class TestQProgram(TestStructuredProgram):
         assert math.isclose(new_qp.body.elements[22].waveform.amplitude, 1.0)  #Check that Square pulses are normalized
         assert isinstance(new_qp.body.elements[23], SetGain)
         assert new_qp.body.elements[23].bus == "flux2"
-        assert math.isclose(new_qp.body.elements[23].gain, 0.047779448708221595)
+        assert math.isclose(new_qp.body.elements[23].gain, 0.012862935904286998)
         assert isinstance(new_qp.body.elements[24], SetOffset)
         assert new_qp.body.elements[24].bus == "flux2"
-        assert math.isclose(new_qp.body.elements[24].offset_path0, 0.5168796046494507)
+        assert math.isclose(new_qp.body.elements[24].offset_path0, 0.5442355808140428)
         assert isinstance(new_qp.body.elements[25], Play)
         assert isinstance(new_qp.body.elements[25].waveform, Square)
         assert new_qp.body.elements[25].bus == "flux2"
@@ -640,10 +640,10 @@ class TestQProgram(TestStructuredProgram):
         # The loop repeats itself until 47 iterations, 
         # we focus here on the initial offsets being modified and the last point
         assert isinstance(new_qp.body.elements[24], SetOffset)
-        assert math.isclose(new_qp.body.elements[24].offset_path0,0.31843980232472535)
+        assert math.isclose(new_qp.body.elements[24].offset_path0,0.3471177904070214)
         assert new_qp.body.elements[24].bus == "flux1"
         assert isinstance(new_qp.body.elements[25], SetOffset)
-        assert math.isclose(new_qp.body.elements[25].offset_path0, 0.5168796046494507)
+        assert math.isclose(new_qp.body.elements[25].offset_path0, 0.5442355808140428)
         assert new_qp.body.elements[25].bus == "flux2"
         # ...
         assert isinstance(new_qp.body.elements[47], Sync)


### PR DESCRIPTION
`NonLinearFluxVector` constructed arrays from for loops with the asumption that it worked like `numpy.arange`. In reality it works like a `numpy.linspace` were the number of divisions is "(stop - start) // step + 1.
This PR fixes that behabour.