### PR TITLE
[QHC-1418] Swap warnings to logger

### DIFF
--- a/src/qililab/extra/quantum_machines/result/qprogram/quantum_machines_measurement_result.py
+++ b/src/qililab/extra/quantum_machines/result/qprogram/quantum_machines_measurement_result.py
@@ -14,10 +14,9 @@
 
 """QuantumMachinesResult class."""
 
-from warnings import warn
-
 import numpy as np
 
+from qililab.config import logger
 from qililab.result.qprogram.measurement_result import MeasurementResult
 from qililab.typings.enums import ResultName
 from qililab.yaml import yaml
@@ -73,7 +72,7 @@ class QuantumMachinesMeasurementResult(MeasurementResult):
             np.ndarray: The thresholded data.
         """
         if self._classification_threshold is None:
-            warn("Classification threshold is not specified, returning a `np.zeros` array.", stacklevel=2)
+            logger.warning("Classification threshold is not specified, returning a `np.zeros` array.")
 
         return (
             np.where(self._classification_threshold <= self.I, 1.0, 0.0)

--- a/src/qililab/instruments/rohde_schwarz/sgs100a.py
+++ b/src/qililab/instruments/rohde_schwarz/sgs100a.py
@@ -16,9 +16,9 @@
 Class to interface with the local oscillator RohdeSchwarz SGS100A
 """
 
-import warnings
 from dataclasses import dataclass
 
+from qililab.config import logger
 from qililab.instruments.decorators import check_device_initialized, log_set_parameter
 from qililab.instruments.instrument import Instrument, ParameterNotFound
 from qililab.instruments.utils import InstrumentFactory
@@ -247,20 +247,20 @@ class SGS100A(Instrument):
             self.device.IQ_state(self.iq_modulation)
             if self.iq_wideband:
                 if self.frequency < 2.5e9:
-                    warnings.warn(
+                    logger.warning(
                         f"LO frequency below 2.5GHz only allows for IF sweeps of ±{self.frequency * 0.2:,.2e} Hz",
-                        ResourceWarning,
+                        exc_info=ResourceWarning,
                     )
                 self.device.write("SOUR:IQ:WBST 1")
             else:
                 if self.frequency < 1e9:
                     freq = self.frequency * 0.05
-                    warnings.warn(
+                    logger.warning(
                         f"Deactivated wideband & LO frequency below 1GHz allows for IF sweeps of ±{freq:,.2e} Hz",
-                        ResourceWarning,
+                        exc_info=ResourceWarning,
                     )
                 else:
-                    warnings.warn("Deactivated wideband allows for IF sweeps of ±50e6 Hz", ResourceWarning)
+                    logger.warning("Deactivated wideband allows for IF sweeps of ±50e6 Hz", exc_info=ResourceWarning)
                 self.device.write("SOUR:IQ:WBST 0")
         elif device_mixer == "SGS-B106V" or not self.iq_modulation:
             self.device.IQ_state(self.iq_modulation)
@@ -274,9 +274,9 @@ class SGS100A(Instrument):
             operation_mode = "NORMal" if self.operation_mode == "normal" else "BBBYpass"
             self.device.write(f":SOUR:OPMode {operation_mode}")
         else:
-            warnings.warn(
+            logger.warning(
                 f"Operation mode '{self.operation_mode}' not allowed, defaulting to normal operation mode",
-                ResourceWarning,
+                exc_info=ResourceWarning,
             )
             self.settings.operation_mode = "normal"
             self.device.write(":SOUR:OPMode NORMal")

--- a/src/qililab/platform/platform.py
+++ b/src/qililab/platform/platform.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 import ast
 import io
 import re
-import warnings
 from contextlib import contextmanager
 from copy import deepcopy
 from dataclasses import asdict
@@ -1456,7 +1455,7 @@ class Platform:
             return results
         except TimeoutError as timeout:
             if output.qdac:
-                warnings.warn("Timeout reached for triggered measurement, trying again.")
+                logger.warning("Timeout reached for triggered measurement, trying again.")
 
                 # Reset instrument settings
                 for bus_alias in sequences:

--- a/src/qililab/result/database/database_manager.py
+++ b/src/qililab/result/database/database_manager.py
@@ -14,7 +14,6 @@
 
 import datetime
 import os
-import warnings
 from configparser import ConfigParser
 from typing import TYPE_CHECKING, overload
 
@@ -24,6 +23,7 @@ from pandas import read_sql
 from sqlalchemy import create_engine, exists
 from sqlalchemy.orm import Session, sessionmaker
 
+from qililab.config import logger
 from qililab.result.database.database_autocal import AutocalMeasurement, CalibrationRun
 from qililab.result.database.database_measurements import Cooldown, Measurement, Sample, SequenceRun
 from qililab.result.database.database_qaas import QaaS_Experiment
@@ -83,15 +83,15 @@ class DatabaseManager:
                 if cd_object:
                     self.current_cd = cooldown
                     if not cd_object.active:
-                        warnings.warn(
+                        logger.warning(
                             f"Cooldown '{cooldown}' is not active. Make sure you have set the right cooldown."
                         )
                         # TODO: limit data addition to active cooldowns
                 else:
                     raise Exception(f"CD entry '{cooldown}' does not exist. Add it with add_cooldown()")
-                warnings.warn(f"Set current sample to {sample} and cooldown to {cooldown}")
+                logger.warning(f"Set current sample to {sample} and cooldown to {cooldown}")
                 return
-            warnings.warn(f"Set current sample to {sample}")
+            logger.warning(f"Set current sample to {sample}")
 
     def add_cooldown(self, cooldown: str, fridge: str, date: datetime.date = datetime.date.today()):
         """Add cooldown to metadata
@@ -531,7 +531,7 @@ class DatabaseManager:
 
         if not os.path.isdir(base_path):
             os.makedirs(base_path)
-            warnings.warn(f"Data folder did not exist. Created one at {base_path}")
+            logger.warning(f"Data folder did not exist. Created one at {base_path}")
 
         self.calibration_measurement = AutocalMeasurement(
             experiment_name=experiment_name,
@@ -667,7 +667,7 @@ class DatabaseManager:
         folder = dir_path
         if not os.path.isfile(folder):
             os.makedirs(folder)
-            warnings.warn(f"Data folder did not exist. Created one at {folder}")
+            logger.warning(f"Data folder did not exist. Created one at {folder}")
 
         measurement = Measurement(
             experiment_name=experiment_name,
@@ -749,7 +749,7 @@ class DatabaseManager:
         folder = dir_path
         if not os.path.isfile(folder):
             os.makedirs(folder)
-            warnings.warn(f"Data folder did not exist. Created one at {folder}")
+            logger.warning(f"Data folder did not exist. Created one at {folder}")
 
         # Save results
         _file = h5py.File(name=result_path, mode="w")


### PR DESCRIPTION
Except for FutureWarnings (that we should eliminate at some point), all instances of warnings.warn have been changed to the qililab logger.

In qililab we are using logger and we should switch to logguru at some point. If the qilisdk team has finished with their env variable config we could copy it.