### PR TITLE
QHC-1417 [BUG-FIX] Rodhe Schwarz IQ wideband for module SGS-B106V

### DIFF
--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -41,6 +41,9 @@
 
 ### Bug fixes
 
+- Fixed a bug for Rohde & Schwarz SGS100A instrument class where the module SGS-B106V did not apply the iq_wideband at the initial_setup.
+    [#1144](https://github.com/qilimanjaro-tech/qililab/pull/1144)
+
 - Fixed a bug in `platform._execute_qblox_compilation_output` where a program with N acquisitions on the same bus returned N² results instead of N. A nested loop incorrectly paired every hardware result with every acquisition slot; replaced with `zip` pairing. This was triggered by any QProgram with acquires at more than one nesting depth on the same bus (e.g. two separate `average` blocks each containing one `acquire`).
   [#1117](https://github.com/qilimanjaro-tech/qililab/pull/1117)
 

--- a/src/qililab/instruments/rohde_schwarz/sgs100a.py
+++ b/src/qililab/instruments/rohde_schwarz/sgs100a.py
@@ -243,7 +243,7 @@ class SGS100A(Instrument):
             self.device.write(":SOUR:POW:ALC:STAT ONT")
         else:
             self.device.write(":SOUR:POW:ALC:STAT OFF")
-        if device_mixer == "SGS-B112V" and self.iq_modulation:
+        if (device_mixer == "SGS-B112V" or device_mixer == "SGS-B106V") and self.iq_modulation:
             self.device.IQ_state(self.iq_modulation)
             if self.iq_wideband:
                 if self.frequency < 2.5e9:
@@ -262,7 +262,7 @@ class SGS100A(Instrument):
                 else:
                     warnings.warn("Deactivated wideband allows for IF sweeps of ±50e6 Hz", ResourceWarning)
                 self.device.write("SOUR:IQ:WBST 0")
-        elif device_mixer == "SGS-B106V" or not self.iq_modulation:
+        elif not self.iq_modulation:
             self.device.IQ_state(self.iq_modulation)
         else:
             raise ValueError(f"iq_modulation set as True for R&S SGS1000A device {device_mixer} without IQ modulation")

--- a/tests/instruments/rohde_schwarz/test_rohde_schwarz_sgs100a.py
+++ b/tests/instruments/rohde_schwarz/test_rohde_schwarz_sgs100a.py
@@ -357,6 +357,19 @@ class TestSGS100A:
             "Operation mode 'wrong_operation_mode' not allowed, defaulting to normal operation mode", ResourceWarning
         )
 
+    @patch("qililab.instruments.rohde_schwarz.SGS100A.get_rs_options")
+    def test_initial_setup_method_iq_wideband_on(self, mock_get_rs_options, sdg100a: SGS100A):
+        """Test initial setup method"""
+        mock_get_rs_options.return_value = "Some,other,SGS-B106V"
+        sdg100a.initial_setup()
+        sdg100a.device.power.assert_called_with(sdg100a.power)
+        sdg100a.device.frequency.assert_called_with(sdg100a.frequency)
+        sdg100a.device.IQ_state.assert_called_with(sdg100a.iq_modulation)
+        sdg100a.device.write.assert_any_call ("SOUR:IQ:WBST 1")
+        sdg100a.device.on.assert_called_once()
+
+        assert sdg100a.settings.iq_modulation is True
+
     @patch("warnings.warn")
     @patch("qililab.instruments.rohde_schwarz.SGS100A.get_rs_options")
     def test_initial_setup_method_wideband_off(self, mock_get_rs_options, mock_warn, sdg100a_wideband_off: SGS100A):
@@ -366,6 +379,7 @@ class TestSGS100A:
         assert sdg100a_wideband_off.settings.iq_wideband is False
         assert sdg100a_wideband_off.iq_wideband is False
         assert sdg100a_wideband_off.iq_modulation is True
+        sdg100a_wideband_off.device.write.assert_any_call ("SOUR:IQ:WBST 0")
 
         mock_warn.assert_any_call(
             "Deactivated wideband & LO frequency below 1GHz allows for IF sweeps of ±4.00e+06 Hz", ResourceWarning


### PR DESCRIPTION
Fixed a bug for Rohde & Schwarz SGS100A instrument class where the module SGS-B106V did not apply the iq_wideband at the initial_setup.