### PR TITLE
[Bugfix] ExperimentExecutor with Acquire and MeasureReset

### DIFF
--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -41,6 +41,9 @@
 
 ### Bug fixes
 
+- Fixed `ExperimentExecutor` not allocating result datasets for `Acquire` (`qp.qblox.acquire`) and `MeasureReset` operations. Previously only `Measure` operations were counted as measurements, so a QProgram that read out via `qp.qblox.acquire` produced no result datasets and `ExperimentResults.get()` raised `KeyError`. The executor now counts the same `(Acquire, Measure, MeasureReset)` set as the `QbloxCompiler`.
+  [#1148](https://github.com/qilimanjaro-tech/qililab/pull/1148)
+
 - Fixed issue where `Platform.set_parameter` using the alias of a "rswu-sp16tr" instrument would raise an error.
   [#1130](https://github.com/qilimanjaro-tech/qililab/pull/1130)
 

--- a/src/qililab/qprogram/experiment_executor.py
+++ b/src/qililab/qprogram/experiment_executor.py
@@ -30,7 +30,15 @@ from qililab.core.variables import Variable
 from qililab.qililab_settings import get_settings
 from qililab.qprogram.blocks import Average, Block, ForLoop, Loop, Parallel
 from qililab.qprogram.experiment import Experiment
-from qililab.qprogram.operations import ExecuteQProgram, GetParameter, Measure, Operation, SetParameter
+from qililab.qprogram.operations import (
+    Acquire,
+    ExecuteQProgram,
+    GetParameter,
+    Measure,
+    MeasureReset,
+    Operation,
+    SetParameter,
+)
 from qililab.qprogram.operations.set_crosstalk import SetCrosstalk
 from qililab.result.experiment_results_writer import (
     ExperimentDataBaseMetadata,
@@ -203,7 +211,10 @@ class ExperimentExecutor:
             for element in block.elements:
                 if isinstance(element, Block):
                     traverse_qprogram(element)
-                if isinstance(element, Measure):
+                # Acquire, Measure and MeasureReset each produce a measurement result in the
+                # QProgramResults timeline (this is the same set the QbloxCompiler treats as
+                # acquisitions), so each must get its own entry in the results structure.
+                if isinstance(element, (Acquire, Measure, MeasureReset)):
                     finalize_measurement_structure()
 
             if isinstance(block, (Loop, ForLoop, Parallel)):
@@ -212,7 +223,7 @@ class ExperimentExecutor:
                 self._shots = 1
 
         def finalize_measurement_structure():
-            """Finalize the structure of a measurement when a Measure operation is encountered."""
+            """Finalize the structure of a measurement when an Acquire, Measure or MeasureReset operation is encountered."""
             qprogram_name = f"QProgram_{self._qprogram_index}"
             measurement_name = f"Measurement_{self._measurement_index}"
 

--- a/tests/qprogram/test_experiment_executor.py
+++ b/tests/qprogram/test_experiment_executor.py
@@ -144,6 +144,18 @@ def fixture_experiment(qprogram: QProgram, crosstalk: CrosstalkMatrix):
     return experiment
 
 
+def make_platform_returning(qprogram_results: QProgramResults):
+    """Build a mock Platform whose ``execute_qprogram`` returns the given results."""
+    platform = create_autospec(Platform)
+    platform.set_parameter = Mock()
+    platform.get_parameter = Mock(return_value=1.23)
+    platform.execute_qprogram = Mock(return_value=qprogram_results)
+    platform.to_dict = Mock(return_value={"name": "platform"})
+    platform.set_crosstalk = Mock()
+    platform.db_manager = Mock()
+    return platform
+
+
 class TestExperimentExecutor:
     """Test ExperimentExecutor class"""
 
@@ -281,6 +293,77 @@ class TestExperimentExecutor:
             qprogram2_measurement1_data, _ = experiment_results.get(2, 1)
             assert qprogram2_measurement1_data.shape == (3, 11, 2)
             assert np.allclose(qprogram2_measurement1_data, measurement_data[None, :, :])
+
+    def test_execute_counts_acquire_as_measurement(self, override_settings):
+        """A QProgram using ``qp.qblox.acquire`` (instead of ``qp.measure``) must allocate a
+        result dataset, just like a Measure, so the acquired data can be read back."""
+        qp = QProgram()
+        frequency = qp.variable(label="frequency", domain=Domain.Frequency)
+        with qp.for_loop(frequency, 0, 10, 1):  # 11 points
+            qp.qblox.acquire(bus="readout_bus", weights=IQPair(Square(1.0, 100), Square(1.0, 100)))
+
+        experiment = Experiment(label="acquire_experiment")
+        experiment.execute_qprogram(qp)
+
+        qprogram_results = QProgramResults()
+        qprogram_results.append_result(
+            "readout_bus", QuantumMachinesMeasurementResult(bus="readout", I=np.arange(0, 11), Q=np.arange(100, 111))
+        )
+        platform = make_platform_returning(qprogram_results)
+
+        with override_settings(
+            experiment_results_save_in_database=False,
+            experiment_live_plot_enabled=False,
+            experiment_live_plot_on_slurm=False,
+        ):
+            executor = ExperimentExecutor(platform=platform, experiment=experiment)
+            results_path = executor.execute()
+
+        with ExperimentResults(results_path) as experiment_results:
+            # A single measurement dataset was allocated for the acquire operation.
+            assert len(experiment_results) == 1
+            data, _ = experiment_results.get(0, 0)
+            assert data.shape == (11, 2)
+            assert np.allclose(data, np.column_stack((np.arange(0, 11), np.arange(100, 111))))
+
+    def test_execute_counts_mixed_measure_and_acquire(self, override_settings):
+        """A QProgram mixing ``qp.measure`` and ``qp.qblox.acquire`` must allocate one
+        measurement dataset per operation, in order of appearance."""
+        qp = QProgram()
+        frequency = qp.variable(label="frequency", domain=Domain.Frequency)
+        with qp.for_loop(frequency, 0, 10, 1):  # 11 points
+            qp.measure(
+                "readout_bus",
+                waveform=IQPair(Square(1.0, 40), Square(1.0, 40)),
+                weights=IQPair(Square(1.0, 100), Square(1.0, 100)),
+            )
+            qp.qblox.acquire(bus="readout_bus", weights=IQPair(Square(1.0, 100), Square(1.0, 100)))
+
+        experiment = Experiment(label="mixed_experiment")
+        experiment.execute_qprogram(qp)
+
+        qprogram_results = QProgramResults()
+        for _ in range(2):  # one result per measurement op: the measure and the acquire
+            qprogram_results.append_result(
+                "readout_bus",
+                QuantumMachinesMeasurementResult(bus="readout", I=np.arange(0, 11), Q=np.arange(100, 111)),
+            )
+        platform = make_platform_returning(qprogram_results)
+
+        with override_settings(
+            experiment_results_save_in_database=False,
+            experiment_live_plot_enabled=False,
+            experiment_live_plot_on_slurm=False,
+        ):
+            executor = ExperimentExecutor(platform=platform, experiment=experiment)
+            results_path = executor.execute()
+
+        with ExperimentResults(results_path) as experiment_results:
+            # Two measurement datasets: Measurement_0 (measure) and Measurement_1 (acquire).
+            assert len(experiment_results) == 2
+            for measurement_index in range(2):
+                data, _ = experiment_results.get(0, measurement_index)
+                assert data.shape == (11, 2)
 
     @patch("qililab.platform.platform.get_db_manager")
     @patch("qililab.result.experiment_results_writer.h5py.File")

--- a/tests/qprogram/test_experiment_executor.py
+++ b/tests/qprogram/test_experiment_executor.py
@@ -16,7 +16,7 @@ from qililab.qprogram.experiment_executor import ExperimentExecutor
 from qililab.qprogram.qprogram import QProgram
 from qililab.core.variables import Domain
 from qililab.result.experiment_results import ExperimentResults
-from qililab.result.qprogram import QProgramResults
+from qililab.result.qprogram import QbloxMeasurementResult, QProgramResults
 from qililab.typings.enums import Parameter
 from qililab.waveforms import IQPair, Square
 
@@ -154,6 +154,14 @@ def make_platform_returning(qprogram_results: QProgramResults):
     platform.set_crosstalk = Mock()
     platform.db_manager = Mock()
     return platform
+
+
+def make_qblox_result(i_values: np.ndarray, q_values: np.ndarray) -> QbloxMeasurementResult:
+    """Build a ``QbloxMeasurementResult`` wrapping the given I/Q integration data."""
+    return QbloxMeasurementResult(
+        bus="readout",
+        raw_measurement_data={"bins": {"integration": {"path0": i_values, "path1": q_values}}},
+    )
 
 
 class TestExperimentExecutor:
@@ -306,9 +314,7 @@ class TestExperimentExecutor:
         experiment.execute_qprogram(qp)
 
         qprogram_results = QProgramResults()
-        qprogram_results.append_result(
-            "readout_bus", QuantumMachinesMeasurementResult(bus="readout", I=np.arange(0, 11), Q=np.arange(100, 111))
-        )
+        qprogram_results.append_result("readout_bus", make_qblox_result(np.arange(0, 11), np.arange(100, 111)))
         platform = make_platform_returning(qprogram_results)
 
         with override_settings(
@@ -344,10 +350,7 @@ class TestExperimentExecutor:
 
         qprogram_results = QProgramResults()
         for _ in range(2):  # one result per measurement op: the measure and the acquire
-            qprogram_results.append_result(
-                "readout_bus",
-                QuantumMachinesMeasurementResult(bus="readout", I=np.arange(0, 11), Q=np.arange(100, 111)),
-            )
+            qprogram_results.append_result("readout_bus", make_qblox_result(np.arange(0, 11), np.arange(100, 111)))
         platform = make_platform_returning(qprogram_results)
 
         with override_settings(


### PR DESCRIPTION
Fixed `ExperimentExecutor` not allocating result datasets for `Acquire` (`qp.qblox.acquire`) and `MeasureReset` operations. Previously only `Measure` operations were counted as measurements, so a QProgram that read out via `qp.qblox.acquire` produced no result datasets and `ExperimentResults.get()` raised `KeyError`. The executor now counts the same `(Acquire, Measure, MeasureReset)` set as the `QbloxCompiler`.