### PR TITLE
[QuickFix] Make db calibration fitting path optional and defaulting to None

### DIFF
--- a/src/qililab/result/database/database_manager.py
+++ b/src/qililab/result/database/database_manager.py
@@ -301,7 +301,7 @@ class DatabaseManager:
             return measurement_by_id
 
     def add_calibration_fitting(
-        self, id: int, path: str, parameters: dict[str, Any] | None = None
+        self, id: int, path: str | None = None, parameters: dict[str, Any] | None = None
     ) -> AutocalMeasurement:
         """Store fitting information into the autocalibration measurements database, loaded by its measurement_id.
 

--- a/tests/result/test_database.py
+++ b/tests/result/test_database.py
@@ -917,6 +917,17 @@ class Testdatabase:
         mock_measurement.add_fitting.assert_called_once_with(db_manager, "/test/fit.h5", {"a": 1.0})
         assert result == mock_measurement
 
+    def test_add_calibration_fitting_without_path(self, db_manager: DatabaseManager):
+        mock_measurement = MagicMock(spec=AutocalMeasurement)
+        mock_measurement.add_fitting.return_value = mock_measurement
+
+        with patch.object(db_manager, "load_calibration_by_id", return_value=mock_measurement) as mock_load:
+            result = db_manager.add_calibration_fitting(123, parameters={"a": 1.0})
+
+        mock_load.assert_called_once_with(123)
+        mock_measurement.add_fitting.assert_called_once_with(db_manager, None, {"a": 1.0})
+        assert result == mock_measurement
+
     def test_add_calibration_fitting_raises_exception_measurement_not_found(self, db_manager: DatabaseManager):
         with patch.object(db_manager, "load_calibration_by_id", return_value=None):
             with pytest.raises(IndexError, match="Autocalibration measurement entry '123' does not exist."):


### PR DESCRIPTION
Made the `path` argument optional in `DatabaseManager.add_calibration_fitting`, so fitting parameters can be attached to an autocalibration measurement without providing a fitting results path.

Seqtante's path is not mandatory while writing in the database.