### PR TITLE
fix(security): QILILAB-04 validate DB-sourced result paths before read_hdf

### DIFF
--- a/src/qililab/qililab_settings.py
+++ b/src/qililab/qililab_settings.py
@@ -32,6 +32,14 @@ class QililabSettings(BaseSettings):
         default=tempfile.gettempdir(),
         description="Base path for saving experiment results. [env: QILILAB_EXPERIMENT_RESULTS_BASE_PATH]",
     )
+    experiment_results_allowed_roots: str = Field(
+        default="",
+        description=(
+            "Optional os.pathsep-separated allow-list of directories that DB-sourced result "
+            "files (Measurement.result_path) must resolve under before they are opened. Empty "
+            "disables confinement. [env: QILILAB_EXPERIMENT_RESULTS_ALLOWED_ROOTS]"
+        ),
+    )
     experiment_results_path_format: str = Field(
         default="{date}/{time}/{label}.h5",
         description="Format of the experiment results path. [env: QILILAB_EXPERIMENT_RESULTS_PATH_FORMAT]",

--- a/src/qililab/result/database/database_measurements.py
+++ b/src/qililab/result/database/database_measurements.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import datetime
+import os
 
 from pandas import read_hdf
 from sqlalchemy import (
@@ -33,10 +34,31 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import Session, sessionmaker
 from xarray import DataArray
 
+from qililab.qililab_settings import get_settings
 from qililab.result.experiment_results import ExperimentResults
 from qililab.result.result_management import load_results
 
 base = declarative_base()
+
+
+def _validated_result_path(result_path: str) -> str:
+    """QILILAB-04 (CWE-502 / CWE-22): validate a DB-sourced result path before opening it.
+
+    ``result_path`` is read verbatim from the shared measurements database, so a tampered
+    row would otherwise let ``pandas.read_hdf`` open an arbitrary local file (and, if PyTables
+    is installed, execute code via its pickle support). The path is canonicalised (resolving
+    symlinks / ``..``); when ``experiment_results_allowed_roots`` is configured, it must
+    additionally resolve under one of those roots.
+    """
+    if not isinstance(result_path, str) or not result_path:
+        raise ValueError("Measurement result_path is missing or not a string.")
+    resolved = os.path.realpath(result_path)
+    roots = [r for r in get_settings().experiment_results_allowed_roots.split(os.pathsep) if r.strip()]
+    if roots and not any(os.path.commonpath([resolved, os.path.realpath(r)]) == os.path.realpath(r) for r in roots):
+        raise ValueError(
+            f"Measurement result_path {resolved!r} is outside the configured experiment_results_allowed_roots."
+        )
+    return resolved
 
 
 class Cooldown(base):  # type: ignore
@@ -233,20 +255,20 @@ class Measurement(base):  # type: ignore
 
     def load_old_h5(self):
         """Load old experiment data from h5 files."""
-        return load_results(self.result_path)
+        return load_results(_validated_result_path(self.result_path))
 
     def load_df(self):
         """Loads experiments data from hdf files."""
-        return read_hdf(self.result_path)
+        return read_hdf(_validated_result_path(self.result_path))
 
     def load_xarray(self):
         """Loads experiments data from hdf files into Xarray format."""
-        df = read_hdf(self.result_path)
+        df = read_hdf(_validated_result_path(self.result_path))
         return df.to_xarray().to_dataarray()
 
     def read_numpy(self):
         """Loads experiments data from hdf files into numpy array format."""
-        df = read_hdf(self.result_path)
+        df = read_hdf(_validated_result_path(self.result_path))
         da = df.to_xarray().to_dataarray()
         arr = da.to_numpy()[0,]
         axis_labels = {dim: da.coords[dim].values for dim in da.dims[1:]}

--- a/tests/result/test_qililab04_result_path.py
+++ b/tests/result/test_qililab04_result_path.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Qilimanjaro Quantum Tech
+# Copyright 2026 Qilimanjaro Quantum Tech
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/result/test_qililab04_result_path.py
+++ b/tests/result/test_qililab04_result_path.py
@@ -1,0 +1,64 @@
+# Copyright 2023 Qilimanjaro Quantum Tech
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""QILILAB-04 regression tests: DB-sourced result paths must be canonicalised and,
+when an allow-list of roots is configured, confined before they are opened."""
+
+import os
+from types import SimpleNamespace
+
+import pytest
+
+from qililab.result.database import database_measurements as dbm
+
+
+def _settings(allowed_roots=""):
+    return SimpleNamespace(experiment_results_allowed_roots=allowed_roots)
+
+
+def test_validated_result_path_default_canonicalises(tmp_path, monkeypatch):
+    """With no allow-list configured, the path is canonicalised and returned."""
+    monkeypatch.setattr(dbm, "get_settings", lambda: _settings(""))
+    p = tmp_path / "r.h5"
+    p.write_text("")
+    assert dbm._validated_result_path(str(p)) == os.path.realpath(str(p))
+
+
+@pytest.mark.parametrize("bad", ["", None, 123])
+def test_validated_result_path_rejects_invalid(bad, monkeypatch):
+    monkeypatch.setattr(dbm, "get_settings", lambda: _settings(""))
+    with pytest.raises(ValueError):
+        dbm._validated_result_path(bad)
+
+
+def test_validated_result_path_confines_to_allowed_roots(tmp_path, monkeypatch):
+    """When allow-list roots are configured, paths outside them are rejected."""
+    root = tmp_path / "results"
+    root.mkdir()
+    inside = root / "a.h5"
+    inside.write_text("")
+    outside = tmp_path / "evil.h5"
+    outside.write_text("")
+    sibling = tmp_path / "results-evil"
+    sibling.mkdir()
+    sibling_file = sibling / "b.h5"
+    sibling_file.write_text("")
+
+    monkeypatch.setattr(dbm, "get_settings", lambda: _settings(str(root)))
+
+    assert dbm._validated_result_path(str(inside)) == os.path.realpath(str(inside))
+    with pytest.raises(ValueError):
+        dbm._validated_result_path(str(outside))
+    with pytest.raises(ValueError):
+        dbm._validated_result_path(str(sibling_file))  # component-aware: not under "results"


### PR DESCRIPTION
## Summary

Fixes **QILILAB-04** (Medium, CWE-502 / CWE-22) from the qililab security analysis.

Finding: https://app.notion.com/p/37d7eec14c5381f0ac46cf77f1ec91ae

`Measurement.load_df()` / `load_xarray()` / `read_numpy()` / `load_old_h5()` call `read_hdf(self.result_path)` (or `load_results`) where `result_path` is a `String` column read verbatim from the shared PostgreSQL DB, with no canonicalisation or confinement. A tampered `measurements` row therefore yields an arbitrary local-file read, and - because `pandas.read_hdf` reads PyTables/HDFStore files which can unpickle arbitrary objects - code execution if PyTables is installed in the environment.

## Fix

A `_validated_result_path()` guard on all four DB-sourced loaders:
- canonicalises the path (`os.path.realpath`, resolving symlinks / `..`),
- and, when the new `experiment_results_allowed_roots` setting is configured, confines it under one of those roots (component-aware, so `/data/results-evil` is **not** accepted under `/data/results`).

## Why the confinement is opt-in (design note)

I deliberately did **not** hard-confine to the existing `experiment_results_base_path`. That setting **defaults to `tempfile.gettempdir()` (`/tmp`)**, whereas DB-sourced result files commonly live on a separate shared results mount - hard-confining to the default would reject every legitimate read on such deployments. So:

- **Default (empty `experiment_results_allowed_roots`):** non-breaking - canonicalise only.
- **Hardened:** operators set `QILILAB_EXPERIMENT_RESULTS_ALLOWED_ROOTS` (os.pathsep-separated) to their results mount(s) for full confinement against DB-row tampering.

**Residual / follow-up:** the PyTables pickle-RCE is **dormant** on a default install (qililab doesn't depend on `tables`, so `read_hdf` raises `ImportError` before unpickling). The always-present issue this PR closes is the unvalidated path. If PyTables ever enters the environment, switching these loaders to the no-pickle h5py / `ExperimentResults` reader would also close the plant-a-malicious-`.h5`-in-the-results-folder vector.

Verified locally: the previously-failing DB + platform tests pass (64 in `test_database.py` + the platform timeout test); `ruff format` / `ruff check` clean.
