### PR TITLE
Bug fix Rohde Schwarz model B106V device not setting iq state during initial setup

### DIFF
--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -15,6 +15,9 @@
 
 ### Bug fixes
 
+- Fixed a bug for Rohde Schwarz `initial_setup` where the `iq_modulation` set as `True` inside the runcard for RS models `SGS-B106V` was not correctly set in the device.
+  [#1132](https://github.com/qilimanjaro-tech/qililab/pull/1132)
+
 - Fixed a bug in `load_sequence_by_id` where measurements were returned in an undefined order, causing incorrect results when processing sequences. Measurements are now ordered by `measurement_id`.
   [#1132](https://github.com/qilimanjaro-tech/qililab/pull/1132)
 

--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -16,7 +16,7 @@
 ### Bug fixes
 
 - Fixed a bug for Rohde Schwarz `initial_setup` where the `iq_modulation` set as `True` inside the runcard for RS models `SGS-B106V` was not correctly set in the device.
-  [#1132](https://github.com/qilimanjaro-tech/qililab/pull/1132)
+  [#1137](https://github.com/qilimanjaro-tech/qililab/pull/1137)
 
 - Fixed a bug in `load_sequence_by_id` where measurements were returned in an undefined order, causing incorrect results when processing sequences. Measurements are now ordered by `measurement_id`.
   [#1132](https://github.com/qilimanjaro-tech/qililab/pull/1132)

--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -7,6 +7,9 @@
 - Upgraded `qblox-instruments` dependency from `0.16.0` to `1.0.3`.
   [#1134](https://github.com/qilimanjaro-tech/qililab/pull/1134)
 
+- Added a raise error for Rohde Schwarz `initial_setup` when `iq_modulation` is set as `True` for models without IQ modulation (`SGS-B106` and `SGS-B112`).
+  [#1137](https://github.com/qilimanjaro-tech/qililab/pull/1137)
+
 ### Breaking changes
 
 ### Deprecations / Removals

--- a/src/qililab/instruments/rohde_schwarz/sgs100a.py
+++ b/src/qililab/instruments/rohde_schwarz/sgs100a.py
@@ -264,6 +264,8 @@ class SGS100A(Instrument):
                 self.device.write("SOUR:IQ:WBST 0")
         elif device_mixer == "SGS-B106V" or not self.iq_modulation:
             self.device.IQ_state(self.iq_modulation)
+        else:
+            raise ValueError(f"iq_modulation set as True for R&S SGS1000A device {device_mixer} without IQ modulation")
         if self.rf_on:
             self.device.on()
         else:

--- a/src/qililab/instruments/rohde_schwarz/sgs100a.py
+++ b/src/qililab/instruments/rohde_schwarz/sgs100a.py
@@ -262,7 +262,7 @@ class SGS100A(Instrument):
                 else:
                     warnings.warn("Deactivated wideband allows for IF sweeps of ±50e6 Hz", ResourceWarning)
                 self.device.write("SOUR:IQ:WBST 0")
-        elif not self.iq_modulation:
+        elif device_mixer == "SGS-B106V" or not self.iq_modulation:
             self.device.IQ_state(self.iq_modulation)
         if self.rf_on:
             self.device.on()

--- a/tests/instruments/rohde_schwarz/test_rohde_schwarz_sgs100a.py
+++ b/tests/instruments/rohde_schwarz/test_rohde_schwarz_sgs100a.py
@@ -308,6 +308,7 @@ class TestSGS100A:
         sdg100a.initial_setup()
         sdg100a.device.power.assert_called_with(sdg100a.power)
         sdg100a.device.frequency.assert_called_with(sdg100a.frequency)
+        sdg100a.device.IQ_state.assert_called_with(sdg100a.iq_modulation)
         sdg100a.device.on.assert_called_once()
 
         assert sdg100a.settings.iq_modulation is True

--- a/tests/instruments/rohde_schwarz/test_rohde_schwarz_sgs100a.py
+++ b/tests/instruments/rohde_schwarz/test_rohde_schwarz_sgs100a.py
@@ -302,6 +302,17 @@ class TestSGS100A:
         )
 
     @patch("qililab.instruments.rohde_schwarz.SGS100A.get_rs_options")
+    def test_initial_setup_method_b106v_model(self, mock_get_rs_options, sdg100a: SGS100A):
+        """Test initial setup method"""
+        mock_get_rs_options.return_value = "Some,other,SGS-B106V"
+        sdg100a.initial_setup()
+        sdg100a.device.power.assert_called_with(sdg100a.power)
+        sdg100a.device.frequency.assert_called_with(sdg100a.frequency)
+        sdg100a.device.on.assert_called_once()
+
+        assert sdg100a.settings.iq_modulation is True
+
+    @patch("qililab.instruments.rohde_schwarz.SGS100A.get_rs_options")
     def test_initial_setup_method_iq_mod_off(self, mock_get_rs_options, sdg100a_iq_mod_off: SGS100A):
         """Test initial method when the runcard sets rf_on as False"""
         mock_get_rs_options.return_value = "Some,other,SGS-B112V"

--- a/tests/instruments/rohde_schwarz/test_rohde_schwarz_sgs100a.py
+++ b/tests/instruments/rohde_schwarz/test_rohde_schwarz_sgs100a.py
@@ -313,6 +313,14 @@ class TestSGS100A:
         assert sdg100a.settings.iq_modulation is True
 
     @patch("qililab.instruments.rohde_schwarz.SGS100A.get_rs_options")
+    def test_initial_setup_method_b112_raises_error(self, mock_get_rs_options, sdg100a: SGS100A):
+        """Test initial setup method"""
+        mock_get_rs_options.return_value = "Some,other,SGS-B112"  # module without IQ-band
+        error_string = "iq_modulation set as True for R&S SGS1000A device SGS-B112 without IQ modulation"
+        with pytest.raises(ValueError, match=re.escape(error_string)):
+            sdg100a.initial_setup()
+
+    @patch("qililab.instruments.rohde_schwarz.SGS100A.get_rs_options")
     def test_initial_setup_method_iq_mod_off(self, mock_get_rs_options, sdg100a_iq_mod_off: SGS100A):
         """Test initial method when the runcard sets rf_on as False"""
         mock_get_rs_options.return_value = "Some,other,SGS-B112V"

--- a/tests/instruments/rohde_schwarz/test_rohde_schwarz_sgs100a.py
+++ b/tests/instruments/rohde_schwarz/test_rohde_schwarz_sgs100a.py
@@ -388,21 +388,25 @@ class TestSGS100A:
     def test_initial_setup_sets_correct_freq_range(self, mock_get_rs_options, sdg100a: SGS100A):
         """Test initial setup method"""
         mock_get_rs_options.return_value = "Some,other,SGS-B112"
+        sdg100a.set_parameter(Parameter.IQ_MODULATION, False)
         sdg100a.initial_setup()
         assert sdg100a.freq_top_limit == 12.75e9
         assert sdg100a.freq_bot_limit == 1e6
 
         mock_get_rs_options.return_value = "Some,other,SGS-B112V"
+        sdg100a.set_parameter(Parameter.IQ_MODULATION, True)
         sdg100a.initial_setup()
         assert sdg100a.freq_top_limit == 12.75e9
         assert sdg100a.freq_bot_limit == 80e6
 
         mock_get_rs_options.return_value = "Some,other,SGS-B106"
+        sdg100a.set_parameter(Parameter.IQ_MODULATION, False)
         sdg100a.initial_setup()
         assert sdg100a.freq_top_limit == 6e9
         assert sdg100a.freq_bot_limit == 1e6
 
         mock_get_rs_options.return_value = "Some,other,SGS-B106V"
+        sdg100a.set_parameter(Parameter.IQ_MODULATION, True)
         sdg100a.initial_setup()
         assert sdg100a.freq_top_limit == 6e9
         assert sdg100a.freq_bot_limit == 80e6


### PR DESCRIPTION
Fixed a bug for Rohde Schwarz `initial_setup` where the `iq_modulation` set as `True` inside the runcard for RS models `SGS-B106V` was not correctly set in the device.