### PR TITLE
Qhc 1431 rename database folder locations to use microsecond and report missing database.ini parameters

### DIFF
--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -5,7 +5,7 @@
 ### Improvements
 
 - Added a `ValueError` while creating the `DatabaseManager` (for example with `get_db_manager`) checking for `user`, `passwd`, `host`, `port` or `database` inside the database.ini config file, if any of these parameters is missing an error is thrown.
-  [#](https://github.com/qilimanjaro-tech/qililab/pull/)
+  [#1152](https://github.com/qilimanjaro-tech/qililab/pull/1152)
 
 - Added support for QPrograms with more than 32 distinct acquisitions in different blocks on the same bus. The compiler detects this case during a pre-traversal pass and maps all acquisitions to hardware index 0 with N bins, one bin per block. The platform then unpacks the single hardware result into N separate `QbloxMeasurementResult` objects, so `len(results["bus"]) == N` as expected.
 
@@ -45,7 +45,7 @@
 ### Bug fixes
 
 - Fixed the folder shape at `add_measurement` and `add_results` to take into account us intervals of time. This will solve any issue with parallelization while creating more than one folder in less than a second.
-  [#](https://github.com/qilimanjaro-tech/qililab/pull/)
+  [#1152](https://github.com/qilimanjaro-tech/qililab/pull/1152)
 
 - Fixed `ExperimentExecutor` not allocating result datasets for `Acquire` (`qp.qblox.acquire`) and `MeasureReset` operations. Previously only `Measure` operations were counted as measurements, so a QProgram that read out via `qp.qblox.acquire` produced no result datasets and `ExperimentResults.get()` raised `KeyError`. The executor now counts the same `(Acquire, Measure, MeasureReset)` set as the `QbloxCompiler`.
   [#1148](https://github.com/qilimanjaro-tech/qililab/pull/1148)

--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -4,6 +4,9 @@
 
 ### Improvements
 
+- Added a `ValueError` while creating the `DatabaseManager` (for example with `get_db_manager`) checking for `user`, `passwd`, `host`, `port` or `database` inside the database.ini config file, if any of these parameters is missing an error is thrown.
+  [#](https://github.com/qilimanjaro-tech/qililab/pull/)
+
 - Added support for QPrograms with more than 32 distinct acquisitions in different blocks on the same bus. The compiler detects this case during a pre-traversal pass and maps all acquisitions to hardware index 0 with N bins, one bin per block. The platform then unpacks the single hardware result into N separate `QbloxMeasurementResult` objects, so `len(results["bus"]) == N` as expected.
 
   The typical use case is sweeping over a non-linear (arbitrary) set of values, not expressible as a hardware `for_loop`:
@@ -40,6 +43,9 @@
 ### Documentation
 
 ### Bug fixes
+
+- Fixed the folder shape at `add_measurement` and `add_results` to take into account us intervals of time. This will solve any issue with parallelization while creating more than one folder in less than a second.
+  [#](https://github.com/qilimanjaro-tech/qililab/pull/)
 
 - Fixed `ExperimentExecutor` not allocating result datasets for `Acquire` (`qp.qblox.acquire`) and `MeasureReset` operations. Previously only `Measure` operations were counted as measurements, so a QProgram that read out via `qp.qblox.acquire` produced no result datasets and `ExperimentResults.get()` raised `KeyError`. The executor now counts the same `(Acquire, Measure, MeasureReset)` set as the `QbloxCompiler`.
   [#1148](https://github.com/qilimanjaro-tech/qililab/pull/1148)

--- a/src/qililab/result/database/database_manager.py
+++ b/src/qililab/result/database/database_manager.py
@@ -48,6 +48,15 @@ class DatabaseManager:
             database_name (str): Name of the config section inside the `.ini`.
         """
         config = _load_config(filename, database_name)
+
+        database_keys = ("user", "passwd", "host", "port", "database")
+        missing = [key for key in database_keys if config.get(key) is None or str(config.get(key)).strip() == ""]
+        if missing:
+            raise ValueError(
+                f"Missing or empty required config value(s) in '{database_name}' "
+                f"Missing the database keys: {', '.join(missing)}"
+            )
+
         self.engine = get_engine(config["user"], config["passwd"], config["host"], config["port"], config["database"])
         self.session: sessionmaker[Session] = sessionmaker(bind=self.engine, expire_on_commit=False)
         self.current_cd: str | None = None
@@ -742,7 +751,7 @@ class DatabaseManager:
         base_path = f"{self.base_path_local}{self.folder_path}"
         if not os.path.isdir(base_path):
             base_path = f"{self.base_path_share}{self.folder_path}"
-        formatted_time = start_time.strftime("%Y-%m-%d/%H_%M_%S")
+        formatted_time = start_time.strftime("%Y-%m-%d/%H_%M_%S_%f")
         dir_path = f"{base_path}/{self.current_sample}/{self.current_cd}/{formatted_time}"
         result_path = f"{dir_path}/{experiment_name}.h5"
 

--- a/src/qililab/result/database/database_manager.py
+++ b/src/qililab/result/database/database_manager.py
@@ -661,7 +661,7 @@ class DatabaseManager:
             cooldown = self.current_cd
 
         start_time = datetime.datetime.now()
-        formatted_time = start_time.strftime("%Y-%m-%d/%H_%M_%S")
+        formatted_time = start_time.strftime("%Y-%m-%d/%H_%M_%S_%f")
 
         base_path = f"{self.base_path_local}{self.folder_path}"
         if not os.path.isdir(base_path):

--- a/tests/result/test_database.py
+++ b/tests/result/test_database.py
@@ -380,6 +380,31 @@ class TestMeasurement:
 class Testdatabase:
     """Test database class"""
 
+    def test_database_manager_raises_error_wrong_config(self):
+        config = {
+            "user": "user",
+            "passwd": "passwd",
+            "host": "host",
+            "port": "5432",
+            "database": "database",
+        }
+
+        del config["user"]
+        del config["port"]
+        del config["database"]
+        with patch("qililab.result.database.database_manager._load_config") as mock_load_config:
+            mock_load_config.return_value = config
+
+            with pytest.raises(ValueError) as exc_info:
+                DatabaseManager("test_file.ini", "database")
+        
+            message = str(exc_info.value)
+            assert "user" in message
+            assert "port" in message
+            assert "database" in message
+            # keys that were present should not be flagged
+            assert "host" not in message.split("Missing the database keys:")[1]
+
     def test_set_sample(self, db_manager: DatabaseManager):
         mock_session = db_manager.session()
         mock_session.query.return_value.scalar.return_value = True
@@ -1189,7 +1214,6 @@ def test_get_db_manager(mock_db_manager):
     filename = os.path.expanduser("~/database.ini")
     get_db_manager()
     mock_db_manager.assert_called_once_with(filename, "postgresql")
-
 
 @patch("qililab.result.database.database_manager.create_engine")
 def test_get_engine(mock_create_engine):

--- a/tests/result/test_database.py
+++ b/tests/result/test_database.py
@@ -1040,11 +1040,11 @@ class Testdatabase:
         measurement = db_manager.add_measurement("exp1", experiment_completed=True)
 
         # Assert
-        expected_path = "/shared_test/measurement_folder/sampleA/cdX/2023-01-01/12_00_00/exp1.h5"
+        expected_path = "/shared_test/measurement_folder/sampleA/cdX/2023-01-01/12_00_00_000000/exp1.h5"
         assert measurement.result_path == expected_path
         db_manager._mock_session.add.assert_called_once()
         db_manager._mock_session.commit.assert_called_once()
-        mock_makedirs.assert_called_once_with("/shared_test/measurement_folder/sampleA/cdX/2023-01-01/12_00_00")
+        mock_makedirs.assert_called_once_with("/shared_test/measurement_folder/sampleA/cdX/2023-01-01/12_00_00_000000")
 
     def test_add_measurement_raises_exception_no_sample(self, db_manager: DatabaseManager):
         # Set current_sample to None to simulate no sample set


### PR DESCRIPTION
- Added a `ValueError` while creating the `DatabaseManager` (for example with `get_db_manager`) checking for `user`, `passwd`, `host`, `port` or `database` inside the database.ini config file, if any of these parameters is missing an error is thrown.
- Fixed the folder shape at `add_measurement` and `add_results` to take into account us intervals of time. This will solve any issue with parallelization while creating more than one folder in less than a second.