### PR TITLE
[QHC-1482] Fix Windows-only test failures (data_management, slurm)

### DIFF
--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -4,6 +4,9 @@
 
 ### Improvements
 
+- Fixed `test_data_management.py` and `test_slurm.py` failing on local Windows dev environments: `save_platform()`'s return path is now compared as a `Path` instead of a raw string (Windows uses backslash separators), and `TestSubmitJob` (which relies on `submitit`'s POSIX-only local executor) is now skipped on Windows.
+  [#1158](https://github.com/qilimanjaro-tech/qililab/pull/1158)
+
 - Pin qpysequence==0.10.8
   [#1155](https://github.com/qilimanjaro-tech/qililab/pull/1155)
 
@@ -65,9 +68,6 @@ In the runcard this parameter is located inside the instruments sequencer for QR
 ### Documentation
 
 ### Bug fixes
-
-- Fixed `test_data_management.py` and `test_slurm.py` failing on local Windows dev environments: `save_platform()`'s return path is now compared as a `Path` instead of a raw string (Windows uses backslash separators), and `TestSubmitJob` (which relies on `submitit`'s POSIX-only local executor) is now skipped on Windows.
-  [#1158](https://github.com/qilimanjaro-tech/qililab/pull/1158)
 
 - Fixed the folder shape at `add_measurement` and `add_results` to take into account us intervals of time. This will solve any issue with parallelization while creating more than one folder in less than a second.
   [#1152](https://github.com/qilimanjaro-tech/qililab/pull/1152)

--- a/docs/releases/changelog-dev.md
+++ b/docs/releases/changelog-dev.md
@@ -66,6 +66,9 @@ In the runcard this parameter is located inside the instruments sequencer for QR
 
 ### Bug fixes
 
+- Fixed `test_data_management.py` and `test_slurm.py` failing on local Windows dev environments: `save_platform()`'s return path is now compared as a `Path` instead of a raw string (Windows uses backslash separators), and `TestSubmitJob` (which relies on `submitit`'s POSIX-only local executor) is now skipped on Windows.
+  [#1158](https://github.com/qilimanjaro-tech/qililab/pull/1158)
+
 - Fixed the folder shape at `add_measurement` and `add_results` to take into account us intervals of time. This will solve any issue with parallelization while creating more than one folder in less than a second.
   [#1152](https://github.com/qilimanjaro-tech/qililab/pull/1152)
 

--- a/tests/test_data_management.py
+++ b/tests/test_data_management.py
@@ -30,13 +30,13 @@ class TestPlatformData:
         """Test the `save_platform` function with a path that doesn't end in .yml."""
         platform = build_platform(Galadriel.runcard)
         path = save_platform(path="tests/", platform=platform)
-        assert path == f"tests/{Galadriel.name}.yml"
+        assert Path(path) == Path(f"tests/{Galadriel.name}.yml")
         Path(path).unlink(missing_ok=True)
 
     def test_save_platform_with_yml_path(self):
         """Test the `save_platform` function with a path that ends in .yml."""
         path = save_platform(path="tests/test.yml", platform=build_platform(Galadriel.runcard))
-        assert path == "tests/test.yml"
+        assert Path(path) == Path("tests/test.yml")
         Path(path).unlink(missing_ok=True)
 
 

--- a/tests/test_slurm.py
+++ b/tests/test_slurm.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import logging
 import ast
+import sys
 import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -29,6 +30,10 @@ def ip(session_ip):
     yield session_ip
 
 
+@pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="submitit's local executor relies on POSIX signals (signal.SIGKILL) and isn't supported on Windows",
+)
 class TestSubmitJob:
     def teardown_method(self):
         """Teardown method to make sure all files are deleted."""


### PR DESCRIPTION
- test_data_management.py: compare Path objects instead of raw strings, since save_platform() returns OS-native separators.
- test_slurm.py: skip TestSubmitJob on Windows, since submitit's local executor relies on POSIX-only signal.SIGKILL.