### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,7 +10,7 @@
 # Jordi Valls: owner of results + DB.
 /src/qililab/result/                    @jordivallsq
 
-# Flavie Le Bars: solo required approver / veto.
+# Flavie Le Bars: sole required approver / veto.
 /src/qililab/instruments/               @flavie-lebars
 /src/qililab/instrument_controllers/    @flavie-lebars
 /src/qililab/instrument_connections/    @flavie-lebars

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,18 @@
+# CODEOWNERS - qililab
+# Docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+# Rules: LAST matching pattern wins; several owners on a path = ANY ONE approves (OR);
+#        a single owner = SOLE required approver. Enforced only with branch protection
+#        on `main`: "Require review from Code Owners" (otherwise advisory).
+
+# Default (QHC): any one may approve.
+*                                       @flavie-lebars @jordivallsq @elygoner
+
+# Jordi Valls: owner of results + DB.
+/src/qililab/result/                    @jordivallsq
+
+# Flavie Le Bars: solo required approver / veto.
+/src/qililab/instruments/               @flavie-lebars
+/src/qililab/instrument_controllers/    @flavie-lebars
+/src/qililab/instrument_connections/    @flavie-lebars
+/src/qililab/platform/                  @flavie-lebars
+/src/qililab/qprogram/                  @flavie-lebars


### PR DESCRIPTION
Adds a `CODEOWNERS` file formalizing review ownership for qililab.

- **Default (QHC squad):** `@flavie-lebars`, `@jordivallsq`, `@elygoner` are auto-requested and any one can approve.
- **Sole owners on specific areas:**
  - **Flavie** (`@flavie-lebars`): instrumentation (`instruments/`, `instrument_controllers/`, `instrument_connections/`), `platform/`, and the QProgram DSL (`qprogram/`, incl. the qblox/qdac compilers).
  - **Jordi** (`@jordivallsq`): results + DB (`result/`).

CODEOWNERS only auto-requests reviewers. Enforcement (requiring code-owner review before merge) is a separate `main` branch-protection setting and is **not** changed by this PR.
