### PR TITLE
fix(security): QILILAB-03 bind live-plot Dash server to loopback by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 
 ### Bug fixes
 
+- Hardened the live-plot Dash server: it now binds to loopback (`127.0.0.1`) by default instead of all interfaces. Routable exposure (for cross-node SLURM viewing) is opt-in via `QILILAB_EXPERIMENT_LIVE_PLOT_HOST` and must be fronted by an authenticated reverse proxy, since the server has no authentication of its own. The absolute result-file path was also removed from the live-plot page title.
+  [#1141](https://github.com/qilimanjaro-tech/qililab/pull/1141)
+
 - Fixed a bug for Rohde Schwarz `initial_setup` where the `iq_modulation` set as `True` inside the runcard for RS models `SGS-B106V` was not correctly set in the device.
   [#1137](https://github.com/qilimanjaro-tech/qililab/pull/1137)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,6 @@
 
 ### Bug fixes
 
-- Hardened the live-plot Dash server: it now binds to loopback (`127.0.0.1`) by default instead of all interfaces. Routable exposure (for cross-node SLURM viewing) is opt-in via `QILILAB_EXPERIMENT_LIVE_PLOT_HOST` and must be fronted by an authenticated reverse proxy, since the server has no authentication of its own. The absolute result-file path was also removed from the live-plot page title.
-  [#1141](https://github.com/qilimanjaro-tech/qililab/pull/1141)
-
 - Fixed a bug for Rohde Schwarz `initial_setup` where the `iq_modulation` set as `True` inside the runcard for RS models `SGS-B106V` was not correctly set in the device.
   [#1137](https://github.com/qilimanjaro-tech/qililab/pull/1137)
 

--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -111,6 +111,9 @@ In the runcard this parameter is located inside the instruments sequencer for QR
 
 - Fixed `QbloxQRM.acquire_qprogram_results` uploading an empty sequence after each individual acquisition deletion, which wiped the hardware acquisition table mid-loop and caused subsequent deletions to fail. The empty-sequence upload now happens once after all acquisitions have been deleted. This was triggered by any QProgram that produced more than one named acquisition on the same sequencer (e.g. two separate `average` blocks each containing one `acquire` on the same bus).
   [#1117](https://github.com/qilimanjaro-tech/qililab/pull/1117)
- 
+
+- Hardened the live-plot Dash server: it now binds to loopback (`127.0.0.1`) by default instead of all interfaces. Routable exposure (for cross-node SLURM viewing) is opt-in via `QILILAB_EXPERIMENT_LIVE_PLOT_HOST` and must be fronted by an authenticated reverse proxy, since the server has no authentication of its own. The absolute result-file path was also removed from the live-plot page title.
+  [#1143](https://github.com/qilimanjaro-tech/qililab/pull/1143)
+
 - Fixed a bug for `ExperimentExecutor`'s `_inclusive_range` function where the range for certain loops had overflows and didn't match the experimental result. Now it matches the `QProgram`'s result shape.
   [#1066](https://github.com/qilimanjaro-tech/qililab/pull/1066)

--- a/src/qililab/qililab_settings.py
+++ b/src/qililab/qililab_settings.py
@@ -52,6 +52,10 @@ class QililabSettings(BaseSettings):
         default=None,
         description="The port number of the Dash server for when experiment_live_plot_on_slurm is True. Defaults to None. [env: QILILAB_EXPERIMENT_LIVE_PLOT_PORT]",
     )
+    experiment_live_plot_host: str = Field(
+        default="127.0.0.1",
+        description="Bind address for the live-plot Dash server when experiment_live_plot_on_slurm is True. Defaults to loopback ('127.0.0.1'). Set to '0.0.0.0' (or a specific routable interface) ONLY when remote/cross-node viewing is required, and ONLY behind an authenticated reverse proxy; the server itself has no authentication. [env: QILILAB_EXPERIMENT_LIVE_PLOT_HOST]",
+    )
 
 
 @lru_cache(maxsize=1)

--- a/src/qililab/result/experiment_live_plot.py
+++ b/src/qililab/result/experiment_live_plot.py
@@ -35,17 +35,23 @@ class ExperimentLivePlot:
 
     LIVE_PLOT_NAME = "live_plot.png"
 
-    def __init__(self, path: str, slurm_execution: bool = True, port_number: int | None = None):
+    def __init__(
+        self, path: str, slurm_execution: bool = True, port_number: int | None = None, host: str = "127.0.0.1"
+    ):
         """Initializes the ExperimentResults instance.
 
         Args:
             path (str): The file path to the HDF5 results file.
             slurm_execution (bool): Flag that defines if the liveplot will be held through Dash or a notebook cell. Defaults to True.
             port_number (int|None): Optional parameter for when slurm_execution is True. It defines the port number of the Dash server. Defaults to None.
+            host (str): Bind address for the Dash server when slurm_execution is True. Defaults to loopback ('127.0.0.1'). A routable
+                address (e.g. '0.0.0.0') must be set explicitly and fronted by an authenticated reverse proxy, since the server has no
+                authentication of its own.
         """
         self.path = path
         self._slurm_execution = slurm_execution
         self._port_number = port_number
+        self._host = host
 
         self.live_plot_dict: dict[tuple[str, str], int] = {}
 
@@ -70,7 +76,9 @@ class ExperimentLivePlot:
         self._live_plot_fig.set_subplots(
             rows=len(dims_dict), cols=1, subplot_titles=[str(key) for key in dims_dict.keys()]
         )
-        self._live_plot_fig.update_layout(height=500 * len(dims_dict), width=700, title_text=self.path)
+        self._live_plot_fig.update_layout(
+            height=500 * len(dims_dict), width=700, title_text=os.path.basename(self.path)
+        )
 
         for n, coordinates in enumerate(dims_dict.keys()):
             self.live_plot_dict[coordinates] = n
@@ -127,8 +135,10 @@ class ExperimentLivePlot:
 
             if not self._port_number:
                 self._port_number = 8050
-            # TODO: assign with access a host that is not 0.0.0.0 as 127.0.0.1 does not work
-            self._dash_app.run(debug=False, host="0.0.0.0", port=self._port_number)  # noqa: S104
+            # Binds to loopback by default; a routable host must be set explicitly via the configurable
+            # `host` (see QililabSettings.experiment_live_plot_host) and fronted by an authenticated proxy.
+            # Do NOT hardcode a wide bind (e.g. "0.0.0.0") here, or ruff S104 will correctly flag it.
+            self._dash_app.run(debug=False, host=self._host, port=self._port_number)
 
         else:
             warnings.filterwarnings("ignore")

--- a/src/qililab/result/experiment_results_writer.py
+++ b/src/qililab/result/experiment_results_writer.py
@@ -132,6 +132,7 @@ class ExperimentResultsWriter(ExperimentResults):
         self._live_plot_true = get_settings().experiment_live_plot_enabled
         self._slurm_execution = get_settings().experiment_live_plot_on_slurm
         self._port_number = get_settings().experiment_live_plot_port
+        self._host = get_settings().experiment_live_plot_host
 
     # pylint: disable=too-many-locals
     def _create_results_file(self):
@@ -211,7 +212,9 @@ class ExperimentResultsWriter(ExperimentResults):
 
             # Generate live plot figures
             if self._live_plot_true:
-                self.results_liveplot = ExperimentLivePlot(self.path, self._slurm_execution, self._port_number)
+                self.results_liveplot = ExperimentLivePlot(
+                    self.path, self._slurm_execution, self._port_number, self._host
+                )
                 self.results_liveplot.live_plot_figures(dims_dict)
 
     def _create_resuts_access(self):

--- a/tests/result/test_experiment_live_plot.py
+++ b/tests/result/test_experiment_live_plot.py
@@ -335,6 +335,21 @@ class TestSlurmDashSetup:
             fig_mock.add_scatter.assert_called()
             mock_dash.return_value.run.assert_called_once_with(debug=False, host="127.0.0.1", port=8050)
 
+    def _capture_run(self, mock_dash, mock_callback, **lp_kwargs):
+        """Run live_plot_figures under mocked Dash; return (run_kwargs, fig_mock). Shared by the bind/title tests."""
+        fig_mock = MagicMock()
+        mock_callback.side_effect = lambda *a, **k: lambda fn: fn
+        with patch("qililab.result.experiment_live_plot.go.Figure", return_value=fig_mock):
+            live_plot = ExperimentLivePlot(port_number=None, **lp_kwargs)
+            dims_dict = {("QProgram_0", "Measurement_0"): MagicMock()}
+            dims_mock = dims_dict[("QProgram_0", "Measurement_0")]
+            dims_mock.__len__.return_value = 2
+            dims_mock[0].label = "x"
+            dims_mock[0].values.return_value = [np.linspace(0, 1, 10)]
+            live_plot.live_plot_figures(dims_dict)
+        _, run_kwargs = mock_dash.return_value.run.call_args
+        return run_kwargs, fig_mock
+
     @patch("qililab.result.experiment_live_plot.Dash")
     @patch("qililab.result.experiment_live_plot.html.Div")
     @patch("qililab.result.experiment_live_plot.dcc.Graph")
@@ -349,23 +364,9 @@ class TestSlurmDashSetup:
         mock_dash,
     ):
         """The Dash server must bind to loopback by default, never 0.0.0.0 (QILILAB-03)."""
-        fig_mock = MagicMock()
-        mock_callback.side_effect = lambda *a, **k: (lambda fn: fn)
-
-        with patch("qililab.result.experiment_live_plot.go.Figure", return_value=fig_mock):
-            live_plot = ExperimentLivePlot(path="/tmp/run/abc.h5", slurm_execution=True, port_number=None)
-
-            dims_dict = {("QProgram_0", "Measurement_0"): MagicMock()}
-            dims_mock = dims_dict[("QProgram_0", "Measurement_0")]
-            dims_mock.__len__.return_value = 2
-            dims_mock[0].label = "x"
-            dims_mock[0].values.return_value = [np.linspace(0, 1, 10)]
-
-            live_plot.live_plot_figures(dims_dict)
-
-            _, run_kwargs = mock_dash.return_value.run.call_args
-            assert run_kwargs["host"] == "127.0.0.1"
-            assert run_kwargs["host"] != "0.0.0.0"
+        run_kwargs, _ = self._capture_run(mock_dash, mock_callback, path="/data/run/abc.h5", slurm_execution=True)
+        assert run_kwargs["host"] == "127.0.0.1"
+        assert run_kwargs["host"] != "0.0.0.0"
 
     @patch("qililab.result.experiment_live_plot.Dash")
     @patch("qililab.result.experiment_live_plot.html.Div")
@@ -381,24 +382,10 @@ class TestSlurmDashSetup:
         mock_dash,
     ):
         """A routable host can still be opted into explicitly (cross-node SLURM viewing)."""
-        fig_mock = MagicMock()
-        mock_callback.side_effect = lambda *a, **k: (lambda fn: fn)
-
-        with patch("qililab.result.experiment_live_plot.go.Figure", return_value=fig_mock):
-            live_plot = ExperimentLivePlot(
-                path="/tmp/run/abc.h5", slurm_execution=True, port_number=None, host="0.0.0.0"
-            )
-
-            dims_dict = {("QProgram_0", "Measurement_0"): MagicMock()}
-            dims_mock = dims_dict[("QProgram_0", "Measurement_0")]
-            dims_mock.__len__.return_value = 2
-            dims_mock[0].label = "x"
-            dims_mock[0].values.return_value = [np.linspace(0, 1, 10)]
-
-            live_plot.live_plot_figures(dims_dict)
-
-            _, run_kwargs = mock_dash.return_value.run.call_args
-            assert run_kwargs["host"] == "0.0.0.0"
+        run_kwargs, _ = self._capture_run(
+            mock_dash, mock_callback, path="/data/run/abc.h5", slurm_execution=True, host="0.0.0.0"
+        )
+        assert run_kwargs["host"] == "0.0.0.0"
 
     @patch("qililab.result.experiment_live_plot.Dash")
     @patch("qililab.result.experiment_live_plot.html.Div")
@@ -414,23 +401,10 @@ class TestSlurmDashSetup:
         mock_dash,
     ):
         """The page title must not leak the absolute result-file path (QILILAB-03)."""
-        fig_mock = MagicMock()
-        mock_callback.side_effect = lambda *a, **k: (lambda fn: fn)
-
-        with patch("qililab.result.experiment_live_plot.go.Figure", return_value=fig_mock):
-            live_plot = ExperimentLivePlot(path="/tmp/run/abc.h5", slurm_execution=True, port_number=None)
-
-            dims_dict = {("QProgram_0", "Measurement_0"): MagicMock()}
-            dims_mock = dims_dict[("QProgram_0", "Measurement_0")]
-            dims_mock.__len__.return_value = 2
-            dims_mock[0].label = "x"
-            dims_mock[0].values.return_value = [np.linspace(0, 1, 10)]
-
-            live_plot.live_plot_figures(dims_dict)
-
-            _, layout_kwargs = fig_mock.update_layout.call_args
-            assert layout_kwargs["title_text"] == "abc.h5"
-            assert "/tmp/run" not in layout_kwargs["title_text"]
+        _, fig_mock = self._capture_run(mock_dash, mock_callback, path="/data/run/abc.h5", slurm_execution=True)
+        _, layout_kwargs = fig_mock.update_layout.call_args
+        assert layout_kwargs["title_text"] == "abc.h5"
+        assert "/data/run" not in layout_kwargs["title_text"]
 
 
 class TestLivePlotSettings:

--- a/tests/result/test_experiment_live_plot.py
+++ b/tests/result/test_experiment_live_plot.py
@@ -333,4 +333,118 @@ class TestSlurmDashSetup:
             fig_mock.update_layout.assert_called()
             fig_mock.update_xaxes.assert_called()
             fig_mock.add_scatter.assert_called()
-            mock_dash.return_value.run.assert_called_once_with(debug=False, host="0.0.0.0", port=8050)
+            mock_dash.return_value.run.assert_called_once_with(debug=False, host="127.0.0.1", port=8050)
+
+    @patch("qililab.result.experiment_live_plot.Dash")
+    @patch("qililab.result.experiment_live_plot.html.Div")
+    @patch("qililab.result.experiment_live_plot.dcc.Graph")
+    @patch("qililab.result.experiment_live_plot.dcc.Interval")
+    @patch("qililab.result.experiment_live_plot.callback")
+    def test_slurm_dash_default_bind_is_loopback(
+        self,
+        mock_callback,
+        mock_interval,
+        mock_graph,
+        mock_div,
+        mock_dash,
+    ):
+        """The Dash server must bind to loopback by default, never 0.0.0.0 (QILILAB-03)."""
+        fig_mock = MagicMock()
+        mock_callback.side_effect = lambda *a, **k: (lambda fn: fn)
+
+        with patch("qililab.result.experiment_live_plot.go.Figure", return_value=fig_mock):
+            live_plot = ExperimentLivePlot(path="/tmp/run/abc.h5", slurm_execution=True, port_number=None)
+
+            dims_dict = {("QProgram_0", "Measurement_0"): MagicMock()}
+            dims_mock = dims_dict[("QProgram_0", "Measurement_0")]
+            dims_mock.__len__.return_value = 2
+            dims_mock[0].label = "x"
+            dims_mock[0].values.return_value = [np.linspace(0, 1, 10)]
+
+            live_plot.live_plot_figures(dims_dict)
+
+            _, run_kwargs = mock_dash.return_value.run.call_args
+            assert run_kwargs["host"] == "127.0.0.1"
+            assert run_kwargs["host"] != "0.0.0.0"
+
+    @patch("qililab.result.experiment_live_plot.Dash")
+    @patch("qililab.result.experiment_live_plot.html.Div")
+    @patch("qililab.result.experiment_live_plot.dcc.Graph")
+    @patch("qililab.result.experiment_live_plot.dcc.Interval")
+    @patch("qililab.result.experiment_live_plot.callback")
+    def test_slurm_dash_host_is_configurable(
+        self,
+        mock_callback,
+        mock_interval,
+        mock_graph,
+        mock_div,
+        mock_dash,
+    ):
+        """A routable host can still be opted into explicitly (cross-node SLURM viewing)."""
+        fig_mock = MagicMock()
+        mock_callback.side_effect = lambda *a, **k: (lambda fn: fn)
+
+        with patch("qililab.result.experiment_live_plot.go.Figure", return_value=fig_mock):
+            live_plot = ExperimentLivePlot(
+                path="/tmp/run/abc.h5", slurm_execution=True, port_number=None, host="0.0.0.0"
+            )
+
+            dims_dict = {("QProgram_0", "Measurement_0"): MagicMock()}
+            dims_mock = dims_dict[("QProgram_0", "Measurement_0")]
+            dims_mock.__len__.return_value = 2
+            dims_mock[0].label = "x"
+            dims_mock[0].values.return_value = [np.linspace(0, 1, 10)]
+
+            live_plot.live_plot_figures(dims_dict)
+
+            _, run_kwargs = mock_dash.return_value.run.call_args
+            assert run_kwargs["host"] == "0.0.0.0"
+
+    @patch("qililab.result.experiment_live_plot.Dash")
+    @patch("qililab.result.experiment_live_plot.html.Div")
+    @patch("qililab.result.experiment_live_plot.dcc.Graph")
+    @patch("qililab.result.experiment_live_plot.dcc.Interval")
+    @patch("qililab.result.experiment_live_plot.callback")
+    def test_title_carries_no_absolute_path(
+        self,
+        mock_callback,
+        mock_interval,
+        mock_graph,
+        mock_div,
+        mock_dash,
+    ):
+        """The page title must not leak the absolute result-file path (QILILAB-03)."""
+        fig_mock = MagicMock()
+        mock_callback.side_effect = lambda *a, **k: (lambda fn: fn)
+
+        with patch("qililab.result.experiment_live_plot.go.Figure", return_value=fig_mock):
+            live_plot = ExperimentLivePlot(path="/tmp/run/abc.h5", slurm_execution=True, port_number=None)
+
+            dims_dict = {("QProgram_0", "Measurement_0"): MagicMock()}
+            dims_mock = dims_dict[("QProgram_0", "Measurement_0")]
+            dims_mock.__len__.return_value = 2
+            dims_mock[0].label = "x"
+            dims_mock[0].values.return_value = [np.linspace(0, 1, 10)]
+
+            live_plot.live_plot_figures(dims_dict)
+
+            _, layout_kwargs = fig_mock.update_layout.call_args
+            assert layout_kwargs["title_text"] == "abc.h5"
+            assert "/tmp/run" not in layout_kwargs["title_text"]
+
+
+class TestLivePlotSettings:
+    """Test the live-plot bind-host setting (QILILAB-03)."""
+
+    def test_default_host_is_loopback(self):
+        """The bind host defaults to loopback."""
+        from qililab.qililab_settings import QililabSettings
+
+        assert QililabSettings().experiment_live_plot_host == "127.0.0.1"
+
+    def test_host_respects_env_var(self, monkeypatch):
+        """The bind host can be overridden via the documented env var."""
+        from qililab.qililab_settings import QililabSettings
+
+        monkeypatch.setenv("QILILAB_EXPERIMENT_LIVE_PLOT_HOST", "0.0.0.0")
+        assert QililabSettings().experiment_live_plot_host == "0.0.0.0"


### PR DESCRIPTION
## Summary

Closes **QILILAB-03** (Medium, CWE-1327).

Finding: https://app.notion.com/p/37d7eec14c5381fe9c0dd73d9e3bfb15

`ExperimentLivePlot` started its Dash server with a hardcoded `host="0.0.0.0"` and no auth, and put the **absolute HDF5 result-file path** in the page title. Anyone on the lab LAN reaching the port (default 8050) saw in-progress measurements + an internal path. Gated behind two opt-in settings (both default `False`), hence Medium.

## Fix

Mirrors the existing `experiment_live_plot_port` plumbing end-to-end:

- **Loopback by default** - new `experiment_live_plot_host` setting defaults to `127.0.0.1`; `QILILAB_EXPERIMENT_LIVE_PLOT_HOST` is the explicit opt-in for the SLURM cross-node case (which is why the old "127.0.0.1 does not work" TODO existed). Its description documents the no-auth caveat + reverse-proxy requirement for any routable bind.
- Threaded through the constructor to the bind site `self._dash_app.run(debug=False, host=self._host, ...)`.
- **Removed `# noqa: S104`** so ruff's bind-all-interfaces lint re-arms against a future regression.
- **Path disclosure**: the title now uses `os.path.basename(self.path)` (no absolute directory tree).

Verified closed 3/3; 12 tests pass.
