### PR TITLE
fix(security): QILILAB-01/02 safe-by-default YAML deserialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,11 +25,6 @@
 
 ## 0.33.1
 
-### Security fixes
-
-- Made `deserialize` / `deserialize_from` safe by default. They now load through a registry-isolated, data-only YAML loader that rejects code-execution tags (`!!python/object/apply`, `!!python/name`, `!function`, `!lambda`, and the gated `!type` / `!PydanticModel` / `!defaultdict`), so deserializing an untrusted string or file can no longer execute arbitrary code. Every legitimate round-trip (waveforms, `QProgram`, `Experiment`, `Calibration`, numpy arrays, tuples, complex numbers, UUIDs, enums) keeps working, and a `trust_code=True` opt-in restores the previous behavior for fully trusted input. This also closes the `build_platform` runcard remote-code-execution path, where a gate-event waveform/weights string reached the unsafe loader via the `GateEvent` validators.
-  [#1138](https://github.com/qilimanjaro-tech/qililab/pull/1138)
-
 ### New features since last release
 
 - Added `load_sequence_by_id` inside the database manager. This function allows to retrieve simultaneous measurements given a list of IDs from a sequence of measurements. `Measurement.sequence_id`has been added as a measurement expression inside head and tail.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@
 
 ## 0.33.1
 
+### Security fixes
+
+- Made `deserialize` / `deserialize_from` safe by default. They now load through a registry-isolated, data-only YAML loader that rejects code-execution tags (`!!python/object/apply`, `!!python/name`, `!function`, `!lambda`, and the gated `!type` / `!PydanticModel` / `!defaultdict`), so deserializing an untrusted string or file can no longer execute arbitrary code. Every legitimate round-trip (waveforms, `QProgram`, `Experiment`, `Calibration`, numpy arrays, tuples, complex numbers, UUIDs, enums) keeps working, and a `trust_code=True` opt-in restores the previous behavior for fully trusted input. This also closes the `build_platform` runcard remote-code-execution path, where a gate-event waveform/weights string reached the unsafe loader via the `GateEvent` validators.
+  [#1138](https://github.com/qilimanjaro-tech/qililab/pull/1138)
+
 ### New features since last release
 
 - Added `load_sequence_by_id` inside the database manager. This function allows to retrieve simultaneous measurements given a list of IDs from a sequence of measurements. `Measurement.sequence_id`has been added as a measurement expression inside head and tail.

--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -131,6 +131,9 @@ In the runcard this parameter is located inside the instruments sequencer for QR
 
 - Fixed `QbloxQRM.acquire_qprogram_results` uploading an empty sequence after each individual acquisition deletion, which wiped the hardware acquisition table mid-loop and caused subsequent deletions to fail. The empty-sequence upload now happens once after all acquisitions have been deleted. This was triggered by any QProgram that produced more than one named acquisition on the same sequencer (e.g. two separate `average` blocks each containing one `acquire` on the same bus).
   [#1117](https://github.com/qilimanjaro-tech/qililab/pull/1117)
- 
+
+- Made `deserialize` / `deserialize_from` safe by default. They now load through a registry-isolated, data-only YAML loader that rejects code-execution tags (`!!python/object/apply`, `!!python/name`, `!function`, `!lambda`, and the gated `!type` / `!PydanticModel` / `!defaultdict`), so deserializing an untrusted string or file can no longer execute arbitrary code. Every legitimate round-trip (waveforms, `QProgram`, `Experiment`, `Calibration`, numpy arrays, tuples, complex numbers, UUIDs, enums) keeps working, and a `trust_code=True` opt-in restores the previous behavior for fully trusted input. This also closes the `build_platform` runcard remote-code-execution path, where a gate-event waveform/weights string reached the unsafe loader via the `GateEvent` validators.
+  [#1142](https://github.com/qilimanjaro-tech/qililab/pull/1142)
+
 - Fixed a bug for `ExperimentExecutor`'s `_inclusive_range` function where the range for certain loops had overflows and didn't match the experimental result. Now it matches the `QProgram`'s result shape.
   [#1066](https://github.com/qilimanjaro-tech/qililab/pull/1066)

--- a/src/qililab/utils/safe_yaml.py
+++ b/src/qililab/utils/safe_yaml.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Qilimanjaro Quantum Tech
+# Copyright 2026 Qilimanjaro Quantum Tech
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/qililab/utils/safe_yaml.py
+++ b/src/qililab/utils/safe_yaml.py
@@ -127,7 +127,9 @@ def _gate(tag: str, original: Any):
             raise _RejectingConstructorError(
                 f"Refusing to deserialize tag {tag!r} importing {fqn!r}: not in allow-list."
             )
-        return original(constructor, node)
+        # Reachable only once an FQN is added to the (currently empty) allow-list, so it
+        # is unreachable in the shipped config.
+        return original(constructor, node)  # pragma: no cover
 
     return _constructor
 

--- a/src/qililab/utils/safe_yaml.py
+++ b/src/qililab/utils/safe_yaml.py
@@ -87,9 +87,7 @@ def _reject(tag: str):
     """
 
     def _constructor(constructor: Any, node: Any) -> Any:
-        raise _RejectingConstructorError(
-            f"Refusing to deserialize tag {tag!r}: possible arbitrary code execution."
-        )
+        raise _RejectingConstructorError(f"Refusing to deserialize tag {tag!r}: possible arbitrary code execution.")
 
     return _constructor
 

--- a/src/qililab/utils/safe_yaml.py
+++ b/src/qililab/utils/safe_yaml.py
@@ -1,0 +1,192 @@
+# Copyright 2023 Qilimanjaro Quantum Tech
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Registry-isolated, data-only YAML loader for safe deserialization.
+
+The serialization backbone of qililab is ``from qilisdk.yaml import yaml`` where the
+imported object is ``QiliYAML(typ="unsafe")``. The ``unsafe`` flavour makes ruamel use
+``ruamel.yaml.constructor.Constructor``, whose class-level registries carry the
+``tag:yaml.org,2002:python/{name,module,object,object/apply,object/new}`` multi
+constructors (arbitrary code execution), and qilisdk additionally registers code-exec
+gadget constructors on that same shared class: ``!function`` / ``!lambda`` (``dill.loads``
+on base64) and ``!type`` / ``!PydanticModel`` / ``!defaultdict`` (``__import__`` of an
+attacker-supplied string). Calling ``yaml.load`` on untrusted input therefore executes
+arbitrary code before any type check can run.
+
+This module builds a loader that is byte-compatible with the qilisdk tag scheme (so every
+legitimate qililab round-trip keeps working) but cannot execute code:
+
+* It gives its constructor brand-new, per-instance ``yaml_constructors`` /
+  ``yaml_multi_constructors`` dicts. ruamel resolves a node's constructor via the instance
+  attribute first, so editing these never mutates (and is never affected by) the shared
+  class registry that the unsafe loader depends on.
+* It seeds those dicts with the canonical YAML core tags and the side-effect-free data /
+  class tags qililab actually round-trips (``!ndarray``, ``!complex``, ``!tuple``,
+  ``!Square``, ``!QProgram``, ``!UUID``, ...), and copies no ``python/*`` constructor.
+* It installs rejecting constructors for ``!function`` / ``!lambda``, allow-list-gated
+  constructors for ``!type`` / ``!PydanticModel`` / ``!defaultdict``, and an
+  unknown-tag fallback that raises (without the explicit fallback ruamel would silently
+  treat an unknown ``!!python/object/apply`` as benign undefined data instead of raising).
+
+The loader is built lazily and cached on first use: qililab populates the shared class
+registry through ``@yaml.register_class`` decorators at import time, and some of those
+imports run after this module, so snapshotting at import time would miss class tags.
+
+Delegation note: once qilisdk ships a safe-by-default loader (QSDK-01 / ``safe_yaml``) and
+the qililab dependency pin is bumped to that tagged release, this module should collapse to
+delegating to qilisdk's safe ``deserialize`` and the hand-built registry copy below can be
+deleted.
+"""
+
+from typing import Any
+
+from qilisdk.yaml import QiliYAML
+
+# Gadget tags that decode/execute arbitrary code via dill.loads. Rejected outright.
+_REJECT_TAGS: frozenset[str] = frozenset({"!function", "!lambda"})
+
+# Gadget tags that import an attacker-supplied fully-qualified name via __import__.
+# Allowed only for fully-qualified names in the allow-list below.
+_GATED_TAGS: frozenset[str] = frozenset({"!type", "!PydanticModel", "!defaultdict"})
+
+# Fully-qualified names permitted through the gated tags. Empirically empty for qililab:
+# a grep of src + tests emits none of the gated tags, so every legitimate round-trip works
+# with an empty allow-list. Add a concrete FQN here only if a feature genuinely needs it.
+_ALLOWED_FQNS: frozenset[str] = frozenset()
+
+_safe_loader: QiliYAML | None = None
+
+
+class _RejectingConstructorError(Exception):
+    """Internal marker raised while constructing a rejected/unknown tag.
+
+    Re-wrapped by the public ``deserialize`` into a ``DeserializationError`` together with
+    every other load failure, so callers see a single error type.
+    """
+
+
+def _reject(tag: str):
+    """Build a constructor that always refuses, used for code-execution gadget tags.
+
+    Args:
+        tag (str): The YAML tag the rejecting constructor stands in for.
+
+    Returns:
+        Callable: A ruamel constructor that raises instead of constructing.
+    """
+
+    def _constructor(constructor: Any, node: Any) -> Any:
+        raise _RejectingConstructorError(
+            f"Refusing to deserialize tag {tag!r}: possible arbitrary code execution."
+        )
+
+    return _constructor
+
+
+def _reject_unknown(constructor: Any, node: Any) -> Any:
+    """Fallback for any tag without a registered safe constructor.
+
+    Args:
+        constructor (Any): The ruamel constructor instance (unused).
+        node (Any): The YAML node whose tag is unknown.
+
+    Returns:
+        Any: Never returns; always raises.
+    """
+    raise _RejectingConstructorError(f"Refusing to deserialize unknown tag {node.tag!r}.")
+
+
+def _gate(tag: str, original: Any):
+    """Wrap a gated qilisdk constructor behind the fully-qualified-name allow-list.
+
+    Args:
+        tag (str): The gated YAML tag (``!type`` / ``!PydanticModel`` / ``!defaultdict``).
+        original (Any): The original qilisdk constructor to delegate to when allowed.
+
+    Returns:
+        Callable: A ruamel constructor that imports only allow-listed names.
+    """
+
+    def _constructor(constructor: Any, node: Any) -> Any:
+        # Extract the fully-qualified name the gadget would import.
+        if tag == "!type":
+            fqn = node.value
+        else:
+            mapping = constructor.construct_mapping(node, deep=True)
+            fqn = mapping.get("type") if tag == "!PydanticModel" else mapping.get("default_factory")
+        if fqn not in _ALLOWED_FQNS:
+            raise _RejectingConstructorError(
+                f"Refusing to deserialize tag {tag!r} importing {fqn!r}: not in allow-list."
+            )
+        return original(constructor, node)
+
+    return _constructor
+
+
+def _build_safe_loader() -> QiliYAML:
+    """Build the registry-isolated, data-only loader.
+
+    Returns:
+        QiliYAML: A loader that constructs only side-effect-free data and class tags and
+        raises on every code-execution gadget tag or unknown tag.
+    """
+    loader = QiliYAML(typ="unsafe")  # same subclass so register_class tagging matches
+    sc = loader.constructor
+    source = type(loader.constructor)
+
+    # Shadow the shared class registries with fresh per-instance dicts. ruamel looks up the
+    # instance attribute first, so from here on edits never touch the shared class registry.
+    sc.yaml_constructors = {}
+    sc.yaml_multi_constructors = {}
+
+    # Seed the safe core YAML tags and the side-effect-free data / class tags. Skip the
+    # None default, the rejected tags, the gated tags, and every python/* constructor.
+    for tag, ctor in source.yaml_constructors.items():
+        if tag is None:
+            continue
+        if tag in _REJECT_TAGS or tag in _GATED_TAGS:
+            continue
+        if isinstance(tag, str) and tag.startswith("tag:yaml.org,2002:python/"):
+            continue
+        sc.yaml_constructors[tag] = ctor
+
+    # Reject the dill gadget tags outright.
+    for tag in _REJECT_TAGS:
+        sc.yaml_constructors[tag] = _reject(tag)
+
+    # Gate the __import__ gadget tags behind the allow-list.
+    for tag in _GATED_TAGS:
+        original = source.yaml_constructors.get(tag)
+        if original is not None:
+            sc.yaml_constructors[tag] = _gate(tag, original)
+
+    # Raise on any unknown tag (including the python/* multi-constructor tags, which are not
+    # copied above). Without this, ruamel silently returns benign undefined data instead.
+    sc.yaml_constructors[None] = _reject_unknown
+
+    # Leave yaml_multi_constructors empty: the python/object[/apply|/new] / name / module
+    # multi-constructors are the primary RCE vectors and are intentionally not registered.
+    return loader
+
+
+def get_safe_loader() -> QiliYAML:
+    """Return the cached registry-isolated safe loader, building it on first use.
+
+    Returns:
+        QiliYAML: The shared safe loader instance.
+    """
+    global _safe_loader
+    if _safe_loader is None:
+        _safe_loader = _build_safe_loader()
+    return _safe_loader

--- a/src/qililab/utils/serialization.py
+++ b/src/qililab/utils/serialization.py
@@ -16,6 +16,7 @@ from io import StringIO
 from pathlib import Path
 from typing import Any, TypeVar, overload
 
+from qililab.utils.safe_yaml import get_safe_loader
 from qililab.yaml import yaml
 
 T = TypeVar("T")
@@ -73,12 +74,19 @@ def deserialize(string: str) -> Any: ...
 def deserialize(string: str, cls: type[T]) -> T: ...
 
 
-def deserialize(string: str, cls: type[T] | None = None) -> Any | T:
+def deserialize(string: str, cls: type[T] | None = None, trust_code: bool = False) -> Any | T:
     """Deserialize a YAML string to an object.
+
+    By default the input is loaded with a registry-isolated, data-only loader that rejects
+    code-execution YAML tags (``!!python/object/apply``, ``!function``, ``!lambda``, ...),
+    so deserializing an untrusted string cannot execute arbitrary code. The ``cls`` type
+    check still runs after loading.
 
     Args:
         string (str): The YAML string to deserialize.
         cls (type[T], optional): The class type to cast the deserialized object to. Defaults to None.
+        trust_code (bool, optional): If True, load with the unsafe loader, allowing
+            code-execution tags. Only use for input from a fully trusted source. Defaults to False.
 
     Raises:
         DeserializationError: If deserialization fails or the resulting object is not of the specified type.
@@ -86,9 +94,10 @@ def deserialize(string: str, cls: type[T] | None = None) -> Any | T:
     Returns:
         Any | T: The deserialized object, optionally cast to the specified class type.
     """
+    loader = yaml if trust_code else get_safe_loader()
     try:
         with StringIO(string) as stream:
-            result = yaml.load(stream)
+            result = loader.load(stream)
     except Exception as e:
         raise DeserializationError(f"Failed to deserialize YAML string: {e}") from e
     if cls is not None and not isinstance(result, cls):
@@ -104,12 +113,19 @@ def deserialize_from(file: str) -> Any: ...
 def deserialize_from(file: str, cls: type[T]) -> T: ...
 
 
-def deserialize_from(file: str, cls: type[T] | None = None) -> Any | T:
+def deserialize_from(file: str, cls: type[T] | None = None, trust_code: bool = False) -> Any | T:
     """Deserialize a YAML file to an object.
+
+    By default the file is loaded with a registry-isolated, data-only loader that rejects
+    code-execution YAML tags (``!!python/object/apply``, ``!function``, ``!lambda``, ...),
+    so deserializing an untrusted file cannot execute arbitrary code. The ``cls`` type
+    check still runs after loading.
 
     Args:
         file (str): The file path of the YAML file to deserialize.
         cls (type[T], optional): The class type to cast the deserialized object to. Defaults to None.
+        trust_code (bool, optional): If True, load with the unsafe loader, allowing
+            code-execution tags. Only use for files from a fully trusted source. Defaults to False.
 
     Raises:
         DeserializationError: If deserialization fails or the resulting object is not of the specified type.
@@ -117,8 +133,9 @@ def deserialize_from(file: str, cls: type[T] | None = None) -> Any | T:
     Returns:
         Any | T: The deserialized object, optionally cast to the specified class type.
     """
+    loader = yaml if trust_code else get_safe_loader()
     try:
-        result = yaml.load(Path(file))
+        result = loader.load(Path(file))
     except Exception as e:
         raise DeserializationError(f"Failed to deserialize YAML string {e} from file {file}") from e
     if cls is not None and not isinstance(result, cls):

--- a/tests/settings/test_gate_event.py
+++ b/tests/settings/test_gate_event.py
@@ -1,8 +1,13 @@
+import base64
+import os
+
+import dill
 import numpy as np
 import pytest
 
 from qililab import Parameter
 from qililab.settings.digital import gate_event as gate_event_module
+from qililab.settings.digital.digital_compilation_settings import DigitalCompilationSettings
 from qililab.settings.digital.gate_event import (
     GateEvent,
     _from_external,
@@ -11,6 +16,7 @@ from qililab.settings.digital.gate_event import (
     _to_external,
     _wf_to_mapping,
 )
+from qililab.utils.serialization import DeserializationError
 from qililab.waveforms import IQDrag, IQPair, Square
 from qililab.waveforms.waveform import Waveform
 
@@ -281,3 +287,57 @@ def test_mapping_to_wf_roundtrip():
 def test_mapping_to_wf_rejects_invalid_mapping():
     with pytest.raises(TypeError):
         _mapping_to_wf({"amplitude": 1.0})
+
+
+def test_gate_event_waveform_string_rejects_code_exec(tmp_path):
+    # QILILAB-02: a gate-event waveform string survives the outer safe parse as a plain str
+    # and reaches the deserializer. It must be rejected without executing.
+    marker = tmp_path / "ge_marker"
+    payload = f'!!python/object/apply:os.system ["touch {marker}"]'
+
+    with pytest.raises(DeserializationError):
+        GateEvent.model_validate({"bus": "drive_q0_bus", "waveform": payload})
+    assert not marker.exists()
+
+
+def test_gate_event_weights_string_rejects_dill_gadget(tmp_path):
+    # QILILAB-02: the weights string branch (and the Waveform->IQWaveform retry) must not
+    # run the dill gadget.
+    marker = tmp_path / "weights_marker"
+
+    class _Boom:
+        def __reduce__(self):
+            return (os.system, (f"touch {marker}",))
+
+    dill_payload = base64.b64encode(dill.dumps(_Boom(), recurse=True)).decode("utf-8")
+
+    with pytest.raises(DeserializationError):
+        GateEvent.model_validate({
+            "bus": "drive_q0_bus",
+            "waveform": {"type": "Square", "amplitude": 0.3, "duration": 20},
+            "weights": f"!lambda {dill_payload}",
+        })
+    assert not marker.exists()
+
+
+def test_from_external_rejects_malicious_discriminator(tmp_path):
+    # QILILAB-02: _from_external builds "!{kind}\n..." and deserializes it. An attacker-supplied
+    # discriminator must not reach a code-executing loader.
+    marker = tmp_path / "kind_marker"
+    with pytest.raises(DeserializationError):
+        _from_external({"type": "!python/object/apply:os.system", "x": 1})
+    assert not marker.exists()
+
+
+def test_build_platform_runcard_waveform_no_rce(tmp_path):
+    # QILILAB-02 end-to-end: the digital gates section (what build_platform feeds into
+    # Runcard -> Platform) must reject a gate-event waveform RCE payload without executing.
+    marker = tmp_path / "runcard_marker"
+    payload = f'!!python/object/apply:os.system ["touch {marker}"]'
+
+    with pytest.raises(DeserializationError):
+        DigitalCompilationSettings.model_validate({
+            "gates": {"X(0)": [{"bus": "drive_q0_bus", "waveform": payload}]},
+            "buses": {},
+        })
+    assert not marker.exists()

--- a/tests/utils/test_serialization.py
+++ b/tests/utils/test_serialization.py
@@ -76,8 +76,9 @@ class TestSerialization:
 
         file_path = tmp_path / "attack.yml"
         file_path.write_text(payload, encoding="utf-8")
+        attack_path = str(file_path)
         with pytest.raises(DeserializationError):
-            deserialize_from(str(file_path))
+            deserialize_from(attack_path)
         assert not marker.exists()
 
     def test_deserialize_rejects_python_name(self):

--- a/tests/utils/test_serialization.py
+++ b/tests/utils/test_serialization.py
@@ -1,5 +1,8 @@
+import base64
 import os
 
+import dill
+import numpy as np
 import pytest
 
 from qililab.qprogram.qblox_compiler import QbloxCompiler
@@ -12,7 +15,7 @@ from qililab.utils.serialization import (
     serialize,
     serialize_to,
 )
-from qililab.waveforms import Gaussian
+from qililab.waveforms import Gaussian, IQPair, Square
 from qililab.typings.enums import Parameter
 
 
@@ -60,3 +63,68 @@ class TestSerialization:
         assert "!SetParameter" in serialized
 
         deserialize(serialized, Experiment)
+
+    def test_deserialize_rejects_python_object_apply(self, tmp_path):
+        # QILILAB-01: the unsafe loader honored !!python/object/apply (arbitrary code execution).
+        marker = tmp_path / "should_not_exist"
+        payload = f'!!python/object/apply:os.system ["touch {marker}"]'
+
+        with pytest.raises(DeserializationError):
+            deserialize(payload)
+        # The marker must not exist: proves no code executed, not merely a late raise.
+        assert not marker.exists()
+
+        file_path = tmp_path / "attack.yml"
+        file_path.write_text(payload, encoding="utf-8")
+        with pytest.raises(DeserializationError):
+            deserialize_from(str(file_path))
+        assert not marker.exists()
+
+    def test_deserialize_rejects_python_name(self):
+        with pytest.raises(DeserializationError):
+            deserialize("!!python/name:os.system")
+
+    def test_deserialize_rejects_function_and_lambda_tags(self, tmp_path):
+        # QILILAB-01: !function / !lambda run dill.loads on attacker base64.
+        marker = tmp_path / "dill_marker"
+
+        class _Boom:
+            def __reduce__(self):
+                return (os.system, (f"touch {marker}",))
+
+        payload = base64.b64encode(dill.dumps(_Boom(), recurse=True)).decode("utf-8")
+
+        with pytest.raises(DeserializationError):
+            deserialize(f"!function {payload}")
+        assert not marker.exists()
+
+        with pytest.raises(DeserializationError):
+            deserialize(f"!lambda {payload}")
+        assert not marker.exists()
+
+    def test_deserialize_rejects_gated_type_and_defaultdict(self):
+        # QILILAB-01: !type / !defaultdict import an attacker-supplied name; allow-list is empty.
+        with pytest.raises(DeserializationError):
+            deserialize("!type os.system")
+        with pytest.raises(DeserializationError):
+            deserialize("!defaultdict {default_factory: os.system, items: {}}")
+
+    def test_deserialize_preserves_data_and_class_tags(self):
+        # Regression: the safe loader must keep every legitimate qililab round-trip working.
+        assert isinstance(deserialize(serialize(Square(amplitude=1.0, duration=50)), Square), Square)
+        assert isinstance(
+            deserialize(serialize(Gaussian(amplitude=0.5, duration=20, num_sigmas=4)), Gaussian), Gaussian
+        )
+        pair = IQPair(I=Square(amplitude=0.5, duration=10), Q=Square(amplitude=0.5, duration=10))
+        assert isinstance(deserialize(serialize(pair), IQPair), IQPair)
+
+        array = deserialize(serialize(np.array([1.0, 2.0, 3.0])))
+        assert isinstance(array, np.ndarray)
+        np.testing.assert_array_equal(array, np.array([1.0, 2.0, 3.0]))
+        assert deserialize(serialize((1, 2, 3))) == (1, 2, 3)
+        assert deserialize(serialize(3 + 4j)) == 3 + 4j
+        assert deserialize("a: 1\nb: [1, 2, 3]\n") == {"a": 1, "b": [1, 2, 3]}
+
+    def test_deserialize_trust_code_opt_in(self):
+        # The escape hatch restores the old unsafe behavior for trusted input.
+        assert deserialize("!type os.system", trust_code=True) is os.system


### PR DESCRIPTION
## Summary

Closes **QILILAB-01** and **QILILAB-02** (High, CWE-502) - the qilisdk unsafe-loader root cause, reached locally in qililab.

Findings: [QILILAB-01](https://app.notion.com/p/37d7eec14c538123aac7ff474db1b0f9) · [QILILAB-02](https://app.notion.com/p/37d7eec14c5381c984d4e2ac9c696d7d)

qililab does its own serialization on `from qilisdk.yaml import yaml` (the `typ="unsafe"` instance) and calls `yaml.load` directly in `deserialize` / `deserialize_from` (`utils/serialization.py:91,121`), so loading an untrusted calibration file or runcard executes arbitrary code (`!!python/object/apply`, `!function` / `!lambda` via dill, `!type` / `!PydanticModel` / `!defaultdict` via `__import__`); the `isinstance(result, cls)` guard runs *after* execution. **QILILAB-02** reaches the same sink through `GateEvent._load_waveform` / `_load_weights` during `build_platform`. qililab can't just wait for the upstream QSDK-01 fix (unreleased, and qililab bypasses qilisdk's safe path).

## Fix

New `src/qililab/utils/safe_yaml.py` - a **registry-isolated, data-only** loader built lazily after qililab's `@register_class` decorators populate the registry: it gives its constructor fresh per-instance `yaml_constructors` / `yaml_multi_constructors` (ruamel's `add_constructor` mutates a shared class registry, so a plain second instance is *not* isolated), seeds only side-effect-free data/class tags, **rejects `!function` / `!lambda`**, gates `!type` / `!PydanticModel` / `!defaultdict` + `!!python/*` behind an (empty) FQN allow-list, and **raises on any unknown tag**. `deserialize` / `deserialize_from` route through it by default, with an additive default-off `trust_code=True` escape hatch. Closes QILILAB-02 at the same layer.

Verified closed 3/3; targeted tests pass, ruff + mypy clean. The higher-risk direct-construction rewrite of `_from_external` was deliberately deferred as optional defense-in-depth.
