### PR TITLE
Qhc 1433 qdac multiple users sharing internal trigger network

### DIFF
--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -74,6 +74,9 @@ In the runcard this parameter is located inside the instruments sequencer for QR
 
 ### Bug fixes
 
+- Fixed the default value for QDAC's voltage list dwell time. Before, it was set to 1 us but the [QDAC documentation page 76](https://qm.quantum-machines.co/hubfs/QDAC%20II%20-%20User%20manual%20v2.2%20(2024-01-17).pdf) states that the minimum is 2 us. If a user states a number smaller than 2 us, the qdac automatically sets the dwell time as the minimum (2 us).
+  [#1154](https://github.com/qilimanjaro-tech/qililab/pull/1154)
+
 - Fixed the QDAC-II trigger network breaking when multiple users are connected to the same instrument. Each qililab instance allocated internal trigger numbers from its own driver-side pool, with no way of knowing which numbers other Python processes were already using. When two instances picked the same number, their triggers fired through each other's networks, interfering with both experiments.
 
   Internal triggers in use are now read directly from the instrument's marker registers before every allocation, so a new trigger always takes the lowest number that is actually free on the hardware. Related behavior changes:

--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -47,9 +47,13 @@
 
 ### Bug fixes
 
-- Fixed an issue where two users connected to the same QDAC-II encountered some issues with the trigger network. This occurred because the device's drivers created an arbitrary number for the internal trigger, unable to communicate this value to other instances of python, If the number was the same the triggers went would be sent though multiple networks (interfering with each other experiments).
+- Fixed the QDAC-II trigger network breaking when multiple users are connected to the same instrument. Each qililab instance allocated internal trigger numbers from its own driver-side pool, with no way of knowing which numbers other Python processes were already using. When two instances picked the same number, their triggers fired through each other's networks, interfering with both experiments.
 
-  This issue has been solved by creating a function (`_check_internal_triggers`) that reviews each channel and creates only internal triggers that have not been set in the internal trigger network.
+  Internal triggers in use are now read directly from the instrument's marker registers before every allocation, so a new trigger always takes the lowest number that is actually free on the hardware. Related behavior changes:
+  - `QDevilQDac2.start()` now starts only the DC lists and AWG waveforms uploaded by this instance, instead of `start_all()`, which also fired generators armed by other users.
+  - `QDevilQDac2.clear_trigger()` now frees the triggers created by this instance from the instrument (previously `free_all_triggers()` released the triggers set by `QCodes`, not affecting the instrument).
+  - `Platform.execute_qprogram` now clears each QDAC-II's trigger network and generator caches after every execution, so consecutive executions always start from a clean trigger state.
+  - Allocating a trigger when all 14 internal triggers are busy raises a `ValueError` including other users triggers.
   [#1154](https://github.com/qilimanjaro-tech/qililab/pull/1154)
 
 - Fixed the folder shape at `add_measurement` and `add_results` to take into account us intervals of time. This will solve any issue with parallelization while creating more than one folder in less than a second.

--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -41,6 +41,11 @@
 
 ### Bug fixes
 
+- Fixed an issue where two users connected to the same QDAC-II encountered some issues with the trigger network. This occurred because the device's drivers created an arbitrary number for the internal trigger, unable to communicate this value to other instances of python, If the number was the same the triggers went would be sent though multiple networks (interfering with each other experiments).
+
+  This issue has been solved by creating a function (`_check_internal_triggers`) that reviews each channel and creates only internal triggers that have not been set in the internal trigger network.
+  [#1154](https://github.com/qilimanjaro-tech/qililab/pull/1154)
+
 - Fixed `ExperimentExecutor` not allocating result datasets for `Acquire` (`qp.qblox.acquire`) and `MeasureReset` operations. Previously only `Measure` operations were counted as measurements, so a QProgram that read out via `qp.qblox.acquire` produced no result datasets and `ExperimentResults.get()` raised `KeyError`. The executor now counts the same `(Acquire, Measure, MeasureReset)` set as the `QbloxCompiler`.
   [#1148](https://github.com/qilimanjaro-tech/qililab/pull/1148)
 
@@ -48,7 +53,7 @@
   [#1130](https://github.com/qilimanjaro-tech/qililab/pull/1130)
 
 - Fixed a bug for Rohde & Schwarz SGS100A instrument class where the module SGS-B106V did not apply the iq_wideband at the initial_setup.
-    [#1144](https://github.com/qilimanjaro-tech/qililab/pull/1144)
+  [#1144](https://github.com/qilimanjaro-tech/qililab/pull/1144)
 
 - Fixed a bug in `platform._execute_qblox_compilation_output` where a program with N acquisitions on the same bus returned N² results instead of N. A nested loop incorrectly paired every hardware result with every acquisition slot; replaced with `zip` pairing. This was triggered by any QProgram with acquires at more than one nesting depth on the same bus (e.g. two separate `average` blocks each containing one `acquire`).
   [#1117](https://github.com/qilimanjaro-tech/qililab/pull/1117)

--- a/src/qililab/instruments/qdevil/qdevil_qdac2.py
+++ b/src/qililab/instruments/qdevil/qdevil_qdac2.py
@@ -579,9 +579,7 @@ class QDevilQDac2(VoltageSource):
     @check_device_initialized
     def reset(self):
         """Reset instrument. This will affect all channels."""
-        if self._triggers:
-            for trigger_name in list(self._triggers.keys()):
-                self.clear_trigger(trigger_name)
+        self.clear_trigger()
         self.clear_cache()
         self.device.reset()
 

--- a/src/qililab/instruments/qdevil/qdevil_qdac2.py
+++ b/src/qililab/instruments/qdevil/qdevil_qdac2.py
@@ -15,9 +15,11 @@
 """QDevil QDAC-II Instrument"""
 
 from dataclasses import dataclass
+from itertools import product
 from typing import TYPE_CHECKING
 
 import numpy as np
+from qcodes_contrib_drivers.drivers.QDevil.QDAC2 import QDac2Trigger_Context
 
 from qililab.instruments import InstrumentFactory, ParameterNotFound, check_device_initialized, log_set_parameter
 from qililab.instruments.voltage_source import VoltageSource
@@ -26,7 +28,7 @@ from qililab.typings import QDevilQDac2 as QDevilQDac2Driver
 from qililab.waveforms import Waveform
 
 if TYPE_CHECKING:
-    from qcodes_contrib_drivers.drivers.QDevil.QDAC2 import List_Context, QDac2Trigger_Context
+    from qcodes_contrib_drivers.drivers.QDevil.QDAC2 import List_Context
 
 
 @InstrumentFactory.register
@@ -42,6 +44,11 @@ class QDevilQDac2(VoltageSource):
     _MIN_RAMPING_RATE: float = 0.01
     _MAX_RAMPING_RATE: float = 2e7
     name = InstrumentName.QDEVIL_QDAC2
+
+    _N_DACS: int = 24
+    _N_INT_TRIGGERS: int = 14
+    _GENERATOR_LIST: tuple[str, str, str, str, str] = ("DC", "SINe", "SQUare", "TRIangle", "AWG")
+    _MARKER_LOCATION: tuple[str, str, str, str, str, str] = ("STARt", "END", "PSTart", "PEND", "SSTart", "SEND")
 
     @dataclass
     class QDevilQDac2Settings(VoltageSource.VoltageSourceSettings):
@@ -61,6 +68,8 @@ class QDevilQDac2(VoltageSource):
         self._cache_awg: dict[int | str, bool] = {}
         self._cache_dc: dict[int | str, List_Context] = {}
         self._triggers: dict[str, QDac2Trigger_Context] = {}
+
+        self._internal_triggers: dict = {}
 
     @property
     def low_pass_filter(self):
@@ -187,7 +196,7 @@ class QDevilQDac2(VoltageSource):
         self._validate_channel(channel_id=channel_id)
 
         envelope = waveform.envelope()
-        values = list(envelope)  # TODO: does np array work?
+        values = list(envelope)
         if channel_id in self._cache_awg:
             raise ValueError(
                 f"Device {self.name} already has a waveform allocated to channel {channel_id}. Clear the cache before allocating a new waveform"
@@ -289,7 +298,12 @@ class QDevilQDac2(VoltageSource):
         if str(trigger) in self._triggers.keys():
             self.clear_trigger(trigger)
 
-        self._triggers[str(trigger)] = self._cache_dc[f"{self.device.name}_{channel_id}"].start_marker()
+        self._triggers[str(trigger)] = self.allocate_internal_trigger(
+            self._cache_dc[f"{self.device.name}_{channel_id}"]
+        )
+
+        channel = self.device.channel(channel_id)
+        channel.write_channel(f"sour{'{0}'}:dc:mark:star {self._triggers[str(trigger)].value}")
 
         self.device.connect_external_trigger(port=out_port, trigger=self._triggers[str(trigger)], width_s=width_s)
 
@@ -310,7 +324,12 @@ class QDevilQDac2(VoltageSource):
         if str(trigger) in self._triggers.keys():
             self.clear_trigger(trigger)
 
-        self._triggers[str(trigger)] = self._cache_dc[f"{self.device.name}_{channel_id}"].start_marker()
+        self._triggers[str(trigger)] = self.allocate_internal_trigger(
+            self._cache_dc[f"{self.device.name}_{channel_id}"]
+        )
+
+        channel = self.device.channel(channel_id)
+        channel.write_channel(f"sour{'{0}'}:dc:mark:star {self._triggers[str(trigger)].value}")
 
     def set_end_marker_external_trigger(
         self,
@@ -338,7 +357,9 @@ class QDevilQDac2(VoltageSource):
         if str(trigger) in self._triggers.keys():
             self.clear_trigger(trigger)
 
-        self._triggers[str(trigger)] = self._cache_dc[f"{self.device.name}_{channel_id}"].allocate_trigger()
+        self._triggers[str(trigger)] = self.allocate_internal_trigger(
+            self._cache_dc[f"{self.device.name}_{channel_id}"]
+        )
 
         channel = self.device.channel(channel_id)
         if not step:
@@ -374,7 +395,9 @@ class QDevilQDac2(VoltageSource):
         if str(trigger) in self._triggers.keys():
             self.clear_trigger(trigger)
 
-        self._triggers[str(trigger)] = self._cache_dc[f"{self.device.name}_{channel_id}"].allocate_trigger()
+        self._triggers[str(trigger)] = self.allocate_internal_trigger(
+            self._cache_dc[f"{self.device.name}_{channel_id}"]
+        )
 
         channel = self.device.channel(channel_id)
         if not step:
@@ -401,7 +424,9 @@ class QDevilQDac2(VoltageSource):
         if str(trigger) in self._triggers.keys():
             self.clear_trigger(trigger)
 
-        self._triggers[str(trigger)] = self._cache_dc[f"{self.device.name}_{channel_id}"].allocate_trigger()
+        self._triggers[str(trigger)] = self.allocate_internal_trigger(
+            self._cache_dc[f"{self.device.name}_{channel_id}"]
+        )
 
         channel = self.device.channel(channel_id)
         if not step:
@@ -426,7 +451,9 @@ class QDevilQDac2(VoltageSource):
         if str(trigger) in self._triggers.keys():
             self.clear_trigger(trigger)
 
-        self._triggers[str(trigger)] = self._cache_dc[f"{self.device.name}_{channel_id}"].allocate_trigger()
+        self._triggers[str(trigger)] = self.allocate_internal_trigger(
+            self._cache_dc[f"{self.device.name}_{channel_id}"]
+        )
 
         channel = self.device.channel(channel_id)
         if not step:
@@ -455,23 +482,63 @@ class QDevilQDac2(VoltageSource):
 
     def start(self):
         """All generators, that have not been explicitly set to trigger on an internal or external trigger, will be started."""
-        self.device.start_all()
+        for awg in self._cache_awg:
+            awg.start()
+        for dc_list in self._cache_dc:
+            dc_list.start()
         self._cache_awg = {}
         self._cache_dc = {}
         # TODO: add synchronous multiple qdac interaction using QDAC2_Array and qdacs.sync (https://qcodes.github.io/Qcodes_contrib_drivers/examples/QDevil/QDAC2/SyncMultipleQDACs.html)
 
     def clear_cache(self):
         """Clears the cache of the instrument"""
-        self.device.remove_traces()  # TODO: this method should be run at initial setup if instrument is in awg mode
+        self.device.remove_traces()
         self._cache_awg = {}
         self._cache_dc = {}
 
-    def clear_trigger(self, trigger: str | None = None):
-        """Clears all created triggers or only the specified trigger in case a trigger string is given."""
-        if trigger:
-            self.device.free_trigger(self._triggers[str(trigger)])
-        else:
-            self.device.free_all_triggers()
+    def _check_internal_triggers(self):
+        for channel_id in range(1, self._N_DACS + 1):
+            channel = self.device.channel(channel_id)
+            for generator, marker_location in product(self._GENERATOR_LIST, self._MARKER_LOCATION):
+                internal_trigger = channel.ask_channel(f"SOUR{'{0}'}:{generator}:MARK:{marker_location}?")
+                if internal_trigger != 0:
+                    self._internal_triggers[internal_trigger] = (channel_id, generator, marker_location)
+
+    def allocate_internal_trigger(self, qdac_generator: "QDevilQDac2Driver") -> QDac2Trigger_Context:
+        """Allocate an internal trigger
+
+        Does not have any effect on the instrument, only the driver.
+
+        Args:
+            qdac_generator (QDevilQDac2Driver): QDAC pulse generator such as DC list, AWG, Square...
+
+        Raises:
+            ValueError: no free triggers
+
+        Returns:
+            QDac2Trigger_Context: Context manager
+        """
+        self._check_internal_triggers()
+        free_int_trigger = set(range(1, self._N_INT_TRIGGERS + 1)) - self._internal_triggers.keys()
+        if not free_int_trigger:
+            raise ValueError("No free internal triggers")
+        return QDac2Trigger_Context(qdac_generator, min(free_int_trigger))
+
+    def clear_trigger(self, trigger: str | None = None) -> None:
+        """Free an internal trigger
+
+        Args:
+            trigger (optional, str | None): trigger to free, if no name is given it will free all triggers
+                                            set in this instance. Defaults to None.
+        """
+        self._check_internal_triggers()
+        triggers = {trigger: self._triggers[trigger]} if trigger is not None else self._triggers
+        for name, marker in triggers.items():
+            internal_trigger = marker.value
+            channel_id, generator, marker_location = self._internal_triggers[internal_trigger]
+            channel = self.device.channel(channel_id)
+            internal_trigger = channel.write_channel(f"SOUR{'{0}'}:{generator}:MARK:{marker_location} 0")
+            self._triggers.pop(name)
 
     def get_parameter(
         self, parameter: Parameter, channel_id: ChannelID | None = None, output_id: OutputID | None = None
@@ -517,7 +584,7 @@ class QDevilQDac2(VoltageSource):
 
     @check_device_initialized
     def turn_on(self):
-        """Start outputing voltage."""
+        """Start outputting voltage."""
         for channel_id in self.dacs:
             index = self.dacs.index(channel_id)
             channel = self.device.channel(channel_id)
@@ -528,7 +595,7 @@ class QDevilQDac2(VoltageSource):
 
     @check_device_initialized
     def turn_off(self):
-        """Stop outputing voltage."""
+        """Stop outputting voltage."""
         for channel_id in self.dacs:
             channel = self.device.channel(channel_id)
             channel.dc_constant_V(0.0)
@@ -549,10 +616,10 @@ class QDevilQDac2(VoltageSource):
         if self._triggers:
             for trigger_name in self._triggers.keys():
                 self.clear_trigger(trigger_name)
+        self.clear_cache()
         self.device.reset()
 
     def remove_digital_trace(self):
-        self.clear_trigger()
         self._triggers = {}
         self.device.remove_traces()
 

--- a/src/qililab/instruments/qdevil/qdevil_qdac2.py
+++ b/src/qililab/instruments/qdevil/qdevil_qdac2.py
@@ -219,7 +219,7 @@ class QDevilQDac2(VoltageSource):
         self,
         waveform: Waveform,
         channel_id: ChannelID,
-        dwell_us: int = 1,
+        dwell_us: int = 2,
         sync_delay_s: float = 0,
         repetitions: int = 1,
         stepped: bool = False,
@@ -344,7 +344,7 @@ class QDevilQDac2(VoltageSource):
             channel_id (ChannelID): Channel id of the qdac
             out_port (int): Trigger output port.
             trigger (str): Name of the trigger.
-            width_s (float, optional): duration in seconds of the trigger pulse. Defaults to 1e-6.
+            width_s (float, optional): duration in seconds of the trigger pulse. Defaults to 2e-6 s.
             step (bool, optional): sends a trigger every step. Defaults to False
         """
         self._validate_channel(channel_id=channel_id)
@@ -475,7 +475,7 @@ class QDevilQDac2(VoltageSource):
                 f"SOUR{channel_id}:{generator}:MARK:{marker_location}?" for generator, marker_location in registers
             )
             response = self.device.ask(query)
-            for (generator, marker_location), value in zip(registers, response.split(";")):
+            for (generator, marker_location), value in zip(registers, response.split(",")):
                 internal_trigger = int(value)
                 if internal_trigger != 0:
                     self._internal_triggers[internal_trigger] = (channel_id, generator, marker_location)

--- a/src/qililab/instruments/qdevil/qdevil_qdac2.py
+++ b/src/qililab/instruments/qdevil/qdevil_qdac2.py
@@ -475,7 +475,7 @@ class QDevilQDac2(VoltageSource):
                 f"SOUR{channel_id}:{generator}:MARK:{marker_location}?" for generator, marker_location in registers
             )
             response = self.device.ask(query)
-            for (generator, marker_location), value in zip(registers, response.split(",")):
+            for (generator, marker_location), value in zip(registers, response.split(","), strict=True):
                 internal_trigger = int(value)
                 if internal_trigger != 0:
                     self._internal_triggers[internal_trigger] = (channel_id, generator, marker_location)

--- a/src/qililab/instruments/qdevil/qdevil_qdac2.py
+++ b/src/qililab/instruments/qdevil/qdevil_qdac2.py
@@ -229,7 +229,8 @@ class QDevilQDac2(VoltageSource):
         Args:
             waveform (Waveform): Waveform to upload
             channel_id (ChannelID): Channel id of the qdac.
-            dwell_us (int, optional): Dwell of the pulse. Defaults to 1.
+            dwell_us (int, optional): Dwell of the pulse the minimum value is 2e-6 s and the maximum is 3.6e4 s (10 h).
+                                        Defaults to 2 (2e-6 s).
             sync_delay_s (float, optional): Delay of each pulse repetition. Defaults to 0.
             repetitions (int, optional): Number of pulse repetitions. Defaults to 1.
             stepped (bool, optional): Trigger defining pulse shape,
@@ -298,7 +299,7 @@ class QDevilQDac2(VoltageSource):
             channel_id (ChannelID): Channel id of the qdac whose DC list emits the trigger.
             out_port (int): External trigger output port to send the pulse through.
             trigger (str): Name used to identify the trigger in this instance.
-            width_s (float, optional): Duration in seconds of the trigger pulse. Defaults to 1e-6.
+            width_s (float, optional): Duration in seconds of the trigger pulse. Defaults to 1e-6 s.
 
         Raises:
             ValueError: if no DC list has been uploaded for the given channel id.
@@ -344,7 +345,7 @@ class QDevilQDac2(VoltageSource):
             channel_id (ChannelID): Channel id of the qdac
             out_port (int): Trigger output port.
             trigger (str): Name of the trigger.
-            width_s (float, optional): duration in seconds of the trigger pulse. Defaults to 2e-6 s.
+            width_s (float, optional): duration in seconds of the trigger pulse. Defaults to 1e-6 s.
             step (bool, optional): sends a trigger every step. Defaults to False
         """
         self._validate_channel(channel_id=channel_id)
@@ -371,7 +372,7 @@ class QDevilQDac2(VoltageSource):
             channel_id (ChannelID): Channel id of the qdac
             out_port (int): Trigger output port.
             trigger (str): Name of the trigger.
-            width_s (float, optional): duration in seconds of the trigger pulse. Defaults to 1e-6.
+            width_s (float, optional): duration in seconds of the trigger pulse. Defaults to 1e-6 s.
             step (bool, optional): sends a trigger every step. Defaults to False
         """
         self._validate_channel(channel_id=channel_id)

--- a/src/qililab/instruments/qdevil/qdevil_qdac2.py
+++ b/src/qililab/instruments/qdevil/qdevil_qdac2.py
@@ -70,6 +70,8 @@ class QDevilQDac2(VoltageSource):
         self._triggers: dict[str, QDac2Trigger_Context] = {}
 
         self._internal_triggers: dict = {}
+        # marker register each trigger of this instance was written to: (channel_id, generator, marker_location)
+        self._marker_registers: dict[str, tuple[ChannelID, str, str]] = {}
 
     @property
     def low_pass_filter(self):
@@ -295,15 +297,7 @@ class QDevilQDac2(VoltageSource):
             raise ValueError(
                 f"No DC list with the given channel ID, first create a DC list with channel ID: {channel_id}"
             )
-        if str(trigger) in self._triggers.keys():
-            self.clear_trigger(trigger)
-
-        self._triggers[str(trigger)] = self.allocate_internal_trigger(
-            self._cache_dc[f"{self.device.name}_{channel_id}"]
-        )
-
-        channel = self.device.channel(channel_id)
-        channel.write_channel(f"sour{'{0}'}:dc:mark:star {self._triggers[str(trigger)].value}")
+        self._set_dc_marker(channel_id, "STARt", str(trigger))
 
         self.device.connect_external_trigger(port=out_port, trigger=self._triggers[str(trigger)], width_s=width_s)
 
@@ -321,15 +315,7 @@ class QDevilQDac2(VoltageSource):
             raise ValueError(
                 f"No DC list with the given channel ID, first create a DC list with channel ID: {channel_id}"
             )
-        if str(trigger) in self._triggers.keys():
-            self.clear_trigger(trigger)
-
-        self._triggers[str(trigger)] = self.allocate_internal_trigger(
-            self._cache_dc[f"{self.device.name}_{channel_id}"]
-        )
-
-        channel = self.device.channel(channel_id)
-        channel.write_channel(f"sour{'{0}'}:dc:mark:star {self._triggers[str(trigger)].value}")
+        self._set_dc_marker(channel_id, "STARt", str(trigger))
 
     def set_end_marker_external_trigger(
         self,
@@ -354,18 +340,7 @@ class QDevilQDac2(VoltageSource):
             raise ValueError(
                 f"No DC list with the given channel ID, first create a DC list with channel ID: {channel_id}"
             )
-        if str(trigger) in self._triggers.keys():
-            self.clear_trigger(trigger)
-
-        self._triggers[str(trigger)] = self.allocate_internal_trigger(
-            self._cache_dc[f"{self.device.name}_{channel_id}"]
-        )
-
-        channel = self.device.channel(channel_id)
-        if not step:
-            channel.write_channel(f"sour{'{0}'}:dc:mark:pend {self._triggers[str(trigger)].value}")
-        else:
-            channel.write_channel(f"sour{'{0}'}:dc:mark:send {self._triggers[str(trigger)].value}")
+        self._set_dc_marker(channel_id, "SEND" if step else "PEND", str(trigger))
 
         self.device.connect_external_trigger(port=out_port, trigger=self._triggers[str(trigger)], width_s=width_s)
 
@@ -392,18 +367,7 @@ class QDevilQDac2(VoltageSource):
             raise ValueError(
                 f"No DC list with the given channel ID, first create a DC list with channel ID: {channel_id}"
             )
-        if str(trigger) in self._triggers.keys():
-            self.clear_trigger(trigger)
-
-        self._triggers[str(trigger)] = self.allocate_internal_trigger(
-            self._cache_dc[f"{self.device.name}_{channel_id}"]
-        )
-
-        channel = self.device.channel(channel_id)
-        if not step:
-            channel.write_channel(f"sour{'{0}'}:dc:mark:pstart {self._triggers[str(trigger)].value}")
-        else:
-            channel.write_channel(f"sour{'{0}'}:dc:mark:sstart {self._triggers[str(trigger)].value}")
+        self._set_dc_marker(channel_id, "SSTart" if step else "PSTart", str(trigger))
 
         self.device.connect_external_trigger(port=out_port, trigger=self._triggers[str(trigger)], width_s=width_s)
 
@@ -421,18 +385,7 @@ class QDevilQDac2(VoltageSource):
             raise ValueError(
                 f"No DC list with the given channel ID, first create a DC list with channel ID: {channel_id}"
             )
-        if str(trigger) in self._triggers.keys():
-            self.clear_trigger(trigger)
-
-        self._triggers[str(trigger)] = self.allocate_internal_trigger(
-            self._cache_dc[f"{self.device.name}_{channel_id}"]
-        )
-
-        channel = self.device.channel(channel_id)
-        if not step:
-            channel.write_channel(f"sour{'{0}'}:dc:mark:pstart {self._triggers[str(trigger)].value}")
-        else:
-            channel.write_channel(f"sour{'{0}'}:dc:mark:sstart {self._triggers[str(trigger)].value}")
+        self._set_dc_marker(channel_id, "SSTart" if step else "PSTart", str(trigger))
 
     def set_end_marker_internal_trigger(self, channel_id: ChannelID, trigger: str, step: bool = False):
         """Method to create an internal trigger at the start of every dc_list period.
@@ -448,18 +401,7 @@ class QDevilQDac2(VoltageSource):
             raise ValueError(
                 f"No DC list with the given channel ID, first create a DC list with channel ID: {channel_id}"
             )
-        if str(trigger) in self._triggers.keys():
-            self.clear_trigger(trigger)
-
-        self._triggers[str(trigger)] = self.allocate_internal_trigger(
-            self._cache_dc[f"{self.device.name}_{channel_id}"]
-        )
-
-        channel = self.device.channel(channel_id)
-        if not step:
-            channel.write_channel(f"sour{'{0}'}:dc:mark:pend {self._triggers[str(trigger)].value}")
-        else:
-            channel.write_channel(f"sour{'{0}'}:dc:mark:send {self._triggers[str(trigger)].value}")
+        self._set_dc_marker(channel_id, "SEND" if step else "PEND", str(trigger))
 
     def play_awg(self, channel_id: ChannelID | None = None, clear_after: bool = True):
         """Plays a waveform for a given channel id. If no channel id is given, plays all waveforms stored in the cache.
@@ -482,8 +424,9 @@ class QDevilQDac2(VoltageSource):
 
     def start(self):
         """All generators, that have not been explicitly set to trigger on an internal or external trigger, will be started."""
-        for _, awg in self._cache_awg.items():
-            awg.start()
+        for channel_id, awg in self._cache_awg.items():
+            awg_context = self.get_dac(channel_id).arbitrary_wave(awg.name)
+            awg_context.start()
         for _, dc_list in self._cache_dc.items():
             dc_list.start()
         self._cache_awg = {}
@@ -496,11 +439,35 @@ class QDevilQDac2(VoltageSource):
         self._cache_awg = {}
         self._cache_dc = {}
 
+    def _set_dc_marker(self, channel_id: ChannelID, marker_location: str, trigger: str) -> None:
+        """Write a trigger's number to a DC marker register and remember where it was written,
+        so the trigger can later be freed without querying the instrument.
+
+        If this instance already has a trigger with the same name, it is freed first."""
+        if trigger in self._triggers:
+            self.clear_trigger(trigger)
+
+        self._triggers[trigger] = self.allocate_internal_trigger(self._cache_dc[f"{self.device.name}_{channel_id}"])
+
+        channel = self.device.channel(channel_id)
+        channel.write_channel(f"SOUR{'{0}'}:DC:MARK:{marker_location} {self._triggers[trigger].value}")
+        self._marker_registers[trigger] = (channel_id, "DC", marker_location)
+
     def _check_internal_triggers(self):
+        """Rebuild the map of internal triggers in use from the instrument's marker registers.
+
+        Sends one compound SCPI query per channel (instead of one query per marker register)
+        to keep the number of instrument round trips low.
+        """
+        self._internal_triggers = {}
+        registers = list(product(self._GENERATOR_LIST, self._MARKER_LOCATION))
         for channel_id in range(1, self._N_DACS + 1):
-            channel = self.device.channel(channel_id)
-            for generator, marker_location in product(self._GENERATOR_LIST, self._MARKER_LOCATION):
-                internal_trigger = int(channel.ask_channel(f"SOUR{'{0}'}:{generator}:MARK:{marker_location}?"))
+            query = ";:".join(
+                f"SOUR{channel_id}:{generator}:MARK:{marker_location}?" for generator, marker_location in registers
+            )
+            response = self.device.ask(query)
+            for (generator, marker_location), value in zip(registers, response.split(";")):
+                internal_trigger = int(value)
                 if internal_trigger != 0:
                     self._internal_triggers[internal_trigger] = (channel_id, generator, marker_location)
 
@@ -531,13 +498,12 @@ class QDevilQDac2(VoltageSource):
             trigger (optional, str | None): trigger to free, if no name is given it will free all triggers
                                             set in this instance. Defaults to None.
         """
-        self._check_internal_triggers()
-        triggers = {trigger: self._triggers[trigger]} if trigger is not None else self._triggers
-        for name, marker in triggers.items():
-            internal_trigger = marker.value
-            channel_id, generator, marker_location = self._internal_triggers[internal_trigger]
-            channel = self.device.channel(channel_id)
-            internal_trigger = channel.write_channel(f"SOUR{'{0}'}:{generator}:MARK:{marker_location} 0")
+        names = [trigger] if trigger is not None else list(self._triggers)
+        for name in names:
+            register = self._marker_registers.pop(name, None)
+            if register is not None:
+                channel_id, generator, marker_location = register
+                self.device.channel(channel_id).write_channel(f"SOUR{'{0}'}:{generator}:MARK:{marker_location} 0")
             self._triggers.pop(name)
 
     def get_parameter(
@@ -621,6 +587,7 @@ class QDevilQDac2(VoltageSource):
 
     def remove_digital_trace(self):
         self._triggers = {}
+        self._marker_registers = {}
         self.device.remove_traces()
 
     def _validate_channel(self, channel_id: ChannelID | None):

--- a/src/qililab/instruments/qdevil/qdevil_qdac2.py
+++ b/src/qililab/instruments/qdevil/qdevil_qdac2.py
@@ -28,7 +28,7 @@ from qililab.typings import QDevilQDac2 as QDevilQDac2Driver
 from qililab.waveforms import Waveform
 
 if TYPE_CHECKING:
-    from qcodes_contrib_drivers.drivers.QDevil.QDAC2 import List_Context, Trace_Context
+    from qcodes_contrib_drivers.drivers.QDevil.QDAC2 import Awg_Context, List_Context
 
 
 @InstrumentFactory.register
@@ -48,7 +48,8 @@ class QDevilQDac2(VoltageSource):
     _N_DACS: int = 24
     _N_INT_TRIGGERS: int = 14
     _GENERATOR_LIST: tuple[str, str, str, str, str] = ("DC", "SINe", "SQUare", "TRIangle", "AWG")
-    _MARKER_LOCATION: tuple[str, str, str, str, str, str] = ("STARt", "END", "PSTart", "PEND", "SSTart", "SEND")
+    _MARKER_LOCATION: tuple[str, str, str, str] = ("STARt", "END", "PSTart", "PEND")
+    _DC_MARKER_LOCATION: tuple[str, str] = ("SSTart", "SEND")
 
     @dataclass
     class QDevilQDac2Settings(VoltageSource.VoltageSourceSettings):
@@ -65,13 +66,15 @@ class QDevilQDac2(VoltageSource):
 
     def __init__(self, settings: dict) -> None:
         super().__init__(settings=settings)
-        self._cache_awg: dict[int | str, Trace_Context] = {}
+        self._cache_awg: dict[int | str, Awg_Context] = {}
         self._cache_dc: dict[int | str, List_Context] = {}
         self._triggers: dict[str, QDac2Trigger_Context] = {}
 
-        self._internal_triggers: dict = {}
+        self._internal_triggers: dict[int, tuple[int, str, str]] = {}
         # marker register each trigger of this instance was written to: (channel_id, generator, marker_location)
         self._marker_registers: dict[str, tuple[ChannelID, str, str]] = {}
+        # cache keys of DC lists armed to start on a trigger; start() must leave these alone
+        self._armed_on_trigger: set[str] = set()
 
     @property
     def low_pass_filter(self):
@@ -210,7 +213,7 @@ class QDevilQDac2(VoltageSource):
             raise ValueError("Waveform amplitudes must be within [-1,1] range.")
         trace = self.device.allocate_trace(channel_id, len(values))
         trace.waveform(values)
-        self._cache_awg[channel_id] = trace
+        self._cache_awg[channel_id] = self.get_dac(channel_id).arbitrary_wave(trace.name)
 
     def upload_voltage_list(
         self,
@@ -264,6 +267,7 @@ class QDevilQDac2(VoltageSource):
                 f"No DC list with the given channel ID, first create a DC list with channel ID: {channel_id}"
             )
         self._cache_dc[f"{self.device.name}_{channel_id}"].start_on_external(in_port)
+        self._armed_on_trigger.add(f"{self.device.name}_{channel_id}")
 
     def set_in_internal_trigger(self, channel_id: ChannelID, trigger: str):
         """Method to read an external trigger and start a dc list when the Qdac reads this trigger.
@@ -282,6 +286,7 @@ class QDevilQDac2(VoltageSource):
                 f"No DC list with the given channel ID, first create a DC list with channel ID: {channel_id}"
             )
         self._cache_dc[f"{self.device.name}_{channel_id}"].start_on(self._triggers[str(trigger)])
+        self._armed_on_trigger.add(f"{self.device.name}_{channel_id}")
 
     def set_out_external_trigger(self, channel_id: ChannelID, out_port: int, trigger: str, width_s: float = 1e-6):
         """Method to send an external trigger at the start of a sequence.
@@ -424,13 +429,14 @@ class QDevilQDac2(VoltageSource):
 
     def start(self):
         """All generators, that have not been explicitly set to trigger on an internal or external trigger, will be started."""
-        for channel_id, awg in self._cache_awg.items():
-            awg_context = self.get_dac(channel_id).arbitrary_wave(awg.name)
-            awg_context.start()
-        for _, dc_list in self._cache_dc.items():
-            dc_list.start()
+        for _, awg in self._cache_awg.items():
+            awg.start()
+        for key, dc_list in self._cache_dc.items():
+            if key not in self._armed_on_trigger:
+                dc_list.start()
         self._cache_awg = {}
         self._cache_dc = {}
+        self._armed_on_trigger = set()
         # TODO: add synchronous multiple qdac interaction using QDAC2_Array and qdacs.sync (https://qcodes.github.io/Qcodes_contrib_drivers/examples/QDevil/QDAC2/SyncMultipleQDACs.html)
 
     def clear_cache(self):
@@ -438,6 +444,7 @@ class QDevilQDac2(VoltageSource):
         self.device.remove_traces()
         self._cache_awg = {}
         self._cache_dc = {}
+        self._armed_on_trigger = set()
 
     def _set_dc_marker(self, channel_id: ChannelID, marker_location: str, trigger: str) -> None:
         """Write a trigger's number to a DC marker register and remember where it was written,
@@ -447,13 +454,13 @@ class QDevilQDac2(VoltageSource):
         if trigger in self._triggers:
             self.clear_trigger(trigger)
 
-        self._triggers[trigger] = self.allocate_internal_trigger(self._cache_dc[f"{self.device.name}_{channel_id}"])
+        self._triggers[trigger] = self.allocate_internal_trigger()
 
         channel = self.device.channel(channel_id)
         channel.write_channel(f"SOUR{'{0}'}:DC:MARK:{marker_location} {self._triggers[trigger].value}")
         self._marker_registers[trigger] = (channel_id, "DC", marker_location)
 
-    def _check_internal_triggers(self):
+    def _check_internal_triggers(self) -> None:
         """Rebuild the map of internal triggers in use from the instrument's marker registers.
 
         Sends one compound SCPI query per channel (instead of one query per marker register)
@@ -461,6 +468,7 @@ class QDevilQDac2(VoltageSource):
         """
         self._internal_triggers = {}
         registers = list(product(self._GENERATOR_LIST, self._MARKER_LOCATION))
+        registers += list(product(("DC",), self._DC_MARKER_LOCATION))
         for channel_id in range(1, self._N_DACS + 1):
             query = ";:".join(
                 f"SOUR{channel_id}:{generator}:MARK:{marker_location}?" for generator, marker_location in registers
@@ -471,7 +479,7 @@ class QDevilQDac2(VoltageSource):
                 if internal_trigger != 0:
                     self._internal_triggers[internal_trigger] = (channel_id, generator, marker_location)
 
-    def allocate_internal_trigger(self, qdac_generator: "QDevilQDac2Driver") -> QDac2Trigger_Context:
+    def allocate_internal_trigger(self) -> QDac2Trigger_Context:
         """Allocate an internal trigger
 
         Does not have any effect on the instrument, only the driver.
@@ -489,7 +497,7 @@ class QDevilQDac2(VoltageSource):
         free_int_trigger = set(range(1, self._N_INT_TRIGGERS + 1)) - self._internal_triggers.keys()
         if not free_int_trigger:
             raise ValueError("No free internal triggers")
-        return QDac2Trigger_Context(qdac_generator, min(free_int_trigger))
+        return QDac2Trigger_Context(self.device, min(free_int_trigger))
 
     def clear_trigger(self, trigger: str | None = None) -> None:
         """Free an internal trigger
@@ -556,8 +564,7 @@ class QDevilQDac2(VoltageSource):
             channel = self.device.channel(channel_id)
             channel.dc_constant_V(self.voltage[index])
         self.remove_digital_trace()
-        self._cache_awg = {}
-        self._cache_dc = {}
+        self.clear_cache()
 
     @check_device_initialized
     def turn_off(self):
@@ -567,8 +574,7 @@ class QDevilQDac2(VoltageSource):
             channel.dc_constant_V(0.0)
         self.remove_digital_trace()
         self.device.reset()
-        self._cache_awg = {}
-        self._cache_dc = {}
+        self.clear_cache()
 
     def stop(self):
         """Stop pulse execution"""

--- a/src/qililab/instruments/qdevil/qdevil_qdac2.py
+++ b/src/qililab/instruments/qdevil/qdevil_qdac2.py
@@ -289,11 +289,19 @@ class QDevilQDac2(VoltageSource):
         self._armed_on_trigger.add(f"{self.device.name}_{channel_id}")
 
     def set_out_external_trigger(self, channel_id: ChannelID, out_port: int, trigger: str, width_s: float = 1e-6):
-        """Method to send an external trigger at the start of a sequence.
+        """Send a pulse through an external trigger output port at the start of the channel's DC list.
+
+        Allocates an internal trigger, writes it to the channel's start marker register and routes
+        it to the given external output port.
 
         Args:
-            channel_id (ChannelID): Channel id of the qdac
-            in_port (int): Trigger input port.
+            channel_id (ChannelID): Channel id of the qdac whose DC list emits the trigger.
+            out_port (int): External trigger output port to send the pulse through.
+            trigger (str): Name used to identify the trigger in this instance.
+            width_s (float, optional): Duration in seconds of the trigger pulse. Defaults to 1e-6.
+
+        Raises:
+            ValueError: if no DC list has been uploaded for the given channel id.
         """
 
         self._validate_channel(channel_id=channel_id)
@@ -418,7 +426,7 @@ class QDevilQDac2(VoltageSource):
 
         if channel_id is None:
             for dac in self.dacs:
-                awg_context = self.get_dac(dac).arbitrary_wave(dac)
+                self.get_dac(dac).arbitrary_wave(dac)
             self.device.start_all()
         else:
             self._validate_channel(channel_id=channel_id)
@@ -438,13 +446,6 @@ class QDevilQDac2(VoltageSource):
         self._cache_dc = {}
         self._armed_on_trigger = set()
         # TODO: add synchronous multiple qdac interaction using QDAC2_Array and qdacs.sync (https://qcodes.github.io/Qcodes_contrib_drivers/examples/QDevil/QDAC2/SyncMultipleQDACs.html)
-
-    def clear_cache(self):
-        """Clears the cache of the instrument"""
-        self.device.remove_traces()
-        self._cache_awg = {}
-        self._cache_dc = {}
-        self._armed_on_trigger = set()
 
     def _set_dc_marker(self, channel_id: ChannelID, marker_location: str, trigger: str) -> None:
         """Write a trigger's number to a DC marker register and remember where it was written,
@@ -483,9 +484,6 @@ class QDevilQDac2(VoltageSource):
         """Allocate an internal trigger
 
         Does not have any effect on the instrument, only the driver.
-
-        Args:
-            qdac_generator (QDevilQDac2Driver): QDAC pulse generator such as DC list, AWG, Square...
 
         Raises:
             ValueError: no free triggers
@@ -563,7 +561,6 @@ class QDevilQDac2(VoltageSource):
             index = self.dacs.index(channel_id)
             channel = self.device.channel(channel_id)
             channel.dc_constant_V(self.voltage[index])
-        self.remove_digital_trace()
         self.clear_cache()
 
     @check_device_initialized
@@ -572,8 +569,6 @@ class QDevilQDac2(VoltageSource):
         for channel_id in self.dacs:
             channel = self.device.channel(channel_id)
             channel.dc_constant_V(0.0)
-        self.remove_digital_trace()
-        self.device.reset()
         self.clear_cache()
 
     def stop(self):
@@ -585,14 +580,20 @@ class QDevilQDac2(VoltageSource):
     @check_device_initialized
     def reset(self):
         """Reset instrument. This will affect all channels."""
-        self.clear_trigger()
         self.clear_cache()
+        self.device.remove_traces()
         self.device.reset()
 
-    def remove_digital_trace(self):
+    def clear_cache(self):
+        """Clears the cache of the instrument"""
+        self.clear_trigger()
+        for trace_name in self._cache_awg:
+            self.device.write(f'trac:rem "{trace_name}"')
+        self._cache_awg = {}
+        self._cache_dc = {}
         self._triggers = {}
         self._marker_registers = {}
-        self.device.remove_traces()
+        self._armed_on_trigger = set()
 
     def _validate_channel(self, channel_id: ChannelID | None):
         """Check if channel identifier is valid and in the allowed range."""

--- a/src/qililab/instruments/qdevil/qdevil_qdac2.py
+++ b/src/qililab/instruments/qdevil/qdevil_qdac2.py
@@ -28,7 +28,7 @@ from qililab.typings import QDevilQDac2 as QDevilQDac2Driver
 from qililab.waveforms import Waveform
 
 if TYPE_CHECKING:
-    from qcodes_contrib_drivers.drivers.QDevil.QDAC2 import List_Context
+    from qcodes_contrib_drivers.drivers.QDevil.QDAC2 import List_Context, Trace_Context
 
 
 @InstrumentFactory.register
@@ -65,7 +65,7 @@ class QDevilQDac2(VoltageSource):
 
     def __init__(self, settings: dict) -> None:
         super().__init__(settings=settings)
-        self._cache_awg: dict[int | str, bool] = {}
+        self._cache_awg: dict[int | str, Trace_Context] = {}
         self._cache_dc: dict[int | str, List_Context] = {}
         self._triggers: dict[str, QDac2Trigger_Context] = {}
 
@@ -208,7 +208,7 @@ class QDevilQDac2(VoltageSource):
             raise ValueError("Waveform amplitudes must be within [-1,1] range.")
         trace = self.device.allocate_trace(channel_id, len(values))
         trace.waveform(values)
-        self._cache_awg[channel_id] = True
+        self._cache_awg[channel_id] = trace
 
     def upload_voltage_list(
         self,
@@ -482,9 +482,9 @@ class QDevilQDac2(VoltageSource):
 
     def start(self):
         """All generators, that have not been explicitly set to trigger on an internal or external trigger, will be started."""
-        for awg in self._cache_awg:
+        for _, awg in self._cache_awg.items():
             awg.start()
-        for dc_list in self._cache_dc:
+        for _, dc_list in self._cache_dc.items():
             dc_list.start()
         self._cache_awg = {}
         self._cache_dc = {}
@@ -500,7 +500,7 @@ class QDevilQDac2(VoltageSource):
         for channel_id in range(1, self._N_DACS + 1):
             channel = self.device.channel(channel_id)
             for generator, marker_location in product(self._GENERATOR_LIST, self._MARKER_LOCATION):
-                internal_trigger = channel.ask_channel(f"SOUR{'{0}'}:{generator}:MARK:{marker_location}?")
+                internal_trigger = int(channel.ask_channel(f"SOUR{'{0}'}:{generator}:MARK:{marker_location}?"))
                 if internal_trigger != 0:
                     self._internal_triggers[internal_trigger] = (channel_id, generator, marker_location)
 
@@ -614,7 +614,7 @@ class QDevilQDac2(VoltageSource):
     def reset(self):
         """Reset instrument. This will affect all channels."""
         if self._triggers:
-            for trigger_name in self._triggers.keys():
+            for trigger_name in list(self._triggers.keys()):
                 self.clear_trigger(trigger_name)
         self.clear_cache()
         self.device.reset()

--- a/src/qililab/instruments/qdevil/qdevil_qdac2.py
+++ b/src/qililab/instruments/qdevil/qdevil_qdac2.py
@@ -14,6 +14,7 @@
 
 """QDevil QDAC-II Instrument"""
 
+from copy import deepcopy
 from dataclasses import dataclass
 from itertools import product
 from typing import TYPE_CHECKING
@@ -580,7 +581,7 @@ class QDevilQDac2(VoltageSource):
     def reset(self):
         """Reset instrument. This will affect all channels."""
         if self._triggers:
-            for trigger_name in list(self._triggers.keys()):
+            for trigger_name in deepcopy(self._triggers.keys()):
                 self.clear_trigger(trigger_name)
         self.clear_cache()
         self.device.reset()

--- a/src/qililab/instruments/qdevil/qdevil_qdac2.py
+++ b/src/qililab/instruments/qdevil/qdevil_qdac2.py
@@ -14,7 +14,6 @@
 
 """QDevil QDAC-II Instrument"""
 
-from copy import deepcopy
 from dataclasses import dataclass
 from itertools import product
 from typing import TYPE_CHECKING
@@ -581,7 +580,7 @@ class QDevilQDac2(VoltageSource):
     def reset(self):
         """Reset instrument. This will affect all channels."""
         if self._triggers:
-            for trigger_name in deepcopy(self._triggers.keys()):
+            for trigger_name in list(self._triggers.keys()):
                 self.clear_trigger(trigger_name)
         self.clear_cache()
         self.device.reset()

--- a/src/qililab/platform/platform.py
+++ b/src/qililab/platform/platform.py
@@ -1258,6 +1258,9 @@ class Platform:
                     if isinstance(instrument, QDevilQDac2)
                 }
             )
+            # Start from a clean instrument state before the compiler re-populates it
+            for qdac_instrument in self.qdac_instruments:
+                qdac_instrument.clear_cache()
             out_trigger_qdac = None
             if len(self.qdac_instruments) > 1:
                 out_trigger_qdac = next(
@@ -1372,9 +1375,6 @@ class Platform:
         output: QProgramCompilationOutput,
         debug: bool = False,
     ):
-        if isinstance(output.qdac, QdacCompilationOutput):
-            for qdac_instrument in self.qdac_instruments:
-                qdac_instrument.clear_cache()
         if isinstance(output.qblox, QbloxCompilationOutput):
             self.trigger_runs = 0
             return self._execute_qblox_compilation_output(output=output, debug=debug)

--- a/src/qililab/platform/platform.py
+++ b/src/qililab/platform/platform.py
@@ -1428,6 +1428,10 @@ class Platform:
                 if output.qdac.trigger_position == "front":
                     for qdac in output.qdac.qdacs:
                         qdac.start()
+                # Remove QDAC-II trigger network created in this execution
+                qdac.clear_trigger()
+                # Remove dc / awg generators from the QDAC-II instrument
+                qdac.clear_cache()
             else:
                 for bus_alias in sequences:
                     buses[bus_alias].run()

--- a/src/qililab/platform/platform.py
+++ b/src/qililab/platform/platform.py
@@ -1428,10 +1428,11 @@ class Platform:
                 if output.qdac.trigger_position == "front":
                     for qdac in output.qdac.qdacs:
                         qdac.start()
-                # Remove QDAC-II trigger network created in this execution
-                qdac.clear_trigger()
-                # Remove dc / awg generators from the QDAC-II instrument
-                qdac.clear_cache()
+                for qdac in output.qdac.qdacs:
+                    # Remove QDAC-II trigger network created in this execution
+                    qdac.clear_trigger()
+                    # Remove dc / awg generators from the QDAC-II instrument
+                    qdac.clear_cache()
             else:
                 for bus_alias in sequences:
                     buses[bus_alias].run()

--- a/src/qililab/platform/platform.py
+++ b/src/qililab/platform/platform.py
@@ -1374,7 +1374,7 @@ class Platform:
     ):
         if isinstance(output.qdac, QdacCompilationOutput):
             for qdac_instrument in self.qdac_instruments:
-                qdac_instrument.remove_digital_trace()
+                qdac_instrument.clear_cache()
         if isinstance(output.qblox, QbloxCompilationOutput):
             self.trigger_runs = 0
             return self._execute_qblox_compilation_output(output=output, debug=debug)

--- a/src/qililab/platform/platform.py
+++ b/src/qililab/platform/platform.py
@@ -1429,9 +1429,7 @@ class Platform:
                     for qdac in output.qdac.qdacs:
                         qdac.start()
                 for qdac in output.qdac.qdacs:
-                    # Remove QDAC-II trigger network created in this execution
-                    qdac.clear_trigger()
-                    # Remove dc / awg generators from the QDAC-II instrument
+                    # Remove QDAC-II trigger network and dc / awg generators from the QDAC-II instrument
                     qdac.clear_cache()
             else:
                 for bus_alias in sequences:

--- a/src/qililab/platform/platform.py
+++ b/src/qililab/platform/platform.py
@@ -59,7 +59,6 @@ from qililab.qprogram import (
     Experiment,
     QbloxCompilationOutput,
     QbloxCompiler,
-    QdacCompilationOutput,
     QProgram,
     QProgramCompilationOutput,
 )

--- a/tests/instruments/qdevil/test_qdevil_qdac2.py
+++ b/tests/instruments/qdevil/test_qdevil_qdac2.py
@@ -1,4 +1,5 @@
 import re
+from itertools import product
 from unittest.mock import MagicMock, call
 
 import pytest
@@ -606,6 +607,17 @@ class TestQDevilQDac2:
 
         # without rebuilding _internal_triggers from the instrument this would be 2
         assert qdac._triggers["t1"].value == 1
+
+    def test_allocate_internal_trigger_limit_of_triggers_raises_error(self, qdac: QDevilQDac2):
+        """When the instrument reports every internal trigger as busy, allocation fails."""
+        channel = qdac.device.channel.return_value
+        registers = list(product(qdac._GENERATOR_LIST, qdac._MARKER_LOCATION))[: qdac._N_INT_TRIGGERS]
+        for trigger_number, (generator, location) in enumerate(registers, start=1):
+            channel.write_channel(f"SOUR{{0}}:{generator}:MARK:{location} {trigger_number}")
+
+        with pytest.raises(ValueError, match="No free internal triggers"):
+            qdac.allocate_internal_trigger(MagicMock())
+        assert len(qdac._internal_triggers) == qdac._N_INT_TRIGGERS
 
     def test_stop(self, qdac: QDevilQDac2, waveform: Square):
         channel_id = 4

--- a/tests/instruments/qdevil/test_qdevil_qdac2.py
+++ b/tests/instruments/qdevil/test_qdevil_qdac2.py
@@ -1,6 +1,6 @@
 import re
 from itertools import product
-from unittest.mock import MagicMock, call
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
@@ -580,11 +580,25 @@ class TestQDevilQDac2:
 
     def test_clear_cache(self, qdac: QDevilQDac2):
         """Test clear_cache method"""
-        qdac._cache_awg = {2: True}
-        qdac.clear_cache()
+        qdac._cache_awg = {2: MagicMock(), 4: MagicMock()}
+        qdac._cache_dc = {f"{qdac.device.name}_4": MagicMock()}
+        qdac._triggers = {"t1": MagicMock()}
+        qdac._marker_registers = {"t1": (4, "DC", "PSTart")}
+        qdac._armed_on_trigger = {f"{qdac.device.name}_4"}
+
+        with patch.object(qdac, "clear_trigger", wraps=qdac.clear_trigger) as clear_trigger:
+            qdac.clear_cache()
+
+        # clear_cache frees this instance's triggers on the instrument before wiping the bookkeeping
+        clear_trigger.assert_called_once_with()
+        qdac.device.channel.return_value.write_channel.assert_any_call("SOUR{0}:DC:MARK:PSTart 0")
+        # only this instance's traces are removed from the instrument, by name
+        qdac.device.write.assert_has_calls([call('trac:rem "2"'), call('trac:rem "4"')])
         assert qdac._cache_awg == {}
         assert qdac._cache_dc == {}
-        qdac.device.remove_traces.assert_called_once()
+        assert qdac._triggers == {}
+        assert qdac._marker_registers == {}
+        assert qdac._armed_on_trigger == set()
 
     def test_clear_trigger(self, qdac: QDevilQDac2, waveform: Square):
         """Test clear_trigger method"""

--- a/tests/instruments/qdevil/test_qdevil_qdac2.py
+++ b/tests/instruments/qdevil/test_qdevil_qdac2.py
@@ -45,10 +45,10 @@ def _stateful_qdac_device() -> MagicMock:
 
     def _ask(command: str) -> str:
         values = []
-        for sub_query in command.split(";"):
+        for sub_query in command.split(","):
             key = _find(_segments(sub_query.lstrip(":")))
             values.append(str(markers[key] if key else 0))
-        return ";".join(values)
+        return ",".join(values)
 
     device.ask.side_effect = _ask
     device.channel.return_value.write_channel.side_effect = _write_channel
@@ -95,12 +95,12 @@ def _shared_physical_qdac(n_connections: int = 2):
 
     def _ask(command: str) -> str:
         values = []
-        for sub_query in command.split(";"):
+        for sub_query in command.split(","):
             header = sub_query.lstrip(":")
             cid = int(header.split(":", 1)[0].upper().removeprefix("SOUR"))
             key = _find(cid, _segments(header))
             values.append(str(markers[key] if key else 0))
-        return ";".join(values)
+        return ",".join(values)
 
     devices = []
     for _ in range(n_connections):

--- a/tests/instruments/qdevil/test_qdevil_qdac2.py
+++ b/tests/instruments/qdevil/test_qdevil_qdac2.py
@@ -615,8 +615,9 @@ class TestQDevilQDac2:
         for trigger_number, (generator, location) in enumerate(registers, start=1):
             channel.write_channel(f"SOUR{{0}}:{generator}:MARK:{location} {trigger_number}")
 
+        qdac_generator = MagicMock()
         with pytest.raises(ValueError, match="No free internal triggers"):
-            qdac.allocate_internal_trigger(MagicMock())
+            qdac.allocate_internal_trigger(qdac_generator)
         assert len(qdac._internal_triggers) == qdac._N_INT_TRIGGERS
 
     def test_stop(self, qdac: QDevilQDac2, waveform: Square):

--- a/tests/instruments/qdevil/test_qdevil_qdac2.py
+++ b/tests/instruments/qdevil/test_qdevil_qdac2.py
@@ -9,6 +9,95 @@ from qililab.typings.enums import Parameter
 from qililab.waveforms import Square
 
 
+def _stateful_qdac_device() -> MagicMock:
+    """MagicMock emulating the QDAC-II marker registers.
+
+    qililab discovers busy internal triggers by querying the instrument
+    (`SOUR{0}:<gen>:MARK:<loc>?`), so the mock must remember what was written
+    via `write_channel` and report it back via `ask_channel`. SCPI is
+    case-insensitive and allows abbreviations ("star" == "STARt"), hence the
+    per-segment prefix matching.
+    """
+    device = MagicMock()
+    markers: dict[tuple[str, ...], int] = {}
+
+    def _segments(header: str) -> tuple[str, ...]:
+        return tuple(header.upper().rstrip("?").split(":"))
+
+    def _find(segments):
+        for stored in markers:
+            if len(stored) == len(segments) and all(
+                a.startswith(b) or b.startswith(a) for a, b in zip(stored, segments)
+            ):
+                return stored
+        return None
+
+    def _write_channel(command: str) -> None:
+        header, _, value = command.partition(" ")
+        segments = _segments(header)
+        key = _find(segments) or segments
+        markers[key] = int(value)
+
+    def _ask_channel(command: str) -> int:
+        key = _find(_segments(command))
+        return markers[key] if key else 0  # int 0, so `!= 0` behaves correctly
+
+    channel = device.channel.return_value
+    channel.write_channel.side_effect = _write_channel
+    channel.ask_channel.side_effect = _ask_channel
+    return device
+
+
+def _shared_physical_qdac(n_connections: int = 2):
+    """N driver connections to ONE physical QDAC-II.
+
+    Channel objects and marker registers are shared across connections,
+    keyed per channel, so trigger allocation on one connection is visible
+    to the others via ask_channel — just like real hardware.
+    """
+    markers: dict[tuple[int, tuple[str, ...]], int] = {}
+    channels: dict[int, MagicMock] = {}
+
+    def _segments(header: str) -> tuple[str, ...]:
+        return tuple(header.upper().rstrip("?").split(":"))
+
+    def _find(cid: int, segments: tuple[str, ...]):
+        for key in markers:
+            stored_cid, stored = key
+            if stored_cid == cid and len(stored) == len(segments) and all(
+                a.startswith(b) or b.startswith(a) for a, b in zip(stored, segments)
+            ):
+                return key
+        return None
+
+    def _get_channel(channel_id) -> MagicMock:
+        cid = int(channel_id)
+        if cid not in channels:
+            ch = MagicMock()
+
+            def _write(command: str, _cid=cid) -> None:
+                header, _, value = command.partition(" ")
+                key = _find(_cid, _segments(header)) or (_cid, _segments(header))
+                markers[key] = int(value)
+
+            def _ask(command: str, _cid=cid) -> int:
+                key = _find(_cid, _segments(command))
+                return markers[key] if key else 0
+
+            ch.write_channel.side_effect = _write
+            ch.ask_channel.side_effect = _ask
+            channels[cid] = ch
+        return channels[cid]
+
+    devices = []
+    for _ in range(n_connections):
+        device = MagicMock()
+        device.name = "qdac_shared"  # one physical instrument, one name
+        device.channel.side_effect = _get_channel
+        devices.append(device)
+    return devices, channels
+
+
 @pytest.fixture(name="qdac")
 def fixture_qdac() -> QDevilQDac2:
     """Fixture that returns an instance of a dummy QDAC-II."""
@@ -23,7 +112,25 @@ def fixture_qdac() -> QDevilQDac2:
             "low_pass_filter": ["dc", "dc", "dc", "dc"],
         }
     )
-    qdac.device = MagicMock()
+    qdac.device = _stateful_qdac_device()
+    return qdac
+
+
+@pytest.fixture(name="qdac_2")
+def fixture_qdac_2() -> QDevilQDac2:
+    """Fixture that returns an instance of a dummy QDAC-II."""
+    qdac = QDevilQDac2(
+        {
+            "alias": "qdac_2",
+            "voltage": [0.5, 0.5, 0.5, 0.5],
+            "span": ["low", "low", "low", "low"],
+            "ramping_enabled": [True, True, True, False],
+            "ramp_rate": [0.01, 0.01, 0.01, 0.01],
+            "dacs": [1, 3, 9, 12],
+            "low_pass_filter": ["dc", "dc", "dc", "dc"],
+        }
+    )
+    qdac.device = _stateful_qdac_device()
     return qdac
 
 
@@ -116,6 +223,11 @@ class TestQDevilQDac2:
         qdac.reset()
 
         qdac.device.reset.assert_called_once()
+        assert qdac._triggers == {}          # trigger was actually freed
+        assert qdac._cache_awg == {}
+        assert qdac._cache_dc == {}
+        # reset released the marker on the instrument
+        qdac.device.channel.return_value.write_channel.assert_any_call("SOUR{0}:DC:MARK:PSTart 0")
 
     def test_get_dac(self, qdac: QDevilQDac2):
         """Test get_dac method"""
@@ -130,7 +242,9 @@ class TestQDevilQDac2:
         channel_id = 4
         qdac.upload_awg_waveform(waveform, channel_id)
         qdac.device.allocate_trace.assert_called_once_with(channel_id, len(waveform.envelope()))
-        assert qdac._cache_awg == {4: True}
+        assert qdac._cache_awg == {channel_id: qdac.device.allocate_trace.return_value}
+        # the waveform data was actually pushed to the trace
+        qdac.device.allocate_trace.return_value.waveform.assert_called_once_with(list(waveform.envelope()))
 
     def test_upload_awg_waveform_fails_overwrite_cache(self, qdac: QDevilQDac2, waveform: Square):
         """Test that upload waveform raises an error when trying to allocate a waveform to an already allocated channel id"""
@@ -230,9 +344,10 @@ class TestQDevilQDac2:
         qdac.set_out_external_trigger(channel_id, out_port, trigger)
         qdac.device.connect_external_trigger.assert_called_once()
 
-        # Same test for reset trigger
+        # Second call clears the old trigger before re-allocating
         qdac.set_out_external_trigger(channel_id, out_port, trigger)
-        qdac.device.free_trigger.assert_called_once()
+        qdac.device.channel.return_value.write_channel.assert_any_call("SOUR{0}:DC:MARK:STARt 0")
+        assert qdac.device.connect_external_trigger.call_count == 2
 
     def test_set_out_external_trigger_no_cache_raises_error(self, qdac: QDevilQDac2, waveform: Square):
         """Test set_out_external_trigger method raises error when no DC list is created"""
@@ -251,10 +366,13 @@ class TestQDevilQDac2:
         """Test set_out_internal_trigger method"""
         channel_id = 4
         trigger = "trigger_test"
-        qdac._triggers = {"trigger_test": "test_free_trigger"}
         qdac.upload_voltage_list(waveform, channel_id)
         qdac.set_out_internal_trigger(channel_id, trigger)
-        qdac.device.free_trigger.assert_called_once()
+        assert qdac._triggers[trigger].value == 1
+
+        # Second call clears the old trigger before re-allocating
+        qdac.set_out_internal_trigger(channel_id, trigger)
+        qdac.device.channel.return_value.write_channel.assert_any_call("SOUR{0}:DC:MARK:STARt 0")
 
     def test_set_out_internal_trigger_no_cache_raises_error(self, qdac: QDevilQDac2, waveform: Square):
         """Test set_out_internal_trigger method raises error when no DC list is created"""
@@ -270,25 +388,26 @@ class TestQDevilQDac2:
 
     def test_set_end_marker_external_trigger(self, qdac: QDevilQDac2, waveform: Square):
         """Test upload_waveform method"""
-        channel_id = 4
-        out_port = 1
-        trigger = "trigger_test"
-        qdac._triggers = {"trigger_test": "test_free_trigger"}
+        channel_id, out_port, trigger = 4, 1, "trigger_test"
         qdac.upload_voltage_list(waveform, channel_id)
         qdac.set_end_marker_external_trigger(channel_id, out_port, trigger)
         qdac.device.connect_external_trigger.assert_called_once()
-        qdac.device.free_trigger.assert_called_once()
+
+        qdac.set_end_marker_external_trigger(channel_id, out_port, trigger, step=True)
+        qdac.device.channel.return_value.write_channel.assert_any_call("SOUR{0}:DC:MARK:PEND 0")
+        assert qdac.device.connect_external_trigger.call_count == 2
 
     def test_set_end_marker_external_trigger_stepped(self, qdac: QDevilQDac2, waveform: Square):
         """Test upload_waveform method"""
         channel_id = 4
         out_port = 1
         trigger = "trigger_test"
-        qdac._triggers = {"trigger_test": "test_free_trigger"}
         qdac.upload_voltage_list(waveform, channel_id)
         qdac.set_end_marker_external_trigger(channel_id, out_port, trigger, step=True)
         qdac.device.connect_external_trigger.assert_called_once()
-        qdac.device.free_trigger.assert_called_once()
+        qdac.device.channel.return_value.write_channel.assert_any_call(
+            f"sour{{0}}:dc:mark:send {qdac._triggers[trigger].value}"
+        )
 
     def test_set_end_marker_external_trigger_no_cache_raises_error(self, qdac: QDevilQDac2, waveform: Square):
         """Test upload_waveform method"""
@@ -308,14 +427,14 @@ class TestQDevilQDac2:
         channel_id = 4
         out_port = 1
         trigger = "trigger_test"
-        qdac._triggers = {}
         qdac.upload_voltage_list(waveform, channel_id)
         qdac.set_start_marker_external_trigger(channel_id, out_port, trigger)
-
         qdac.device.connect_external_trigger.assert_called_once()
 
+        # step=True re-call: old PSTart marker is released, SSTart is set
         qdac.set_start_marker_external_trigger(channel_id, out_port, trigger, step=True)
-        qdac.device.free_trigger.assert_called_once()
+        qdac.device.channel.return_value.write_channel.assert_any_call("SOUR{0}:DC:MARK:PSTart 0")
+        assert qdac.device.connect_external_trigger.call_count == 2
 
     def test_set_start_marker_external_trigger_no_cache_raises_error(self, qdac: QDevilQDac2, waveform: Square):
         """Test upload_waveform method"""
@@ -334,14 +453,12 @@ class TestQDevilQDac2:
         """Test upload_waveform method"""
         channel_id = 4
         trigger = "trigger_test"
-        qdac._triggers = {}
         qdac.upload_voltage_list(waveform, channel_id)
         qdac.set_end_marker_internal_trigger(channel_id, trigger)
-
-        qdac.device.channel(channel_id).write_channel.assert_called_once()
+        qdac.device.channel.return_value.write_channel.assert_called_once()
 
         qdac.set_end_marker_internal_trigger(channel_id, trigger, step=True)
-        qdac.device.free_trigger.assert_called_once()
+        qdac.device.channel.return_value.write_channel.assert_any_call("SOUR{0}:DC:MARK:PEND 0")
 
     def test_set_end_marker_internal_trigger_no_cache_raises_error(self, qdac: QDevilQDac2, waveform: Square):
         """Test upload_waveform method"""
@@ -359,14 +476,12 @@ class TestQDevilQDac2:
         """Test upload_waveform method"""
         channel_id = 4
         trigger = "trigger_test"
-        qdac._triggers = {}
         qdac.upload_voltage_list(waveform, channel_id)
         qdac.set_start_marker_internal_trigger(channel_id, trigger)
-
-        qdac.device.channel(channel_id).write_channel.assert_called_once()
+        qdac.device.channel.return_value.write_channel.assert_called_once()
 
         qdac.set_start_marker_internal_trigger(channel_id, trigger, step=True)
-        qdac.device.free_trigger.assert_called_once()
+        qdac.device.channel.return_value.write_channel.assert_any_call("SOUR{0}:DC:MARK:PSTart 0")
 
     def test_set_start_marker_internal_trigger_no_cache_raises_error(self, qdac: QDevilQDac2, waveform: Square):
         """Test upload_waveform method"""
@@ -407,7 +522,7 @@ class TestQDevilQDac2:
         channel_id = 4
         trigger = "trigger_test"
         qdac._cache_dc = {}
-        qdac._triggers = {"trigger_test": "test_free_trigger"}
+        qdac._triggers = {"trigger_test": MagicMock()}  # exists, so we reach the cache check
 
         with pytest.raises(
             ValueError,
@@ -415,9 +530,19 @@ class TestQDevilQDac2:
         ):
             qdac.set_in_internal_trigger(channel_id, trigger)
 
-    def test_start(self, qdac: QDevilQDac2):
+    def test_start(self, qdac: QDevilQDac2, waveform: Square):
+        channel_id = 4
+        qdac.upload_awg_waveform(waveform, channel_id)
+        qdac.upload_voltage_list(waveform, channel_id)
+        trace = qdac._cache_awg[channel_id]
+        dc_list = qdac._cache_dc[f"{qdac.device.name}_{channel_id}"]
+
         qdac.start()
-        qdac.device.start_all()
+
+        trace.start.assert_called_once()
+        dc_list.start.assert_called_once()
+        assert qdac._cache_awg == {}
+        assert qdac._cache_dc == {}
 
     def test_clear_cache(self, qdac: QDevilQDac2):
         """Test clear_cache method"""
@@ -430,17 +555,15 @@ class TestQDevilQDac2:
     def test_clear_trigger(self, qdac: QDevilQDac2, waveform: Square):
         """Test clear_trigger method"""
         qdac.clear_trigger()
-        qdac.device.free_all_triggers.assert_called_once()
 
         # Creating test trigger
-        channel_id = 4
-        trigger = "trigger_test"
-        qdac._triggers = {}
+        channel_id, trigger = 4, "trigger_test"
         qdac.upload_voltage_list(waveform, channel_id)
         qdac.set_end_marker_internal_trigger(channel_id, trigger)
 
-        qdac.clear_trigger("trigger_test")
-        qdac.device.free_all_triggers.assert_called_once()
+        qdac.clear_trigger(trigger)
+        assert qdac._triggers == {}
+        qdac.device.channel.return_value.write_channel.assert_any_call("SOUR{0}:DC:MARK:PEND 0")
 
     def test_stop(self, qdac: QDevilQDac2, waveform: Square):
         channel_id = 4
@@ -535,3 +658,57 @@ class TestQDevilQDac2:
         """Test the _validate_channel method raises an exception with wrong parameters"""
         with pytest.raises(ValueError):
             qdac._validate_channel(channel_id)
+
+    def test_qdac_to_qdac_consecutive_execution(self, qdac: QDevilQDac2, qdac_2: QDevilQDac2, waveform: Square):
+        """qdac emits on out port 1; qdac_2 starts its DC list on in port 1."""
+        qdac.device.name = "qdac"
+        qdac_2.device.name = "qdac_2"
+
+        qdac.upload_voltage_list(waveform, channel_id=4)
+        qdac.set_out_external_trigger(channel_id=4, out_port=1, trigger="sync")
+        qdac.device.connect_external_trigger.assert_called_once()
+
+        qdac_2.upload_voltage_list(waveform, channel_id=3)
+        qdac_2.set_in_external_trigger(channel_id=3, in_port=1)
+        qdac_2._cache_dc["qdac_2_3"].start_on_external.assert_called_once_with(1)
+
+    def test_two_users_shared_qdac_trigger_pool(self, qdac: QDevilQDac2, qdac_2: QDevilQDac2, waveform: Square):
+        """Two connections to one physical QDAC: the second user sees the first
+        user's allocated internal trigger and gets the next free one."""
+        devices, channels = _shared_physical_qdac(2)
+        qdac.device, qdac_2.device = devices
+
+        # User 1: DC list + start marker on channel 4
+        qdac.upload_voltage_list(waveform, channel_id=4)
+        qdac.set_start_marker_internal_trigger(channel_id=4, trigger="t1")
+
+        # User 2: same flow on channel 3 — scan finds trigger 1 busy, allocates 2
+        qdac_2.upload_voltage_list(waveform, channel_id=3)
+        qdac_2.set_start_marker_internal_trigger(channel_id=3, trigger="t1")
+
+        assert qdac._triggers["t1"].value == 1
+        assert qdac_2._triggers["t1"].value == 2
+
+        # Each user's DC list is independent
+        dc_list_1 = qdac._cache_dc["qdac_shared_4"]
+        dc_list_2 = qdac_2._cache_dc["qdac_shared_3"]
+        assert dc_list_1 is not dc_list_2
+
+        # User 1 starts; user 2's list must not run
+        qdac.start()
+        dc_list_1.start.assert_called_once()
+        dc_list_2.start.assert_not_called()
+        assert qdac._cache_dc == {}
+        assert set(qdac_2._cache_dc) == {"qdac_shared_3"}
+
+        qdac_2.start()
+        dc_list_2.start.assert_called_once()
+
+        # User 1 frees their trigger: only channel 4's register is zeroed
+        qdac.clear_trigger("t1")
+        assert "t1" not in qdac._triggers
+        assert "t1" in qdac_2._triggers
+        ch3_writes = [c.args[0] for c in channels[3].write_channel.call_args_list]
+        ch4_writes = [c.args[0] for c in channels[4].write_channel.call_args_list]
+        assert any(w.upper().startswith("SOUR{0}:DC:MARK:PSTART 0") for w in ch4_writes)
+        assert not any(w.endswith(" 0") for w in ch3_writes)

--- a/tests/instruments/qdevil/test_qdevil_qdac2.py
+++ b/tests/instruments/qdevil/test_qdevil_qdac2.py
@@ -12,17 +12,21 @@ from qililab.waveforms import Square
 def _stateful_qdac_device() -> MagicMock:
     """MagicMock emulating the QDAC-II marker registers.
 
-    qililab discovers busy internal triggers by querying the instrument
-    (`SOUR{0}:<gen>:MARK:<loc>?`), so the mock must remember what was written
-    via `write_channel` and report it back via `ask_channel`. SCPI is
-    case-insensitive and allows abbreviations ("star" == "STARt"), hence the
-    per-segment prefix matching.
+    qililab discovers busy internal triggers with one compound SCPI query per
+    channel (`SOUR<n>:<gen>:MARK:<loc>?;:...` via `device.ask`), so the mock
+    must remember what was written via `write_channel` and report it back.
+    SCPI is case-insensitive and allows abbreviations ("star" == "STARt"),
+    hence the per-segment prefix matching. `device.channel` returns a single
+    shared mock, so the channel number in the first segment is normalized away.
     """
     device = MagicMock()
     markers: dict[tuple[str, ...], int] = {}
 
     def _segments(header: str) -> tuple[str, ...]:
-        return tuple(header.upper().rstrip("?").split(":"))
+        parts = header.upper().rstrip("?").split(":")
+        if parts[0].startswith("SOUR"):
+            parts[0] = "SOUR"  # SOUR{0} and SOUR<n> address the same shared channel mock
+        return tuple(parts)
 
     def _find(segments):
         for stored in markers:
@@ -38,13 +42,15 @@ def _stateful_qdac_device() -> MagicMock:
         key = _find(segments) or segments
         markers[key] = int(value)
 
-    def _ask_channel(command: str) -> int:
-        key = _find(_segments(command))
-        return markers[key] if key else 0  # int 0, so `!= 0` behaves correctly
+    def _ask(command: str) -> str:
+        values = []
+        for sub_query in command.split(";"):
+            key = _find(_segments(sub_query.lstrip(":")))
+            values.append(str(markers[key] if key else 0))
+        return ";".join(values)
 
-    channel = device.channel.return_value
-    channel.write_channel.side_effect = _write_channel
-    channel.ask_channel.side_effect = _ask_channel
+    device.ask.side_effect = _ask
+    device.channel.return_value.write_channel.side_effect = _write_channel
     return device
 
 
@@ -53,13 +59,15 @@ def _shared_physical_qdac(n_connections: int = 2):
 
     Channel objects and marker registers are shared across connections,
     keyed per channel, so trigger allocation on one connection is visible
-    to the others via ask_channel — just like real hardware.
+    to the others via the compound `device.ask` scan — just like real hardware.
     """
     markers: dict[tuple[int, tuple[str, ...]], int] = {}
     channels: dict[int, MagicMock] = {}
 
     def _segments(header: str) -> tuple[str, ...]:
-        return tuple(header.upper().rstrip("?").split(":"))
+        parts = header.upper().rstrip("?").split(":")
+        parts[0] = "SOUR"  # channel number is carried separately, as the key's first element
+        return tuple(parts)
 
     def _find(cid: int, segments: tuple[str, ...]):
         for key in markers:
@@ -80,20 +88,25 @@ def _shared_physical_qdac(n_connections: int = 2):
                 key = _find(_cid, _segments(header)) or (_cid, _segments(header))
                 markers[key] = int(value)
 
-            def _ask(command: str, _cid=cid) -> int:
-                key = _find(_cid, _segments(command))
-                return markers[key] if key else 0
-
             ch.write_channel.side_effect = _write
-            ch.ask_channel.side_effect = _ask
             channels[cid] = ch
         return channels[cid]
+
+    def _ask(command: str) -> str:
+        values = []
+        for sub_query in command.split(";"):
+            header = sub_query.lstrip(":")
+            cid = int(header.split(":", 1)[0].upper().removeprefix("SOUR"))
+            key = _find(cid, _segments(header))
+            values.append(str(markers[key] if key else 0))
+        return ";".join(values)
 
     devices = []
     for _ in range(n_connections):
         device = MagicMock()
         device.name = "qdac_shared"  # one physical instrument, one name
         device.channel.side_effect = _get_channel
+        device.ask.side_effect = _ask
         devices.append(device)
     return devices, channels
 
@@ -406,7 +419,7 @@ class TestQDevilQDac2:
         qdac.set_end_marker_external_trigger(channel_id, out_port, trigger, step=True)
         qdac.device.connect_external_trigger.assert_called_once()
         qdac.device.channel.return_value.write_channel.assert_any_call(
-            f"sour{{0}}:dc:mark:send {qdac._triggers[trigger].value}"
+            f"SOUR{{0}}:DC:MARK:SEND {qdac._triggers[trigger].value}"
         )
 
     def test_set_end_marker_external_trigger_no_cache_raises_error(self, qdac: QDevilQDac2, waveform: Square):
@@ -539,7 +552,10 @@ class TestQDevilQDac2:
 
         qdac.start()
 
-        trace.start.assert_called_once()
+        # the cached trace is wrapped in an AWG generator and started
+        channel = qdac.device.channel.return_value
+        channel.arbitrary_wave.assert_called_once_with(trace.name)
+        channel.arbitrary_wave.return_value.start.assert_called_once()
         dc_list.start.assert_called_once()
         assert qdac._cache_awg == {}
         assert qdac._cache_dc == {}
@@ -564,6 +580,32 @@ class TestQDevilQDac2:
         qdac.clear_trigger(trigger)
         assert qdac._triggers == {}
         qdac.device.channel.return_value.write_channel.assert_any_call("SOUR{0}:DC:MARK:PEND 0")
+
+    def test_clear_trigger_no_argument_clears_all_triggers(self, qdac: QDevilQDac2, waveform: Square):
+        """clear_trigger() without a name frees every trigger of this instance (the platform cleanup path)."""
+        qdac.upload_voltage_list(waveform, channel_id=4)
+        qdac.upload_voltage_list(waveform, channel_id=2)
+        qdac.set_start_marker_internal_trigger(channel_id=4, trigger="t1")
+        qdac.set_end_marker_internal_trigger(channel_id=2, trigger="t2")
+        assert len(qdac._triggers) == 2
+
+        qdac.clear_trigger()
+
+        assert qdac._triggers == {}
+        qdac.device.channel.return_value.write_channel.assert_any_call("SOUR{0}:DC:MARK:PSTart 0")
+        qdac.device.channel.return_value.write_channel.assert_any_call("SOUR{0}:DC:MARK:PEND 0")
+
+    def test_internal_trigger_reusable_after_clear(self, qdac: QDevilQDac2, waveform: Square):
+        """A freed internal trigger number is seen as free again on the next allocation."""
+        qdac.upload_voltage_list(waveform, channel_id=4)
+        qdac.set_start_marker_internal_trigger(channel_id=4, trigger="t1")
+        assert qdac._triggers["t1"].value == 1
+
+        qdac.clear_trigger("t1")
+        qdac.set_start_marker_internal_trigger(channel_id=4, trigger="t1")
+
+        # without rebuilding _internal_triggers from the instrument this would be 2
+        assert qdac._triggers["t1"].value == 1
 
     def test_stop(self, qdac: QDevilQDac2, waveform: Square):
         channel_id = 4

--- a/tests/instruments/qdevil/test_qdevil_qdac2.py
+++ b/tests/instruments/qdevil/test_qdevil_qdac2.py
@@ -45,7 +45,7 @@ def _stateful_qdac_device() -> MagicMock:
 
     def _ask(command: str) -> str:
         values = []
-        for sub_query in command.split(","):
+        for sub_query in command.split(";"):
             key = _find(_segments(sub_query.lstrip(":")))
             values.append(str(markers[key] if key else 0))
         return ",".join(values)
@@ -95,7 +95,7 @@ def _shared_physical_qdac(n_connections: int = 2):
 
     def _ask(command: str) -> str:
         values = []
-        for sub_query in command.split(","):
+        for sub_query in command.split(";"):
             header = sub_query.lstrip(":")
             cid = int(header.split(":", 1)[0].upper().removeprefix("SOUR"))
             key = _find(cid, _segments(header))

--- a/tests/instruments/qdevil/test_qdevil_qdac2.py
+++ b/tests/instruments/qdevil/test_qdevil_qdac2.py
@@ -255,10 +255,14 @@ class TestQDevilQDac2:
         """Test upload_waveform method"""
         channel_id = 4
         qdac.upload_awg_waveform(waveform, channel_id)
+        trace = qdac.device.allocate_trace.return_value
         qdac.device.allocate_trace.assert_called_once_with(channel_id, len(waveform.envelope()))
-        assert qdac._cache_awg == {channel_id: qdac.device.allocate_trace.return_value}
         # the waveform data was actually pushed to the trace
-        qdac.device.allocate_trace.return_value.waveform.assert_called_once_with(list(waveform.envelope()))
+        trace.waveform.assert_called_once_with(list(waveform.envelope()))
+        # the trace was wrapped in an AWG generator and cached
+        channel = qdac.device.channel.return_value
+        channel.arbitrary_wave.assert_called_once_with(trace.name)
+        assert qdac._cache_awg == {channel_id: channel.arbitrary_wave.return_value}
 
     def test_upload_awg_waveform_fails_overwrite_cache(self, qdac: QDevilQDac2, waveform: Square):
         """Test that upload waveform raises an error when trying to allocate a waveform to an already allocated channel id"""
@@ -548,18 +552,31 @@ class TestQDevilQDac2:
         channel_id = 4
         qdac.upload_awg_waveform(waveform, channel_id)
         qdac.upload_voltage_list(waveform, channel_id)
-        trace = qdac._cache_awg[channel_id]
+        awg = qdac._cache_awg[channel_id]
         dc_list = qdac._cache_dc[f"{qdac.device.name}_{channel_id}"]
 
         qdac.start()
 
-        # the cached trace is wrapped in an AWG generator and started
-        channel = qdac.device.channel.return_value
-        channel.arbitrary_wave.assert_called_once_with(trace.name)
-        channel.arbitrary_wave.return_value.start.assert_called_once()
+        awg.start.assert_called_once()
         dc_list.start.assert_called_once()
         assert qdac._cache_awg == {}
         assert qdac._cache_dc == {}
+
+    def test_start_skips_trigger_armed_lists(self, qdac: QDevilQDac2, waveform: Square):
+        """start() must not start (or re-trigger) DC lists armed to wait on a trigger."""
+        qdac.upload_voltage_list(waveform, channel_id=4)
+        qdac.upload_voltage_list(waveform, channel_id=2)
+        # the shared device mock returns one channel object for all ids — give each entry its own mock
+        armed = qdac._cache_dc[f"{qdac.device.name}_4"] = MagicMock()
+        plain = qdac._cache_dc[f"{qdac.device.name}_2"] = MagicMock()
+        qdac.set_in_external_trigger(channel_id=4, in_port=1)
+
+        qdac.start()
+
+        armed.start.assert_not_called()
+        armed.start_on_external.assert_called_once_with(1)
+        plain.start.assert_called_once()
+        assert qdac._armed_on_trigger == set()
 
     def test_clear_cache(self, qdac: QDevilQDac2):
         """Test clear_cache method"""
@@ -615,9 +632,8 @@ class TestQDevilQDac2:
         for trigger_number, (generator, location) in enumerate(registers, start=1):
             channel.write_channel(f"SOUR{{0}}:{generator}:MARK:{location} {trigger_number}")
 
-        qdac_generator = MagicMock()
         with pytest.raises(ValueError, match="No free internal triggers"):
-            qdac.allocate_internal_trigger(qdac_generator)
+            qdac.allocate_internal_trigger()
         assert len(qdac._internal_triggers) == qdac._N_INT_TRIGGERS
 
     def test_stop(self, qdac: QDevilQDac2, waveform: Square):

--- a/tests/platform/test_platform.py
+++ b/tests/platform/test_platform.py
@@ -798,7 +798,7 @@ class TestPlatform:
         assert platform.get_parameter(alias="drive_line_q0_bus", parameter=Parameter.EXPONENTIAL_TIME_CONSTANT_0, output_id=0) == 200
         assert platform.get_parameter(alias="drive_line_q0_bus", parameter=Parameter.EXPONENTIAL_STATE_0, output_id=0) == "enabled"
         assert platform.get_parameter(alias="drive_line_q0_bus", parameter=Parameter.FIR_COEFF, output_id=0)== [0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4, 0.4]
-        
+
         #  Check that filters marked as delay_comp in the runcard have not been changed
         assert platform.get_parameter(alias="flux_line_q3_bus", parameter=Parameter.EXPONENTIAL_STATE_0, output_id=3) == "delay_comp"
         assert platform.get_parameter(alias="flux_line_q3_bus", parameter=Parameter.EXPONENTIAL_STATE_0) == "delay_comp"
@@ -829,7 +829,7 @@ class TestPlatform:
         """Test that the filter is created if needed"""
         platform_galadriel_no_filter.set_parameter(alias="drive_line_q0_bus", parameter=Parameter.FIR_STATE, value = True, output_id=0)
         assert platform_galadriel_no_filter.get_parameter(alias="drive_line_q0_bus", parameter=Parameter.FIR_STATE, output_id=0) == "enabled"
-        
+
 
     def test_setting_filter_bypassed_give_warning(self, caplog, platform: Platform):
         #  Check that setting a filter as bypassed will actually put/leave it as delay_comp if needed
@@ -1207,7 +1207,7 @@ class TestMethods:
             patch.object(QDevilQDac2, "set_start_marker_external_trigger") as set_start_marker_external_trigger,
             patch.object(QDevilQDac2, "remove_digital_trace") as remove_digital_trace,
             patch.object(QDevilQDac2, "start") as start,
-            patch.object(QDevilQDac2, "_check_internal_triggers") as check_internal_triggers,
+            patch.object(QDevilQDac2, "clear_trigger") as clear_trigger,
             patch.object(QDevilQDac2, "clear_cache") as clear_cache,
         ):
             acquire_qprogram_results.return_value = [123]
@@ -1232,12 +1232,12 @@ class TestMethods:
         assert set_start_marker_external_trigger.call_count == 3  # called as many times as executes
         assert remove_digital_trace.call_count == 3  # called as many times as executes
         assert start.call_count == 3  # called as many times as executes
-        assert check_internal_triggers.call_count == 3  # called as many times as executes
+        assert clear_trigger.call_count == 3  # cleanup after each execution frees this instance's triggers
         assert clear_cache.call_count == 3  # called as many times as executes
 
         # assure only one debug was called
         assert patched_open.call_count == 1
-        
+
     def test_execute_qprogram_with_qblox_and_multiple_qdacs(self, platform_qblox_qdacs: Platform):
         """Test that the execute method compiles the qprogram, calls the buses to run and return the results."""
         drive_wf = IQPair(I=Square(amplitude=1.0, duration=40), Q=Square(amplitude=0.0, duration=40))
@@ -1277,7 +1277,7 @@ class TestMethods:
             patch.object(QDevilQDac2, "set_start_marker_external_trigger") as set_start_marker_external_trigger,
             patch.object(QDevilQDac2, "remove_digital_trace") as remove_digital_trace,
             patch.object(QDevilQDac2, "start") as start,
-            patch.object(QDevilQDac2, "_check_internal_triggers") as check_internal_triggers,
+            patch.object(QDevilQDac2, "clear_trigger") as clear_trigger,
             patch.object(QDevilQDac2, "clear_cache") as clear_cache,
         ):
             acquire_qprogram_results.return_value = [123]
@@ -1304,8 +1304,8 @@ class TestMethods:
         assert set_start_marker_external_trigger.call_count == 3  # called as many times as executes
         assert remove_digital_trace.call_count == 6  # called as many times as executes
         assert start.call_count == 6  # called as many times as executes
-        assert check_internal_triggers.call_count == 3  # called as many times as executes
-        assert clear_cache.call_count == 3  # called as many times as executes
+        assert clear_trigger.call_count == 6  # cleanup after each execution frees each qdac's triggers: 2 qdacs x 3 executes
+        assert clear_cache.call_count == 6  # 2 qdacs x 3 executes
 
         # assure only one debug was called
         assert patched_open.call_count == 1
@@ -1352,7 +1352,7 @@ class TestMethods:
             patch.object(QDevilQDac2, "set_in_external_trigger") as set_in_external_trigger,
             patch.object(QDevilQDac2, "remove_digital_trace") as remove_digital_trace,
             patch.object(QDevilQDac2, "start") as start,
-            patch.object(QDevilQDac2, "_check_internal_triggers") as check_internal_triggers,
+            patch.object(QDevilQDac2, "clear_trigger") as clear_trigger,
             patch.object(QDevilQDac2, "clear_cache") as clear_cache,
         ):
             acquire_qprogram_results.return_value = [123]
@@ -1377,7 +1377,7 @@ class TestMethods:
         assert set_in_external_trigger.call_count == 3  # called as many times as executes
         assert remove_digital_trace.call_count == 3  # called as many times as executes
         assert start.call_count == 3  # called as many times as executes
-        assert check_internal_triggers.call_count == 3  # called as many times as executes
+        assert clear_trigger.call_count == 3  # cleanup after each execution frees this instance's triggers
         assert clear_cache.call_count == 3  # called as many times as executes
 
         # assure only one debug was called
@@ -1412,7 +1412,7 @@ class TestMethods:
             patch.object(QDevilQDac2, "set_in_external_trigger") as set_in_external_trigger,
             patch.object(QDevilQDac2, "remove_digital_trace") as remove_digital_trace,
             patch.object(QDevilQDac2, "start") as start,
-            patch.object(QDevilQDac2, "_check_internal_triggers") as check_internal_triggers,
+            patch.object(QDevilQDac2, "clear_trigger") as clear_trigger,
             patch.object(QDevilQDac2, "clear_cache") as clear_cache,
         ):
             acquire_qprogram_results.return_value = [123]
@@ -1437,12 +1437,12 @@ class TestMethods:
         assert set_in_external_trigger.call_count == 3  # called as many times as executes
         assert remove_digital_trace.call_count == 3  # called as many times as executes
         assert start.call_count == 3  # called as many times as executes
-        assert check_internal_triggers.call_count == 3  # called as many times as executes
+        assert clear_trigger.call_count == 3  # cleanup after each execution frees this instance's triggers
         assert clear_cache.call_count == 3  # called as many times as executes
 
         # assure only one debug was called
         assert patched_open.call_count == 1
-        
+
         assert calibration.crosstalk_matrix == expected_crosstalk
 
     def test_execute_qprogram_single_baseband_channel(self, platform: Platform):
@@ -2126,14 +2126,14 @@ class TestMethods:
         with pytest.raises(ValueError, match=error_string):
             platform.db_save_results(experiment_name, results, loops, qprogram, description)
 
-    @pytest.mark.qm    
+    @pytest.mark.qm
     def test_platform_draw_quantum_machine_raises_error(
         self, qp_quantum_machine: QProgram, platform_quantum_machines: Platform
     ):
 
         with pytest.raises(NotImplementedError) as exc_info:
             platform_quantum_machines.draw(qp_quantum_machine)
-    
+
         assert str(exc_info.value) == "The drawing feature is currently only supported for QBlox."
 
     def test_trigger_network_setup_and_reset(self, platform):
@@ -2252,7 +2252,7 @@ class TestMethods:
 
         with pytest.raises(Exception, match="Filter parameters are controlled using output_id and not channel_id"):
             platform.set_parameter(alias="drive_line_q0_bus", parameter=Parameter.EXPONENTIAL_STATE_0, value="bypassed", channel_id=output_id)
-            
+
         with pytest.raises(Exception, match=f"OutputID {output_id} is not linked to bus with alias {bus_alias}"):
             platform.get_parameter(alias="drive_line_q0_bus", parameter=Parameter.EXPONENTIAL_STATE_0, output_id=output_id)
 

--- a/tests/platform/test_platform.py
+++ b/tests/platform/test_platform.py
@@ -1206,7 +1206,6 @@ class TestMethods:
             patch.object(QDevilQDac2, "upload_voltage_list") as upload_voltage_list,
             patch.object(QDevilQDac2, "set_start_marker_external_trigger") as set_start_marker_external_trigger,
             patch.object(QDevilQDac2, "start") as start,
-            patch.object(QDevilQDac2, "clear_trigger") as clear_trigger,
             patch.object(QDevilQDac2, "clear_cache") as clear_cache,
         ):
             acquire_qprogram_results.return_value = [123]
@@ -1230,7 +1229,6 @@ class TestMethods:
         assert upload_voltage_list.call_count == 3  # called as many times as executes
         assert set_start_marker_external_trigger.call_count == 3  # called as many times as executes
         assert start.call_count == 3  # called as many times as executes
-        assert clear_trigger.call_count == 3  # cleanup after each execution frees this instance's triggers
         assert clear_cache.call_count == 6  # once before and once after each of the 3 executes
 
         # assure only one debug was called
@@ -1274,7 +1272,6 @@ class TestMethods:
             patch.object(QDevilQDac2, "set_in_external_trigger") as set_in_external_trigger,
             patch.object(QDevilQDac2, "set_start_marker_external_trigger") as set_start_marker_external_trigger,
             patch.object(QDevilQDac2, "start") as start,
-            patch.object(QDevilQDac2, "clear_trigger") as clear_trigger,
             patch.object(QDevilQDac2, "clear_cache") as clear_cache,
         ):
             acquire_qprogram_results.return_value = [123]
@@ -1300,7 +1297,6 @@ class TestMethods:
         assert set_in_external_trigger.call_count == 3  # called as many times as executes
         assert set_start_marker_external_trigger.call_count == 3  # called as many times as executes
         assert start.call_count == 6  # called as many times as executes
-        assert clear_trigger.call_count == 6  # cleanup after each execution frees each qdac's triggers: 2 qdacs x 3 executes
         assert clear_cache.call_count == 12  # 2 qdacs x (before + after) x 3 executes
 
         # assure only one debug was called
@@ -1347,7 +1343,6 @@ class TestMethods:
             patch.object(QDevilQDac2, "upload_voltage_list") as upload_voltage_list,
             patch.object(QDevilQDac2, "set_in_external_trigger") as set_in_external_trigger,
             patch.object(QDevilQDac2, "start") as start,
-            patch.object(QDevilQDac2, "clear_trigger") as clear_trigger,
             patch.object(QDevilQDac2, "clear_cache") as clear_cache,
         ):
             acquire_qprogram_results.return_value = [123]
@@ -1371,7 +1366,6 @@ class TestMethods:
         assert upload_voltage_list.call_count == 3  # called as many times as executes
         assert set_in_external_trigger.call_count == 3  # called as many times as executes
         assert start.call_count == 3  # called as many times as executes
-        assert clear_trigger.call_count == 3  # cleanup after each execution frees this instance's triggers
         assert clear_cache.call_count == 6  # once before and once after each of the 3 executes
 
         # assure only one debug was called
@@ -1405,7 +1399,6 @@ class TestMethods:
             patch.object(QDevilQDac2, "upload_voltage_list") as upload_voltage_list,
             patch.object(QDevilQDac2, "set_in_external_trigger") as set_in_external_trigger,
             patch.object(QDevilQDac2, "start") as start,
-            patch.object(QDevilQDac2, "clear_trigger") as clear_trigger,
             patch.object(QDevilQDac2, "clear_cache") as clear_cache,
         ):
             acquire_qprogram_results.return_value = [123]
@@ -1429,7 +1422,6 @@ class TestMethods:
         assert upload_voltage_list.call_count == 3  # called as many times as executes
         assert set_in_external_trigger.call_count == 3  # called as many times as executes
         assert start.call_count == 3  # called as many times as executes
-        assert clear_trigger.call_count == 3  # cleanup after each execution frees this instance's triggers
         assert clear_cache.call_count == 6  # once before and once after each of the 3 executes
 
         # assure only one debug was called

--- a/tests/platform/test_platform.py
+++ b/tests/platform/test_platform.py
@@ -1207,6 +1207,8 @@ class TestMethods:
             patch.object(QDevilQDac2, "set_start_marker_external_trigger") as set_start_marker_external_trigger,
             patch.object(QDevilQDac2, "remove_digital_trace") as remove_digital_trace,
             patch.object(QDevilQDac2, "start") as start,
+            patch.object(QDevilQDac2, "_check_internal_triggers") as check_internal_triggers,
+            patch.object(QDevilQDac2, "clear_cache") as clear_cache,
         ):
             acquire_qprogram_results.return_value = [123]
             first_execution_results = platform_qblox_qdac.execute_qprogram(qprogram=qprogram)
@@ -1230,6 +1232,8 @@ class TestMethods:
         assert set_start_marker_external_trigger.call_count == 3  # called as many times as executes
         assert remove_digital_trace.call_count == 3  # called as many times as executes
         assert start.call_count == 3  # called as many times as executes
+        assert check_internal_triggers.call_count == 3  # called as many times as executes
+        assert clear_cache.call_count == 3  # called as many times as executes
 
         # assure only one debug was called
         assert patched_open.call_count == 1
@@ -1273,6 +1277,8 @@ class TestMethods:
             patch.object(QDevilQDac2, "set_start_marker_external_trigger") as set_start_marker_external_trigger,
             patch.object(QDevilQDac2, "remove_digital_trace") as remove_digital_trace,
             patch.object(QDevilQDac2, "start") as start,
+            patch.object(QDevilQDac2, "_check_internal_triggers") as check_internal_triggers,
+            patch.object(QDevilQDac2, "clear_cache") as clear_cache,
         ):
             acquire_qprogram_results.return_value = [123]
             first_execution_results = platform_qblox_qdacs.execute_qprogram(qprogram=qprogram)
@@ -1298,6 +1304,8 @@ class TestMethods:
         assert set_start_marker_external_trigger.call_count == 3  # called as many times as executes
         assert remove_digital_trace.call_count == 6  # called as many times as executes
         assert start.call_count == 6  # called as many times as executes
+        assert check_internal_triggers.call_count == 3  # called as many times as executes
+        assert clear_cache.call_count == 3  # called as many times as executes
 
         # assure only one debug was called
         assert patched_open.call_count == 1
@@ -1344,6 +1352,8 @@ class TestMethods:
             patch.object(QDevilQDac2, "set_in_external_trigger") as set_in_external_trigger,
             patch.object(QDevilQDac2, "remove_digital_trace") as remove_digital_trace,
             patch.object(QDevilQDac2, "start") as start,
+            patch.object(QDevilQDac2, "_check_internal_triggers") as check_internal_triggers,
+            patch.object(QDevilQDac2, "clear_cache") as clear_cache,
         ):
             acquire_qprogram_results.return_value = [123]
             first_execution_results = platform_qblox_qdac.execute_qprogram(qprogram=qprogram)
@@ -1367,6 +1377,8 @@ class TestMethods:
         assert set_in_external_trigger.call_count == 3  # called as many times as executes
         assert remove_digital_trace.call_count == 3  # called as many times as executes
         assert start.call_count == 3  # called as many times as executes
+        assert check_internal_triggers.call_count == 3  # called as many times as executes
+        assert clear_cache.call_count == 3  # called as many times as executes
 
         # assure only one debug was called
         assert patched_open.call_count == 1
@@ -1400,6 +1412,8 @@ class TestMethods:
             patch.object(QDevilQDac2, "set_in_external_trigger") as set_in_external_trigger,
             patch.object(QDevilQDac2, "remove_digital_trace") as remove_digital_trace,
             patch.object(QDevilQDac2, "start") as start,
+            patch.object(QDevilQDac2, "_check_internal_triggers") as check_internal_triggers,
+            patch.object(QDevilQDac2, "clear_cache") as clear_cache,
         ):
             acquire_qprogram_results.return_value = [123]
             first_execution_results = platform_qblox_qdac.execute_qprogram(qprogram=qprogram, calibration=calibration, crosstalk=False)
@@ -1423,6 +1437,8 @@ class TestMethods:
         assert set_in_external_trigger.call_count == 3  # called as many times as executes
         assert remove_digital_trace.call_count == 3  # called as many times as executes
         assert start.call_count == 3  # called as many times as executes
+        assert check_internal_triggers.call_count == 3  # called as many times as executes
+        assert clear_cache.call_count == 3  # called as many times as executes
 
         # assure only one debug was called
         assert patched_open.call_count == 1

--- a/tests/platform/test_platform.py
+++ b/tests/platform/test_platform.py
@@ -1205,7 +1205,6 @@ class TestMethods:
             # Mock Qdac functions without connecting
             patch.object(QDevilQDac2, "upload_voltage_list") as upload_voltage_list,
             patch.object(QDevilQDac2, "set_start_marker_external_trigger") as set_start_marker_external_trigger,
-            patch.object(QDevilQDac2, "remove_digital_trace") as remove_digital_trace,
             patch.object(QDevilQDac2, "start") as start,
             patch.object(QDevilQDac2, "clear_trigger") as clear_trigger,
             patch.object(QDevilQDac2, "clear_cache") as clear_cache,
@@ -1230,10 +1229,9 @@ class TestMethods:
         assert second_execution_results.results["resonator"] == [456]
         assert upload_voltage_list.call_count == 3  # called as many times as executes
         assert set_start_marker_external_trigger.call_count == 3  # called as many times as executes
-        assert remove_digital_trace.call_count == 3  # called as many times as executes
         assert start.call_count == 3  # called as many times as executes
         assert clear_trigger.call_count == 3  # cleanup after each execution frees this instance's triggers
-        assert clear_cache.call_count == 3  # called as many times as executes
+        assert clear_cache.call_count == 6  # once before and once after each of the 3 executes
 
         # assure only one debug was called
         assert patched_open.call_count == 1
@@ -1275,7 +1273,6 @@ class TestMethods:
             patch.object(QDevilQDac2, "set_out_external_trigger") as set_out_external_trigger,
             patch.object(QDevilQDac2, "set_in_external_trigger") as set_in_external_trigger,
             patch.object(QDevilQDac2, "set_start_marker_external_trigger") as set_start_marker_external_trigger,
-            patch.object(QDevilQDac2, "remove_digital_trace") as remove_digital_trace,
             patch.object(QDevilQDac2, "start") as start,
             patch.object(QDevilQDac2, "clear_trigger") as clear_trigger,
             patch.object(QDevilQDac2, "clear_cache") as clear_cache,
@@ -1302,10 +1299,9 @@ class TestMethods:
         assert set_out_external_trigger.call_count == 3  # called as many times as executes
         assert set_in_external_trigger.call_count == 3  # called as many times as executes
         assert set_start_marker_external_trigger.call_count == 3  # called as many times as executes
-        assert remove_digital_trace.call_count == 6  # called as many times as executes
         assert start.call_count == 6  # called as many times as executes
         assert clear_trigger.call_count == 6  # cleanup after each execution frees each qdac's triggers: 2 qdacs x 3 executes
-        assert clear_cache.call_count == 6  # 2 qdacs x 3 executes
+        assert clear_cache.call_count == 12  # 2 qdacs x (before + after) x 3 executes
 
         # assure only one debug was called
         assert patched_open.call_count == 1
@@ -1350,7 +1346,6 @@ class TestMethods:
             # Mock Qdac functions without connecting
             patch.object(QDevilQDac2, "upload_voltage_list") as upload_voltage_list,
             patch.object(QDevilQDac2, "set_in_external_trigger") as set_in_external_trigger,
-            patch.object(QDevilQDac2, "remove_digital_trace") as remove_digital_trace,
             patch.object(QDevilQDac2, "start") as start,
             patch.object(QDevilQDac2, "clear_trigger") as clear_trigger,
             patch.object(QDevilQDac2, "clear_cache") as clear_cache,
@@ -1375,10 +1370,9 @@ class TestMethods:
         assert second_execution_results.results["resonator"] == [456]
         assert upload_voltage_list.call_count == 3  # called as many times as executes
         assert set_in_external_trigger.call_count == 3  # called as many times as executes
-        assert remove_digital_trace.call_count == 3  # called as many times as executes
         assert start.call_count == 3  # called as many times as executes
         assert clear_trigger.call_count == 3  # cleanup after each execution frees this instance's triggers
-        assert clear_cache.call_count == 3  # called as many times as executes
+        assert clear_cache.call_count == 6  # once before and once after each of the 3 executes
 
         # assure only one debug was called
         assert patched_open.call_count == 1
@@ -1410,7 +1404,6 @@ class TestMethods:
             # Mock Qdac functions without connecting
             patch.object(QDevilQDac2, "upload_voltage_list") as upload_voltage_list,
             patch.object(QDevilQDac2, "set_in_external_trigger") as set_in_external_trigger,
-            patch.object(QDevilQDac2, "remove_digital_trace") as remove_digital_trace,
             patch.object(QDevilQDac2, "start") as start,
             patch.object(QDevilQDac2, "clear_trigger") as clear_trigger,
             patch.object(QDevilQDac2, "clear_cache") as clear_cache,
@@ -1435,10 +1428,9 @@ class TestMethods:
         assert second_execution_results.results["resonator"] == [456]
         assert upload_voltage_list.call_count == 3  # called as many times as executes
         assert set_in_external_trigger.call_count == 3  # called as many times as executes
-        assert remove_digital_trace.call_count == 3  # called as many times as executes
         assert start.call_count == 3  # called as many times as executes
         assert clear_trigger.call_count == 3  # cleanup after each execution frees this instance's triggers
-        assert clear_cache.call_count == 3  # called as many times as executes
+        assert clear_cache.call_count == 6  # once before and once after each of the 3 executes
 
         # assure only one debug was called
         assert patched_open.call_count == 1


### PR DESCRIPTION
Fixed the QDAC-II trigger network breaking when multiple users are connected to the same instrument. Each qililab instance allocated internal trigger numbers from its own driver-side pool, with no way of knowing which numbers other Python processes were already using. When two instances picked the same number, their triggers fired through each other's networks, interfering with both experiments.

  Internal triggers in use are now read directly from the instrument's marker registers before every allocation, so a new trigger always takes the lowest number that is actually free on the hardware. Related behavior changes:
  - `QDevilQDac2.start()` now starts only the DC lists and AWG waveforms uploaded by this instance, instead of `start_all()`, which also fired generators armed by other users.
  - `QDevilQDac2.clear_trigger()` now frees the triggers created by this instance from the instrument (previously `free_all_triggers()` released the triggers set by `QCodes`, not affecting the instrument).
  - `Platform.execute_qprogram` now clears each QDAC-II's trigger network and generator caches after every execution, so consecutive executions always start from a clean trigger state.
  - Allocating a trigger when all 14 internal triggers are busy raises a `ValueError` including other users triggers.