### PR TITLE
Scope CODEOWNERS to source paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,9 +3,14 @@
 # Rules: LAST matching pattern wins; several owners on a path = ANY ONE approves (OR);
 #        a single owner = SOLE required approver. Enforced only with branch protection
 #        on `main`: "Require review from Code Owners" (otherwise advisory).
+#
+# Scope: only source under src/qililab/ is owned. tests/, docs/ (incl. the changelog),
+#        pyproject.toml / uv.lock and .github/ are intentionally left UNOWNED, so a PR
+#        touching them (even alongside a source file) does not auto-request the whole
+#        QHC squad. A PR that touches only unowned paths gets no auto-requested owner.
 
-# Default (QHC): any one may approve.
-*                                       @flavie-lebars @jordivallsq @elygoner
+# Source defaults to QHC: any one may approve.
+/src/qililab/                           @flavie-lebars @jordivallsq @elygoner
 
 # Jordi Valls: owner of results + DB.
 /src/qililab/result/                    @jordivallsq


### PR DESCRIPTION
Scopes `CODEOWNERS` to source paths so a PR no longer auto-requests the whole QHC squad when it only touches tests or docs.

## What went wrong

The initial file used a global `*` default listing the whole QHC squad. GitHub requests **every** owner of **every** changed file, and nearly every PR also touches a test and the changelog, which matched only `*`. So the whole squad got auto-requested even when the only source change was in a single owner's area.

Example, #1164 (a QDAC hotfix) changed:
- `src/qililab/platform/platform.py` -> Flavie (correct)
- `tests/platform/test_platform.py` -> matched only `*` -> whole squad
- `docs/releases/changelog-dev.md` -> matched only `*` -> whole squad

A platform-only fix pulled in reviewers who don't own that area.

## Fix

Replace the `*` catch-all with a `/src/qililab/` base, so ownership is scoped to source. `tests/`, `docs/`, deps and `.github/` then fall outside the owned tree. The same PR #1164 would now request **Flavie only**. This matches how scipy / pandas / PyTorch scope CODEOWNERS to real source directories.

## Ownership (intent unchanged)

- `/src/qililab/` -> QHC (`@flavie-lebars @jordivallsq @elygoner`), any one approves.
- `result/` -> `@jordivallsq`.
- `instruments/`, `instrument_controllers/`, `instrument_connections/`, `platform/`, `qprogram/` -> `@flavie-lebars` (sole).

## Intentionally unowned (no auto-request)

`tests/`, `docs/` (incl. `docs/releases/changelog-dev.md`), `pyproject.toml`, `uv.lock`, `.github/`, and root files. A PR touching only these gets no auto-requested code owner; the author requests reviewers as needed.
