### PR TITLE
Remove stale qibo references from docs and docstrings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,7 +134,6 @@ data/
 _build
 slurm_job_data*
 
-.qibo_configuration
 .tmp/*
 tmp.*
 .tmp/*

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,7 +65,6 @@ html_theme_options = {
     "awesome_external_links": True,
     "main_nav_links": {
         "QaaS": "https://qaas.readthedocs.io/en/latest/",
-        "Qiboconnection": "https://qaas.readthedocs.io/projects/qiboconnection/en/latest/",
         "Qililab": "index",
     },
     "extra_header_link_icons": {

--- a/docs/fundamentals/platform.rst
+++ b/docs/fundamentals/platform.rst
@@ -87,203 +87,24 @@ After building the platform, you need to connect to the instruments, set all the
 
 Executing a circuit with Platform:
 -----------------------------------
-The Platform offers the capability to execute circuits defined with `Qibo <https://qibo.science/>`_, an open-source middleware for quantum computing.
-
-To execute a circuit, you first need to build, connect, and set up the platform as shown in the above examples. Then, define your
-Qibo circuit, for example, a pi pulse and a measurement gate on qubit ``q`` (``int``):
+Once the platform is built, connected and set up, you can execute a circuit defined with ``qilisdk.digital``. For example, a
+pi pulse followed by a measurement gate on qubit ``q`` (``int``):
 
 .. code-block:: python3
 
-    from qibo.models import Circuit
-    from qibo import gates
+    from qilisdk.digital import Circuit, X, M
 
-    circuit = Circuit(q+1)
-    circuit.add(gates.X(q))
-    circuit.add(gates.M(q))
-
-And you are ready to execute the circuit with the platform:
-
->>> result = platform.execute(program=circuit, num_avg=1000, repetition_duration=6000)
->>> result.array
-array([[5.],
-        [5.]])
-
-getting the integrated values of the I/Q signals received by the digitizer!
-
-.. note::
-
-    When disabling scope acquisition mode, the array obtained has shape `(#sequencers, 2, #bins)`. In this case,
-    given that you are using only 1 sequencer to acquire the results, you would obtain an array with shape `(2, #bins)`.
-
-You could also get the results in a more standard format, as already classified ``counts`` or ``probabilities`` dictionaries, with:
-
->>> result.counts
-{'0': 501, '1': 499}
-
->>> result.probabilities
-{'0': .501, '1': .499}
-
-.. note::
-
-    You can find more information about the results, in the :class:`.Results` class documentation.
-
-|
-
-Running a Rabi sweep with Platform:
----------------------------------------
-
-To perform a Rabi sweep, build, connect and set up the platform, and then create a circuit with a
-pi pulse and a measurement gate in qubit ``q`` (``int``), as in the previous examples, which all together look like:
-
-.. code-block:: python
-
-    import qililab as ql
-
-    import numpy as np
-
-    from qibo.models import Circuit
-    from qibo import gates
-
-    # Defining the Rabi circuit:
-    circuit = Circuit(q+1)
-    circuit.add(gates.X(q))
-    circuit.add(gates.M(q))
-
-    # Building the platform:
-    platform = ql.build_platform(runcard="runcards/galadriel.yml")
-
-    # Connecting and setting up the platform:
-    platform.connect()
-    platform.initial_setup()
-    platform.turn_on_instruments()
-
-Now to run the Rabi sweep, you would need to run this sequence by looping over the amplitude of the AWG used
-to create the pi pulse:
-
-.. image:: platform_images/rabi.png
-  :width: 400
-  :align: center
-
-To do this, you need to use the ``set_parameter()`` method with the alias of the bus used
-to drive qubit ``q`` (let's assume it's called ``"drive_q"``):
-
-.. code-block:: python3
-
-    results = []
-    amp_values = [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.9, 1.0]
-
-    for amp in amp_values:
-        platform.set_parameter(alias="drive_q", parameter=ql.Parameter.AMPLITUDE, value=amp)
-        result = platform.execute(program=circuit, num_avg=1000, repetition_duration=6000)
-        results.append(result.array)
-
-And then you can use ``np.hstack`` to stack the obtained results horizontally. By doing this, you would obtain an
-array with shape `(2, N)`, where N is the number of elements inside the loop:
-
->>> results = np.hstack(results)
->>> results
-array([[5, 4, 3, 2, 1, 2, 3, 4, 5, 4, 3],
-        [5, 4, 3, 2, 1, 2, 3, 4, 5, 4, 3]])
-
-You can see how the integrated I/Q values oscillated, indicating that qubit 0 oscillates between ground and
-excited state!
-
-|
-
-A faster Rabi sequence, translating the circuit to pulses:
------------------------------------------------------------
-
-Since you are looping over variables that are independent of the circuit (in this case, the amplitude of the AWG),
-you can speed up the experiment by translating the circuit into pulses only once:
-
-.. code-block:: python3
-
-    from qililab.pulse.circuit_to_pulses import CircuitToPulses
-
-    pulse_schedule = CircuitToPulses(platform=platform).translate(circuits=[circuit])
-
-and then, executing the obtained pulses inside the loop, by passing the translated
-``pulse_schedule`` instead than the ``circuit``, to the ``execute()`` method:
-
-.. code-block:: python3
-
-    results = []
-    amp_values = [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.9, 1.0]
-
-    for amp in amp_values:
-        platform.set_parameter(alias="drive_q", parameter=ql.Parameter.AMPLITUDE, value=amp)
-        result = platform.execute(program=pulse_schedule, num_avg=1000, repetition_duration=6000)
-        results.append(result.array)
-
-This approach yields to similar results, but much faster!
-
->>> results = np.hstack(results)
->>> results
-array([[5, 4, 3, 2, 1, 2, 3, 4, 5, 4, 3],
-        [5, 4, 3, 2, 1, 2, 3, 4, 5, 4, 3]])
-
-|
-
-Ramsey sequence, looping over a parameter inside the circuit:
-----------------------------------------------------------------
-
-To perform a Ramsey sequence, build, connect and setup the platform as before, but this time with a different circuit:
-
-.. code-block:: python
-
-    import qililab as ql
-
-    from qibo.models import Circuit
-    from qibo import gates
-
-    # Defining the Ramsey circuit:
     circuit = Circuit(q + 1)
-    circuit.add(gates.RX(q, theta=np.pi/2))
-    circuit.add(ql.Wait(q, t=0))
-    circuit.add(gates.RX(q, theta=np.pi/2))
-    circuit.add(gates.M(q))
+    circuit.add(X(q))
+    circuit.add(M(q))
 
-    # Building the platform:
-    platform = ql.build_platform(runcard="runcards/galadriel.yml")
+The circuit is transpiled to the platform's native gate set and executed with :meth:`.Platform.execute_circuit`, which
+returns a dictionary of measurement samples:
 
-    # Connecting and setting up the platform:
-    platform.connect()
-    platform.initial_setup()
-    platform.turn_on_instruments()
-
-where you would add two default qibo ``RX`` gates, with a qililab ``Wait`` gate in between, which is just a personalized qibo gate that adds a
-free evolution of duration ``t`` that corresponds to a rotation at the detuning frequency, around the Z axis:
-
-.. image:: platform_images/ramsey_bloch.png
-  :width: 500
-  :align: center
-
-
-To run the Ramsey sequence, you would need to loop over the ``t`` parameter of the ``Wait`` gate. This will produce a
-different `Z` axis height projection for each wait time, resulting in a sinusoidal pattern.
-
-Since the parameter is inside the Qibo circuit, you will need to use Qibo own ``circuit.set_parameters()`` method, putting the parameters
-you want to set in the order they appear in the circuit construction:
+>>> result = platform.execute_circuit(circuit, nshots=1000)
 
 .. note::
-    For more information, please visit the Qibo documentation about `qibo.models.circuit.set_parameter() <https://qibo.science/qibo/stable/api-reference/qibo.html#gates:~:text=circuit%E2%80%99s%20gate%20queue.-,set_parameters,-(parameters)>`_ method.
 
-.. code-block:: python3
+    See :meth:`.Platform.execute_circuit` and :meth:`.Platform.compile_circuit` for the full signature and options, and
+    :ref:`Transpilation <transpilation>` for details on how circuits are transpiled and compiled.
 
-    results = []
-    wait_times = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-
-    for wait in wait_times:
-        circuit.set_parameters([np.pi/2, wait, np.pi/2])
-        result = platform.execute(program=circuit, num_avg=1000, repetition_duration=6000)
-        results.append(result.array)
-
-which for each execution, would set ``np.pi/2`` to the ``theta`` parameters of the ``RX`` gates, and the looped ``wait`` time  to the ``t`` parameter of the
-``Wait`` gate.
-
-And finally, if you print the results, you obtain the sinusoidal expected behaviour!
-
->>> results = np.hstack(results)
->>> results
-array([[5, 4, 3, 2, 1, 2, 3, 4, 5, 4, 3],
-        [5, 4, 3, 2, 1, 2, 3, 4, 5, 4, 3]])

--- a/docs/fundamentals/transpilation.rst
+++ b/docs/fundamentals/transpilation.rst
@@ -3,112 +3,79 @@
 Transpilation
 =============
 
-The transpilation is done automatically, for :meth:`ql.execute()` and :meth:`platform.execute()` methods.
-But it can also be done manually, with more control, directly using the :class:`.CircuitTranspiler` class.
+Transpilation is done automatically when a circuit is compiled or executed through
+:meth:`.Platform.compile_circuit` and :meth:`.Platform.execute_circuit`. It can also be run manually, with more
+control, directly through the :class:`.CircuitTranspiler` class.
 
-The process involves the following steps (by default only: **3.**, **4**., and **6.** run):
+The transpiler runs a linear pipeline of ``CircuitTranspilerPass`` objects. Each pass has a single, narrowly defined
+responsibility, and the circuit is passed from one pass to the next. The default pipeline performs, in order:
 
+1. **Cancel identity pairs:** removes adjacent pairs of Hermitian gates that cancel out (``CancelIdentityPairsPass``).
 
-1. **Routing and Placement:** Routes and places the circuit's logical qubits onto the chip's physical qubits. The final qubit layout is returned and logged. This step uses the ``placer``, ``router``, and ``routing_iterations`` parameters from ``transpilation_config`` if provided; otherwise, default values are applied. Refer to the :meth:`.CircuitTranspiler.route_circuit()` method for more information.
+2. **Canonical basis + single-qubit fusion:** rewrites the circuit into a canonical basis and fuses consecutive
+   single-qubit gates (``CircuitToCanonicalBasisPass``, ``FuseSingleQubitGatesPass``).
 
-2. **1st Optimization:** Canceling adjacent pairs of Hermitian gates (H, X, Y, Z, CNOT, CZ, and SWAPs). Refer to the :meth:`.CircuitTranspiler.optimize_gates()` method for more information.
+3. **Layout and routing:** maps the circuit's logical qubits onto the chip's physical qubits and inserts the SWAPs
+   required by the chip topology. When no explicit ``qubit_mapping`` is given this uses ``SabreLayoutPass`` +
+   ``SabreSwapPass``; when a mapping is given it uses ``CustomLayoutPass``.
 
-3. **Native Gate Translation:** Translates the circuit into the chip's native gate set (CZ, RZ, Drag, Wait, and M (Measurement)). Refer to the :meth:`.CircuitTranspiler.gates_to_native()` method for more information.
+4. **Native gate translation:** translates the routed circuit into the chip's native gate set
+   (``CanonicalBasisToNativeSetPass``).
 
-4. **Adding phases to our Drag gates:** commuting RZ gates until the end of the circuit to discard them as virtual Z gates, and due to the phase corrections from CZ. Refer to the :meth:`.CircuitTranspiler.add_phases_from_RZs_and_CZs_to_drags()` method for more information.
+5. **Drag phase corrections:** commutes RZ gates and applies the phase corrections coming from the CZ gates onto the
+   Drag gates (``AddPhasesToRmwFromRZAndCZPass``).
 
-5. **2nd Optimization:** Optimizing the resulting Drag gates, by combining multiple pulses into a single one. Refer to the :meth:`.CircuitTranspiler.optimize_transpiled_gates()` method for more information.
+The conversion of the transpiled, native-gate circuit into an executable :class:`.QProgram` is performed separately by
+``CircuitToQProgramCompiler`` (invoked by :meth:`.Platform.compile_circuit`).
 
-6. **Pulse Schedule Conversion:** Converts the native gates into a pulse schedule using calibrated settings from the runcard. Refer to the :meth:`.CircuitTranspiler.gates_to_pulses()` method for more information.
+**Example:**
 
-.. note::
-
-    Default steps are only: **3.**, **4**., and **6.**, since they are always needed.
-
-    To do Step **1.** set ``routing=True`` in ``transpilation_config`` (default behavior skips it).
-
-    To do Steps **2.** and **5.** set ``optimize=True`` in ``transpilation_config`` (default behavior skips it).
-
-**Examples:**
-
-For example, the most basic use, would be to automatically transpile during an execute, like:
-
-.. code-block:: python
-
-    from qibo import gates, Circuit
-    from qibo.transpiler import ReverseTraversal, Sabre
-    import qililab as ql
-
-    # Create circuit:
-    c = Circuit(5)
-    c.add(gates.CNOT(1, 0))
-
-    # Create transpilation config:
-    transpilation = {routing: True, optimize: False, router: Sabre, placer: ReverseTraversal}
-
-    # Create transpiler:
-    result = ql.execute(c, runcard="<path_to_runcard>", transpilation_config=transpilation)
-
-Or from a ``platform.execute()`` and using `DigitalTranspilationConfig` for argument hintings instead, like:
+For most use cases, transpilation happens implicitly when you compile or execute a circuit:
 
 .. code-block:: python
 
-    from qibo import gates, Circuit
-    from qibo.transpiler import ReverseTraversal, Sabre
+    from qilisdk.digital import Circuit, RY, CZ, M
     from qililab import build_platform
-    from qililab.digital import DigitalTranspilationConfig
 
-    # Create circuit:
-    c = Circuit(5)
-    c.add(gates.CNOT(1, 0))
+    # Create a circuit:
+    circuit = Circuit(2)
+    circuit.add(RY(0, theta=0.2))
+    circuit.add(CZ(0, 1))
+    circuit.add(M(1))
 
-    # Create platform:
+    # Build the platform and execute (transpilation runs automatically):
     platform = build_platform(runcard="<path_to_runcard>")
-    transpilation = DigitalTranspilationConfig(routing= True, optimize= False, router= Sabre, placer= ReverseTraversal)
+    result = platform.execute_circuit(circuit, nshots=1000)
 
-    # Create transpiler:
-    result = platform.execute(c, num_avg=1000, repetition_duration=200_000, transpilation_config=transpilation)
-
-Now, if we want more manual control instead, we can instantiate the ``CircuitTranspiler`` object like:
+If you want manual control over the transpilation, instantiate a :class:`.CircuitTranspiler` with the platform's
+digital compilation settings and call :meth:`.CircuitTranspiler.run`:
 
 .. code-block:: python
 
-    from qibo import gates
-    from qibo.models import Circuit
-    from qibo.transpiler.placer import ReverseTraversal, Random
-    from qibo.transpiler.router import Sabre
+    from qilisdk.digital import Circuit, RY, CZ, M
     from qililab import build_platform
     from qililab.digital import CircuitTranspiler
 
-    # Create circuit:
-    c = Circuit(5)
-    c.add(gates.CNOT(1, 0))
+    # Create a circuit:
+    circuit = Circuit(2)
+    circuit.add(RY(0, theta=0.2))
+    circuit.add(CZ(0, 1))
+    circuit.add(M(1))
 
-    # Create platform:
+    # Build the platform and transpile:
     platform = build_platform(runcard="<path_to_runcard>")
-
-    # Create transpiler:
     transpiler = CircuitTranspiler(platform.digital_compilation_settings)
 
-And now, transpile manually, like in the following examples:
+    transpiled_circuit = transpiler.run(circuit)
+    final_layout = transpiler.context.final_layout
+
+To use an explicit logical-to-physical qubit mapping instead of the automatic layout/routing passes, pass
+``qubit_mapping`` to the constructor:
 
 .. code-block:: python
 
-    # Default Transpilation (with ReverseTraversal, Sabre, platform's connectivity and optimize = True):
-    transpiled_circuit, final_layouts = transpiler.transpile_circuit(c)
+    transpiler = CircuitTranspiler(platform.digital_compilation_settings, qubit_mapping={0: 2, 1: 3})
+    transpiled_circuit = transpiler.run(circuit)
 
-    # Or another case, not doing optimization for some reason, and with Non-Default placer:
-    transpiled_circuit, final_layout = transpiler.transpile_circuit(c, placer=Random, optimize=False)
-
-    # Or also specifying the `router` with kwargs:
-    transpiled_circuit, final_layouts = transpiler.transpile_circuit(c, router=(Sabre, {"lookahead": 2}))
-
-And even we could only do a single step of the transpilation manually, like in the following, where we will only route:
-
-.. code-block:: python
-
-    # Default Transpilation (with ReverseTraversal, Sabre, platform's connectivity and optimize = True):
-    transpiled_circuit, qubits, final_layouts = transpiler.route_circuit(c)
-
-    # Or another case with Non-Default placer:
-    transpiled_circuit, qubits, final_layout = transpiler.route_circuit(c, placer=Random)
+You can also supply a custom ``pipeline`` (a list of ``CircuitTranspilerPass`` objects) to the constructor to fully
+control which passes run and in which order.

--- a/src/qililab/_optionals.py
+++ b/src/qililab/_optionals.py
@@ -53,7 +53,7 @@ class ImportedFeature:
 
     Attributes:
         name (str):
-            A label for the feature (e.g. 'qibo-backend').
+            A label for the feature (e.g. 'quantum-machines').
         symbols (dict[str, Union[Any, Callable]]):
             A mapping from symbol name to the real or stubbed object.
             If the required dependency is missing, the symbol is a stub

--- a/src/qililab/platform/platform.py
+++ b/src/qililab/platform/platform.py
@@ -110,202 +110,10 @@ class Platform:
     And then, for each experiment you want to run, you would typically repeat:
 
     >>> platform.set_parameter(...)  # Sets any parameter of the Platform.
-    >>> result = platform.execute(...)  # Executes the platform.
+    >>> result = platform.execute_circuit(...)  # Executes a circuit on the platform.
 
     Args:
         runcard (Runcard): Dataclass containing the serialized platform (chip, instruments, buses...), created during :meth:`ql.build_platform()` with the given runcard dictionary.
-
-    Examples:
-
-        .. note::
-
-            The following examples contain made up results. These will soon be updated with real results.
-
-        .. note::
-
-            All the following examples are explained in detail in the :ref:`Platform <platform>` section of the documentation. However, here are a few thing to keep in mind:
-
-            - To connect, your computer must be in the same network of the instruments specified in the runcard, with their IP's addresses. Connection is necessary for the subsequent steps.
-
-            - You might want to skip the ``platform.initial_setup()`` and the ``platform.turn_on_instruments()`` steps if you think nothing has been modified, but we recommend doing them every time.
-
-            - ``platform.turn_on_instruments()`` is used to turn on the signal output of all the sources defined in the runcard (RF, Voltage and Current sources).
-
-            - You can print ``platform.chip`` and ``platform.buses`` at any time to check the platform's structure.
-
-        **1. Executing a circuit with Platform:**
-
-
-        To execute a circuit you first need to define your circuit, for example, one with a pi pulse and a measurement gate in qubit ``q`` (``int``).
-        Then you also need to build, connect, set up, and execute the platform, which together look like:
-
-        .. code-block:: python
-
-            import qililab as ql
-
-            from qibo.models import Circuit
-            from qibo import gates
-
-            # Defining the Rabi circuit:
-            circuit = Circuit(q + 1)
-            circuit.add(gates.X(q))
-            circuit.add(gates.M(q))
-
-            # Building the platform:
-            platform = ql.build_platform(runcard="runcards/galadriel.yml")
-
-            # Connecting and setting up the platform:
-            platform.connect()
-            platform.initial_setup()
-            platform.turn_on_instruments()
-
-            # Executing the platform:
-            result = platform.execute(program=circuit, num_avg=1000, repetition_duration=6000)
-
-        The results would look something like this:
-
-        >>> result.array
-        array([[6.],
-                [6.]])
-
-        .. note::
-
-            The obtained values correspond to the integral of the I/Q signals received by the digitizer.
-            And they have shape `(#sequencers, 2, #bins)`, in this case you only have 1 sequencer and 1 bin.
-
-        You could also get the results in a more standard format, as already classified ``counts`` or ``probabilities`` dictionaries.
-        To do so the call to execute circuit must be slightly different, as the number of averages must be 1:
-
-        .. code-block:: python
-
-            # Executing the platform with the same amount of loops but using bins:
-            result = platform.execute(program=circuit, num_avg=1, num_bins=1000, repetition_duration=6000)
-
-        Then:
-
-        >>> result.counts
-        {'0': 501, '1': 499}
-
-        >>> result.probabilities
-        {'0': .501, '1': .499}
-
-        .. note::
-
-            You can find more information about the results, in the :class:`.Results` class documentation.
-
-        |
-
-        **2. Running a Rabi sweep with Platform:**
-
-        To perform a Rabi sweep, you need the previous circuit, and again, you also need to build, connect and setup the platform.
-        But this time, instead than executing the circuit once, you will loop changing the amplitude parameter of the AWG (generator of the pi pulse):
-
-        .. code-block:: python
-
-            # Looping over the AWG amplitude to execute the Rabi sweep:
-            results = []
-            amp_values = [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.9, 1.0]
-
-            for amp in amp_values:
-                platform.set_parameter(alias="drive_q", parameter=ql.Parameter.AMPLITUDE, value=amp)
-                result = platform.execute(program=circuit, num_avg=1000, repetition_duration=6000)
-                results.append(result.array)
-
-        Now you can use ``np.hstack`` to stack the results horizontally. By doing this, you would obtain an
-        array with shape `(2, N)`, where N is the number of elements inside the loop:
-
-        >>> import numpy as np
-        >>> np.hstack(results)
-        array([[5, 4, 3, 2, 1, 2, 3, 4, 5, 4, 3],
-                [5, 4, 3, 2, 1, 2, 3, 4, 5, 4, 3]])
-
-        You can see how the integrated I/Q values oscillate, indicating that qubit ``q`` oscillates between the ground and
-        excited states!
-
-        |
-
-        **3. A faster Rabi sweep, translating the circuit to pulses:**
-
-        Since you are looping over variables that are independent of the circuit (in this case, the amplitude of the AWG),
-        you can speed up the experiment by translating the circuit into pulses beforehand, only once, and then, executing the obtained
-        pulses inside the loop.
-
-        Which is the same as before, but passing the ``pulse_schedule`` instead than the ``circuit``, to the ``execute()`` method:
-
-        .. code-block:: python
-
-            from qililab.pulse.circuit_to_pulses import CircuitToPulses
-
-            # Translating the circuit to pulses:
-            pulse_schedule = CircuitToPulses(platform=platform).translate(circuits=[circuit])
-
-            # Looping over the AWG amplitude to execute the Rabi sweep:
-            results = []
-            amp_values = [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.9, 1.0]
-
-            for amp in amp_values:
-                platform.set_parameter(alias="drive_q", parameter=ql.Parameter.AMPLITUDE, value=amp)
-                result = platform.execute(program=pulse_schedule, num_avg=1000, repetition_duration=6000)
-                results.append(result.array)
-
-        If you now stack and print the results, you will obtain similar results, but much faster!
-
-        >>> np.hstack(results)
-        array([[5, 4, 3, 2, 1, 2, 3, 4, 5, 4, 3],
-                [5, 4, 3, 2, 1, 2, 3, 4, 5, 4, 3]])
-        TODO: !!! Change this results for the actual ones !!!
-
-        |
-
-        **4. Ramsey sequence, looping over a parameter inside the circuit:**
-
-        To run a Ramsey sequence you also need to build, connect and set up the platform as before. However, the circuit will be different from the previous one,
-        and also, this time, you need to loop over a parameter of the circuit itself, specifically over the time of the ``Wait`` gate.
-
-        To do this, since the parameter is inside the Qibo circuit, you will need to use Qibo own ``circuit.set_parameters()`` method, specifying the
-        parameters you want to set, in the same order they appear in the circuit construction:
-
-        .. code-block:: python
-
-            import qililab as ql
-
-            from qibo.models import Circuit
-            from qibo import gates
-
-            # Building the platform:
-            platform = ql.build_platform(runcard="runcards/galadriel.yml")
-
-            # Connecting and setting up the platform:
-            platform.connect()
-            platform.initial_setup()
-            platform.turn_on_instruments()
-
-            # Defining the Ramsey circuit:
-            circuit = Circuit(q + 1)
-            circuit.add(gates.RX(q, theta=np.pi / 2))
-            circuit.add(ql.Wait(q, t=0))
-            circuit.add(gates.RX(q, theta=np.pi / 2))
-            circuit.add(gates.M(q))
-
-            # Looping over the wait time t to execute the Ramsey:
-            results = []
-            wait_times = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-
-            for wait in wait_times:
-                circuit.set_parameters([np.pi / 2, wait, np.pi / 2])
-                result = platform.execute(program=circuit, num_avg=1000, repetition_duration=6000)
-                results.append(result.array)
-
-        which for each execution, would set ``np.pi/2`` to the ``theta`` parameters of the ``RX`` gates, and the looped ``wait`` time  to the ``t`` parameter of the
-        ``Wait`` gate.
-
-        If you print the results, you'll see how you obtain the sinusoidal expected behavior!
-
-        >>> results = np.hstack(results)
-        >>> results
-        array([[5, 4, 3, 2, 1, 2, 3, 4, 5, 4, 3],
-                [5, 4, 3, 2, 1, 2, 3, 4, 5, 4, 3]])
-        TODO: !!! Change this results for the actual sinusoidal ones (change wait_times of execution if needed) !!!
     """
 
     def __init__(self, runcard: Runcard):
@@ -1892,18 +1700,18 @@ class Platform:
     def compile_circuit(
         self, circuit: Circuit, nshots: int, *, qubit_mapping: dict[int, int] | None = None
     ) -> tuple[QProgram, dict[int, int]]:
-        """Compiles the circuit / pulse schedule into a set of assembly programs, to be uploaded into the awg buses.
+        """Transpiles a circuit and compiles it into a :class:`.QProgram` ready to be executed on the platform.
 
-        If the ``program`` argument is a :class:`.Circuit`, it will first be translated into a :class:`.PulseSchedule` using the transpilation
-        settings of the platform and passed  transpile configuration. Then the pulse schedules will be compiled into the assembly programs.
+        The circuit is first transpiled to the platform's native gate set and then compiled into a :class:`.QProgram`,
+        using the platform's :attr:`.digital_compilation_settings`.
 
         .. note::
 
-            Compile is called during ``platform.execute()``, check its documentation for more information.
+            This is called internally by :meth:`.execute_circuit`; check its documentation for more information.
 
-        The transpilation is performed using the :meth:`.CircuitTranspiler.transpile_circuit()` method. Refer to the method's documentation or :ref:`Transpilation <transpilation>` for more detailed information.
+        The transpilation is performed using :class:`.CircuitTranspiler`. Refer to its documentation or :ref:`Transpilation <transpilation>` for more detailed information.
 
-        The main stages of this process are: **1.** Routing, **2.** Canceling Hermitian pairs, **3.** Translate to native gates, **4.** Correcting Drag phases, **5** Optimize Drag gates, **6.** Convert to pulse schedule.
+        The main stages of this process are: **1.** Routing, **2.** Canceling Hermitian pairs, **3.** Translate to native gates, **4.** Correcting Drag phases, **5** Optimize Drag gates, **6.** Convert to a :class:`.QProgram`.
 
         .. note ::
 
@@ -1914,18 +1722,17 @@ class Platform:
             To do Steps **2.** and **5.** set optimize=True in transpilation_config (default behavior skips it)
 
         Args:
-            program (PulseSchedule | Circuit): Circuit or pulse schedule to compile.
-            num_avg (int): Number of hardware averages used.
-            repetition_duration (int): Minimum duration of a single execution.
-            num_bins (int): Number of bins used.
+            circuit (Circuit): The ``qilisdk.digital`` circuit to transpile and compile.
+            nshots (int): Number of shots (hardware averages) used.
+            qubit_mapping (dict[int, int] | None): Optional logical-to-physical qubit mapping. If ``None``, a trivial mapping is used.
 
         Returns:
-            tuple[dict, list[int] | None]: Tuple containing the dictionary of compiled assembly programs (The key is the bus alias (``str``),
-                and the value is the assembly compilation (``list``)), and its corresponding final layout (Initial Re-mapping + SWAPs routing) of
-                the Original Logical Qubits (l_q) in the physical circuit (wires): [l_q in wire 0, l_q in wire 1, ...] (None = trivial mapping).
+            tuple[QProgram, dict[int, int]]: Tuple containing the compiled :class:`.QProgram` and its corresponding final layout
+                (Initial Re-mapping + SWAPs routing) of the Original Logical Qubits (l_q) in the physical circuit (wires):
+                [l_q in wire 0, l_q in wire 1, ...].
 
         Raises:
-            ValueError: raises value error if the circuit execution time is longer than ``repetition_duration`` for some qubit.
+            ValueError: if the platform has no ``digital_compilation_settings`` defined.
         """
         if self.digital_compilation_settings is None:
             raise ValueError("Cannot compile Circuit without defining DigitalCompilationSettings.")


### PR DESCRIPTION
## Why

Qibo was fully removed from qililab (the codebase migrated to `qilisdk`; see the CHANGELOG: *"All references to Qibo have been removed from the codebase, along with the complete removal of the pulse module"*). The **code** was migrated, but several **docstrings and docs** were never updated and still teach an API that no longer exists.

## What's stale (and now fixed)

| Stale reference | Reality in code |
|---|---|
| `from qibo.models import Circuit` / `from qibo import gates` | `from qilisdk.digital import Circuit, X, M, RX, CZ` |
| `platform.execute(program=circuit, num_avg=…, repetition_duration=…)` | **method deleted** → `platform.execute_circuit(circuit, nshots=…)` |
| `from qililab.pulse.circuit_to_pulses import CircuitToPulses` | **module deleted** |
| `ql.Wait(q, t=0)` in a `Circuit` + `circuit.set_parameters([...])` | qibo-era API, gone |
| `CircuitTranspiler.transpile_circuit()` / `route_circuit()` / `optimize_gates()` / `gates_to_native()` / `gates_to_pulses()`, `DigitalTranspilationConfig`, `ql.execute` | **all absent** — real surface is `CircuitTranspiler(settings, qubit_mapping=…).run(circuit)` over a `CircuitTranspilerPass` pipeline |

## Changes (one commit per file)

- **`.gitignore`** — remove dead `.qibo_configuration` entry.
- **`src/qililab/_optionals.py`** — docstring example label `'qibo-backend'` → the real optional feature `'quantum-machines'`.
- **`docs/conf.py`** — drop the stale `Qiboconnection` docs-site nav link (no longer a dependency).
- **`src/qililab/platform/platform.py`** — remove the `Platform` class docstring's removed-API Rabi/Ramsey tutorial, and fix `compile_circuit`'s docstring to match its real signature (`circuit` / `nshots` / `qubit_mapping`, returns a `QProgram`).
- **`docs/fundamentals/platform.rst`** — replace the four removed-API tutorials with one concise `execute_circuit` example using `qilisdk.digital`, deferring detail to the API reference.
- **`docs/fundamentals/transpilation.rst`** — rewrite around the current pass-pipeline API (`CircuitTranspiler(...).run()`).

Net `+69 / −476`. `CHANGELOG.md` is intentionally left untouched (historical record).

## Scope / notes for reviewers

- This **removes** the dead tutorials rather than reconstructing full sweep walk-throughs; if richer tutorials are wanted, that's a follow-up. All retained/new examples (`qilisdk.digital` gates, `execute_circuit`, the default transpiler pass list) were verified against the tree and tests at `origin/main`.
- The `docs` (Sphinx) CI job passes on 3.11/3.12/3.13, so the `.rst` renders and `:ref:` targets build cleanly.

